### PR TITLE
Add CLI opts to mdbook

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
     - [System dependencies](./getting-started/system-dependencies.md)
     - [Application dependencies](./getting-started/application-dependencies.md)
   - [A Fuel Indexer Project](./getting-started/fuel-indexer-project.md)
+    - [Configuration](./getting-started/configuration.md)
 - [Examples](./examples/index.md)
   - [Hello World](./examples/hello-indexer.md)
   - [Simple Native](./examples/simple-native.md)

--- a/docs/src/api/gql-server.md
+++ b/docs/src/api/gql-server.md
@@ -1,15 +1,15 @@
 # GraphQL Server
 
-The `api_server` crate of the Fuel Indexer contains a standalone GraphQL API server that acts as a queryable endpoint on top of the data layer.
+The `fuel-indexer-api-server` crate of the Fuel Indexer contains a standalone GraphQL API server that acts as a queryable endpoint on top of the data layer.
 
-Note that the main binary of the `fuel_indexer` crate _also_ contains a queryable GraphQL API endpoint. However, the `api_server` crate offers a standalone GraphQL API endpoint, whereas the `fuel_indexer` bundles its GraphQL API endpoint with other Fuel Indexer functionality (e.g., execution, handling, data-layer contruction, etc).
+Note that the main binary of the `fuel-indexer` crate _also_ contains a queryable GraphQL API endpoint. However, the `fuel-indexer-api-server` crate offers a standalone GraphQL API endpoint, whereas the `fuel-indexer-api-server` bundles its GraphQL API endpoint with other Fuel Indexer functionality (e.g., execution, handling, data-layer contruction, etc).
 
 To run the standalone Fuel Indexer GraphQL API server:
 
 ```bash
 cd fuel-indexer/
 
-RUST_LOG=debug cargo run --bin api_server -- --config api_server/config.yaml
+RUST_LOG=debug cargo run --bin fuel-indexer-api-server -- --config config.yaml
 ```
 
-Where `config.yaml` is based on [the default service configuration file](https://github.com/FuelLabs/fuel-indexer/blob/master/api_server/config.yaml).
+Where `config.yaml` is based on [the default service configuration file](https://github.com/FuelLabs/fuel-indexer/blob/master/config.yaml).

--- a/docs/src/getting-started/configuration.md
+++ b/docs/src/getting-started/configuration.md
@@ -1,0 +1,67 @@
+# Indexer Configuration
+
+Below you will find a list of CLI configuration options that can be used to configure either the Fuel Indexer service, the standalone Fuel Indexer GraphQL API service, or both. For those who prefer using a configuration file,
+you can [checkout the default service configuration file](https://github.com/FuelLabs/fuel-indexer/blob/master/config.yaml), which also shows the default values used for these configuration options.
+
+## Usage:
+
+Using the main Fuel Indexer service binary.
+
+`cargo run --bin fuel-indexer -- [options]`
+
+Using the standalone GraphQL API server.
+
+`cargo run --bin fuel-indexer-api-server -- [options]`
+
+
+### Options:
+
+`-c` `--config`
+
+- Path to the configuration file.
+
+`t` `--test-manifest`
+
+- Path to the test manifest file.
+
+> Fuel node: The node running the Fuel client implementation.
+
+`--fuel-node-host` <FUEL-NODE-HOST>
+
+- IP of the Fuel node
+
+`--fuel-node-port` <FUEL-NODE-PORT>
+
+- Port of the Fuel node
+
+> GraphQL API: The enpoint at which GraphQL queries will be processed. This is context dependent. If ran
+using the `fuel-indexer` binary, these options apply to the GraphQL service run in that binary. If ran using
+the `fuel-indexer-api-server` binary, these options will apply to that service.
+
+`--graphql-api-host` <GRAPHQL-API-HOST>
+
+- IP at which to bind the GraphQL server
+
+`--graphql-api-port` <GRAPHQL-API-PORT>
+
+> Postgres: Standard Postgres connection options.
+
+`--postgres-host` <POSTGRES-HOST>
+
+- Postgres host
+
+`--postgres-port` <POSTGRES-PORT>
+
+- Postgres port
+
+`--postgres-username` <POSTGRES-USERNAME>
+
+- Postgres username
+
+`--postgres-password` <POSTGRES-PASSWORD>
+
+- Postgres password (redacted from logging)
+
+`--postgres-database` <POSTGRES-DATABASE>
+
+- Postgres database

--- a/docs/src/getting-started/configuration.md
+++ b/docs/src/getting-started/configuration.md
@@ -20,7 +20,7 @@ Using the standalone GraphQL API server.
 
 - Path to the configuration file.
 
-`t` `--test-manifest`
+`-t` `--test-manifest`
 
 - Path to the test manifest file.
 

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -5,6 +5,7 @@ This section provides an outline regarding how to get started using a Fuel Index
 - [Setting up](./setup.md)
   - [System dependencies](./system-dependencies.md)
   - [Application dependencies](./application-dependencies.md)
+  - [Indexer Configuration](./configuration.md)
 - [Project Structure](./fuel-indexer-project.md)
 - [Examples](./../examples/index.md)
   - [Hello World](./../examples/hello-indexer.md)

--- a/fuel-indexer-api-server/Cargo.toml
+++ b/fuel-indexer-api-server/Cargo.toml
@@ -12,7 +12,7 @@ name = "api_server"
 path = "src/lib.rs"
 
 [[bin]]
-name = "api_server"
+name = "fuel-indexer-api-server"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
### Description
- This PR adds service CLI opts to the mdbook
- Eventually it would be nice to automate this (similar to forc?) but for now this is fine
  - Tracking this in https://github.com/FuelLabs/fuel-indexer/issues/141
- PR also renames the `api_server` binary to `fuel-indexer-api-server` to match convention and updates the docs accordingly

### Testing steps
- N/A