### PR TITLE
Copy over verify_tag logic

### DIFF
--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# References https://github.com/FuelLabs/fuel-core/blob/master/.github/workflows/scripts/verify_tag.sh
+set -e
+
+err() {
+    echo -e "\e[31m\e[1merror:\e[0m $@" 1>&2;
+}
+
+status() {
+    WIDTH=12
+    printf "\e[32m\e[1m%${WIDTH}s\e[0m %s\n" "$1" "$2"
+}
+
+REF=$1
+MANIFEST=$2
+
+if [ -z "$REF" ]; then
+    err "Expected ref to be set"
+    exit 1
+fi
+
+if [ -z "$MANIFEST" ]; then
+    err "Expected manifest to be set"
+    exit 1
+fi
+
+# strip preceeding 'v' if it exists on tag
+REF=${REF/#v}
+TOML_VERSION=$(cat $MANIFEST | dasel -r toml 'package.version')
+
+if [ "$TOML_VERSION" != "$REF" ]; then
+    err "Crate version $TOML_VERSION, doesn't match tag version $REF"
+    exit 1
+else
+  status "Crate version matches tag $TOML_VERSION"
+fi


### PR DESCRIPTION
### Description
- This PR copies over the `verify_tag.sh` logic using [fuel-core's verify_tag.sh](https://github.com/FuelLabs/fuel-core/blob/master/.github/workflows/scripts/verify_tag.sh) as a reference 

### Testing steps
- [ ] This addition will only run on a `publish` event.
  - This logic actually already existed in a job, but the job never triggered, so there was no error thrown for `verify_tag.sh` not existing.
  - This PR simply just adds the script
  - Should be a pretty easy PR to eyeball 