### PR TITLE
Add sqlite constraint support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - run: cargo install sqlx-cli
-      - run: ./run_migrations.sh
+      - run: ./scripts/run_migrations.ci.sh
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         name: Cargo Check Workspace Locked
@@ -74,7 +74,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - run: cargo install sqlx-cli
-      - run: ./run_migrations.sh
+      - run: ./scripts/run_migrations.ci.sh
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         name: Cargo Build Workspace
@@ -104,7 +104,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - run: cargo install sqlx-cli
-      - run: ./run_migrations.sh
+      - run: ./scripts/run_migrations.ci.sh
       - uses: Swatinem/rust-cache@v1
       - name: Cargo Test Workspace
         uses: actions-rs/cargo@v1
@@ -134,7 +134,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - run: cargo install sqlx-cli
-      - run: ./run_migrations.sh
+      - run: ./scripts/run_migrations.ci.sh
       - uses: Swatinem/rust-cache@v1
       - name: Cargo Test Workspace
         uses: actions-rs/cargo@v1
@@ -165,7 +165,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - run: cargo install sqlx-cli
-      - run: ./run_migrations.sh
+      - run: ./scripts/run_migrations.ci.sh
       - name: Cargo Test Workspace
         uses: actions-rs/cargo@v1
         with:
@@ -227,7 +227,7 @@ jobs:
           default: true
       - uses: Swatinem/rust-cache@v1
       - run: cargo install sqlx-cli
-      - run: ./run_migrations.sh
+      - run: ./scripts/run_migrations.ci.sh
       - name: Install cargo-udeps
         uses: actions-rs/cargo@v1
         with:
@@ -259,7 +259,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - run: cargo install sqlx-cli
-      - run: ./run_migrations.sh
+      - run: ./scripts/run_migrations.ci.sh
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ docs/book/
 
 .env
 .dockerignore
+*.db
+*.db*
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@
 [![discord](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xfpK4Pe)
 
 The Fuel Indexer is a standalone binary that can be used to index various components of [the Fuel protocol](https://github.com/FuelLabs/fuel-specs/tree/master/specs/protocol). These indexable components include blocks, transactions, and [receipts](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md) and state within a fuel network, allowing for high-performance read-only access to the blockchain for advanced dApp use-cases.
+
+## Usage
+
+### Clone repository
+
+```bash
+git clone git@github.com:FuelLabs/fuel-indexer.git
+```
+
+### Run migrations
+
+```bash
+DATABASE_URL=postgres://postgres@localhost sh scripts/run_migrations.local.sh
+```

--- a/config.yaml
+++ b/config.yaml
@@ -3,25 +3,32 @@
 ## This configuration spec is intended to be used for a single instance
 ## of a Fuel Indexer node or service.
 ##
-## For more info on how the Fuel Indexer work, read the book: https://fuellabs.github.io/fuel-indexer/master/
+## For more info on how the Fuel Indexer works, read the book: https://fuellabs.github.io/fuel-indexer/master/
+## or specifically read up on these configuration options: https://fuellabs.github.io/fuel-indexer/master/getting-started/configuration.html
 
 ## Fuel Node configuration
+#
 # fuel_node:
 #   host: 127.0.0.1
 #   port: 4000
 
 ## GraphQL API configuration
+#
 # graphql_api:
 #   host: 0.0.0.0
 #   port: 29987
 #   run_migrations: false
 
-## Postgres configuration
-# postgres:
-#   user: postgres
-#   database:
-#   password:
-#   host: 127.0.0.1
-#   port: 5432
+## Database configuration options. Use either the Postgres
+## configuration or the SQLite configuration, but not both
+#
+# database:
+#   postgres:
+#     user: postgres
+#     database:
+#     password:
+#     host: 127.0.0.1
+#     port: 5432
 
-# sqlite_db_path: ../main.db
+#   sqlite:
+#     path: database/sqlite/sqlite.db

--- a/docs/src/getting-started/configuration.md
+++ b/docs/src/getting-started/configuration.md
@@ -44,6 +44,12 @@ the `fuel-indexer-api-server` binary, these options will apply to that service.
 
 `--graphql-api-port` <GRAPHQL-API-PORT>
 
+- Port at which to bind the GraphQL server
+
+- `--run-migrations` <RUN-MIGRATIONS>
+
+- Whether to run the migrations on the GraphQL API's connected database
+
 > Postgres: Standard Postgres connection options.
 
 `--postgres-host` <POSTGRES-HOST>
@@ -65,3 +71,9 @@ the `fuel-indexer-api-server` binary, these options will apply to that service.
 `--postgres-database` <POSTGRES-DATABASE>
 
 - Postgres database
+
+> SQLite: An alternative database implementation using standard SQLite connection options
+
+- `--sqlite-database` <SQLITE-DATABASE>
+
+- Path to SQLite database

--- a/examples/simple-native/src/main.rs
+++ b/examples/simple-native/src/main.rs
@@ -69,6 +69,7 @@ pub async fn main() -> Result<()> {
         Some(path) => IndexerConfig::from_file(path).await?,
         None => IndexerConfig::from_opts(opt.clone()),
     };
+
     // Load the indexer manifest
     let manifest = Manifest::from_file(&opt.test_manifest.unwrap())?;
 

--- a/fuel-indexer-lib/src/lib.rs
+++ b/fuel-indexer-lib/src/lib.rs
@@ -55,6 +55,8 @@ pub mod defaults {
     pub const POSTGRES_HOST: &str = "127.0.0.1";
     pub const POSTGRES_PORT: &str = "5432";
 
+    pub const SQLITE_DATABASE: &str = "sqlite.db";
+
     pub const GRAPHQL_API_RUN_MIGRATIONS: bool = false;
 }
 
@@ -95,8 +97,8 @@ pub mod config {
         pub graphql_api_port: Option<String>,
         #[clap(long, help = "Database type", default_value = "postgres", value_parser(["postgres", "sqlite"]))]
         pub database: String,
-        #[clap(long, default_value = "sqlite.db", help = "Sqlite database.")]
-        pub sqlite_database: String,
+        #[clap(long, help = "Sqlite database.")]
+        pub sqlite_database: Option<String>,
         #[clap(long, help = "Postgres username. (default = 'postgres')")]
         pub postgres_user: Option<String>,
         #[clap(long, help = "Postgres database. (default = 'postgres')")]
@@ -187,6 +189,7 @@ pub mod config {
     }
 
     #[derive(Clone, Deserialize)]
+    #[serde(rename_all = "snake_case")]
     pub enum DatabaseConfig {
         Sqlite {
             path: PathBuf,

--- a/fuel-indexer-schema/src/db.rs
+++ b/fuel-indexer-schema/src/db.rs
@@ -18,7 +18,7 @@ pub enum IndexerConnectionPool {
     Sqlite(sqlx::Pool<sqlx::Sqlite>),
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum DbType {
     Postgres,
     Sqlite,

--- a/fuel-indexer-schema/src/db/tables.rs
+++ b/fuel-indexer-schema/src/db/tables.rs
@@ -402,7 +402,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_schema_builder_for_basic_schema_returns_proper_create_sql() {
+    fn test_schema_builder_for_basic_postgres_schema_returns_proper_create_sql() {
         let graphql_schema: &str = r#"
         schema {
             query: QueryRoot
@@ -454,7 +454,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_builder_for_indices_returns_proper_create_sql() {
+    fn test_schema_builder_for_postgres_indices_returns_proper_create_sql() {
         let graphql_schema: &str = r#"
         schema {
             query: QueryRoot
@@ -493,7 +493,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_builder_for_foreign_keys_returns_proper_create_sql() {
+    fn test_schema_builder_for_postgres_foreign_keys_returns_proper_create_sql() {
         let graphql_schema: &str = r#"
         schema {
             query: QueryRoot
@@ -532,5 +532,86 @@ mod tests {
         assert_eq!(foreign_keys.len(), 2);
         assert_eq!(foreign_keys[0].create_statement(), "ALTER TABLE namespace.lender ADD CONSTRAINT fk_borrower_id FOREIGN KEY (borrower) REFERENCES namespace.borrower(id) ON DELETE NO ACTION ON UPDATE NO ACTION INITIALLY DEFERRED;".to_string());
         assert_eq!(foreign_keys[1].create_statement(), "ALTER TABLE namespace.auditor ADD CONSTRAINT fk_borrower_id FOREIGN KEY (borrower) REFERENCES namespace.borrower(id) ON DELETE NO ACTION ON UPDATE NO ACTION INITIALLY DEFERRED;".to_string());
+    }
+
+    #[test]
+    fn test_schema_builder_for_sqlite_indices_returns_proper_create_sql() {
+        let graphql_schema: &str = r#"
+        schema {
+            query: QueryRoot
+        }
+
+        type QueryRoot {
+            thing1: Thing1
+            thing2: Thing2
+        }
+
+        type Payer {
+            id: ID!
+            account: Address! @indexed
+        }
+
+        type Payee {
+            id: ID!
+            account: Address!
+            hash: Bytes32! @indexed
+        }
+    "#;
+
+        let sb = SchemaBuilder::new("namespace", "v1", DbType::Sqlite);
+
+        let SchemaBuilder { indices, .. } = sb.build(graphql_schema);
+
+        assert_eq!(indices.len(), 2);
+        assert_eq!(
+            indices[0].create_statement(),
+            "CREATE INDEX payer_account_idx ON payer(account);".to_string()
+        );
+        assert_eq!(
+            indices[1].create_statement(),
+            "CREATE INDEX payee_hash_idx ON payee(hash);".to_string()
+        );
+    }
+
+    #[test]
+    fn test_schema_builder_for_sqlite_foreign_keys_returns_proper_create_sql() {
+        let graphql_schema: &str = r#"
+        schema {
+            query: QueryRoot
+        }
+
+        type QueryRoot {
+            borrower: Borrower
+            lender: Lender
+            auditor: Auditor
+        }
+
+        type Borrower {
+            id: ID!
+            account: Address! @indexed
+        }
+
+        type Lender {
+            id: ID!
+            account: Address!
+            hash: Bytes32! @indexed
+            borrower: Borrower!
+        }
+
+        type Auditor {
+            id: ID!
+            account: Address!
+            hash: Bytes32! @indexed
+            borrower: Borrower!
+        }
+    "#;
+
+        let sb = SchemaBuilder::new("namespace", "v1", DbType::Sqlite);
+
+        let SchemaBuilder { foreign_keys, .. } = sb.build(graphql_schema);
+
+        assert_eq!(foreign_keys.len(), 2);
+        assert_eq!(foreign_keys[0].create_statement(), "ALTER TABLE lender DROP COLUMN borrower; ALTER TABLE lender ADD COLUMN borrower BIGINT REFERENCES borrower(id);");
+        assert_eq!(foreign_keys[1].create_statement(), "ALTER TABLE auditor DROP COLUMN borrower; ALTER TABLE auditor ADD COLUMN borrower BIGINT REFERENCES borrower(id);");
     }
 }

--- a/fuel-indexer/src/api.rs
+++ b/fuel-indexer/src/api.rs
@@ -63,19 +63,19 @@ pub struct GraphQlApi;
 
 impl GraphQlApi {
     pub async fn run(config: IndexerConfig) {
-        let sm = SchemaManager::new(&config.database_config.to_string())
+        let sm = SchemaManager::new(&config.database.to_string())
             .await
             .expect("SchemaManager create failed");
         let schema_manager = Arc::new(RwLock::new(sm));
         let config = Arc::new(config.clone());
         let listen_on = config.graphql_api.clone().into();
 
-        let pool = IndexerConnectionPool::connect(&config.database_config.to_string())
+        let pool = IndexerConnectionPool::connect(&config.database.to_string())
             .await
             .expect("Failed to establish connection pool");
 
         if config.graphql_api.run_migrations {
-            run_migration(&config.database_config.to_string()).await;
+            run_migration(&config.database.to_string()).await;
         }
 
         let app = Router::new()

--- a/fuel-indexer/src/bin/fuel-indexer.rs
+++ b/fuel-indexer/src/bin/fuel-indexer.rs
@@ -28,7 +28,7 @@ pub async fn main() -> Result<()> {
 
     info!("Configuration: {:?}", config);
 
-    run_migration(&config.database_config.to_string()).await;
+    run_migration(&config.database.to_string()).await;
 
     let _local_node = if opt.local {
         let s = FuelService::new_node(Config::local_node()).await.unwrap();

--- a/fuel-indexer/src/database.rs
+++ b/fuel-indexer/src/database.rs
@@ -287,7 +287,6 @@ mod tests {
             .expect("Could not create SchemaManager");
 
         let result = manager.new_schema("test_namespace", GRAPHQL_SCHEMA).await;
-        println!("TJDEBUG {:?}", result);
         assert!(result.is_ok());
 
         let pool = IndexerConnectionPool::connect(database_url)

--- a/fuel-indexer/src/service.rs
+++ b/fuel-indexer/src/service.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::{
     task::JoinHandle,
@@ -29,14 +29,14 @@ use tracing::{debug, error, info, warn};
 pub struct IndexerConfig {
     pub fuel_node: FuelNodeConfig,
     pub graphql_api: GraphQLConfig,
-    pub database_config: DatabaseConfig,
+    pub database: DatabaseConfig,
 }
 
 #[derive(Deserialize)]
 pub struct TmpIndexerConfig {
     pub fuel_node: Option<FuelNodeConfig>,
     pub graphql_api: Option<GraphQLConfig>,
-    pub database_config: Option<DatabaseConfig>,
+    pub database: Option<DatabaseConfig>,
 }
 
 impl IndexerConfig {
@@ -45,8 +45,8 @@ impl IndexerConfig {
             self.fuel_node = cfg;
         }
 
-        if let Some(cfg) = tmp.database_config {
-            self.database_config = cfg;
+        if let Some(cfg) = tmp.database {
+            self.database = cfg;
         }
 
         if let Some(cfg) = tmp.graphql_api {
@@ -55,7 +55,7 @@ impl IndexerConfig {
     }
 
     pub fn from_opts(args: IndexerArgs) -> IndexerConfig {
-        let database_config = match args.database.as_str() {
+        let database = match args.database.as_str() {
             "postgres" => DatabaseConfig::Postgres {
                 user: args
                     .postgres_user
@@ -70,15 +70,18 @@ impl IndexerConfig {
                 database: args.postgres_database,
             },
             "sqlite" => DatabaseConfig::Sqlite {
-                path: PathBuf::from(args.sqlite_database),
+                path: args
+                    .sqlite_database
+                    .unwrap_or_else(|| defaults::SQLITE_DATABASE.into())
+                    .into(),
             },
             _ => {
-                unreachable!()
+                panic!("Unrecognized database type in options.");
             }
         };
 
         IndexerConfig {
-            database_config,
+            database,
             fuel_node: FuelNodeConfig {
                 host: args
                     .fuel_node_host
@@ -117,7 +120,7 @@ impl IndexerConfig {
 
     pub fn inject_env_vars(&mut self) {
         let _ = self.fuel_node.inject_env_vars();
-        let _ = self.database_config.inject_env_vars();
+        let _ = self.database.inject_env_vars();
         let _ = self.graphql_api.inject_env_vars();
     }
 }
@@ -134,15 +137,15 @@ impl IndexerService {
     pub async fn new(config: IndexerConfig) -> IndexerResult<IndexerService> {
         let IndexerConfig {
             fuel_node,
-            database_config,
+            database,
             ..
         } = config;
-        let manager = SchemaManager::new(&database_config.to_string()).await?;
+        let manager = SchemaManager::new(&database.to_string()).await?;
 
         Ok(IndexerService {
             fuel_node_addr: fuel_node.to_string().parse()?,
             manager,
-            database_url: database_config.to_string(),
+            database_url: database.to_string(),
             handles: HashMap::default(),
             killers: HashMap::default(),
         })

--- a/fuel-indexer/tests/test_indexer.rs
+++ b/fuel-indexer/tests/test_indexer.rs
@@ -55,7 +55,7 @@ mod tests {
 
         let config = IndexerConfig {
             fuel_node: FuelNodeConfig::from(srv.bound_address),
-            database_config: DatabaseConfig::Postgres {
+            database: DatabaseConfig::Postgres {
                 user: "postgres".into(),
                 password: Some("my-secret".into()),
                 host: "127.0.0.1".into(),

--- a/scripts/run_migrations.ci.sh
+++ b/scripts/run_migrations.ci.sh
@@ -1,3 +1,4 @@
+
 export DATABASE_URL="postgres://postgres:my-secret@localhost:5432/postgres"
 
 cd database/postgres

--- a/scripts/run_migrations.local.sh
+++ b/scripts/run_migrations.local.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$DATABASE_URL" ]; then
+    echo "DATABASE_URL is not set in this shell. Please set DATABASE_URL and retry."
+    exit 1
+else
+    echo "Migrating using DATABASE_URL at '$DATABASE_URL'"
+fi
+
+if [[ $DATABASE_URL = postgres* ]]; then
+    cd database/postgres
+    DATABASE_URL=$DATABASE_URL sqlx migrate run
+elif [[ $DATABASE_URL = sqlite* ]]; then
+    cd database/sqlite
+    DATABASE_URL=$DATABASE_URL sqlx database create
+    DATABASE_URL=$DATABASE_URL sqlx migrate run
+else
+    echo "Unrecognized database path prefix on DATABASE_URL '$DATABASE_URL'"
+    exit 1
+fi


### PR DESCRIPTION
### Description
- This PR does a few things
  - Adds a `scripts/` folder with the `run_migrations` script(s)
  - Adds a `scripts/run_migrations.local.sh` which we can use locally to run migrations
  - Changes `run_migrations.sh` to `run_migrations.ci.sh` since this exact format is needed on CI (I'm sure we can combine these files down the road)
  - Updates `configuration.md` in the mdbook with the new CLI options

- Important:
  - [SQL Features that SQLite does not support](https://www.sqlite.org/omitted.html)
  - I added _relationships_ to SQLite but they are _not_ constraints
    - I made that decision because the way SQLite works, it would require creating the relationship _constraint_ in the `CREATE` statement. And as everything is setup, we'd have to pass the "is a foriegn key?" logic downstream to where the `CREATE` statement is located. Doesn't work as seamless with our setup as Postgres constraints do. 
    - So....if we run into the case where a user wants a SQLite relationship _constraint_ down the line, we can take care of that then (I can create a tracking issue for this). But for the sake of this issue, I feel like a relationship is fine 
    - @tjsharp1 Let me know how you feel about this

### Testing steps
- Pretty much the same testing steps as https://github.com/FuelLabs/fuel-indexer/pull/135