### PR TITLE
Fix host resolution in Fuel service

### DIFF
--- a/fuel-indexer-lib/src/lib.rs
+++ b/fuel-indexer-lib/src/lib.rs
@@ -2,7 +2,7 @@ pub mod utils {
 
     use anyhow::Result;
     use std::net::{SocketAddr, ToSocketAddrs};
-    use tracing::{debug, warn};
+    use tracing::{info, warn};
 
     pub fn trim_env_key(key: &str) -> &str {
         // Abmiguous key: $FOO, non-ambiguous key: ${FOO}
@@ -36,7 +36,7 @@ pub mod utils {
                     .pop()
                     .unwrap_or_else(|| panic!("Could not derive SocketAddr from '{}'", host));
 
-                debug!("Parsed SocketAddr '{}' from '{}'", addr.to_string(), host);
+                info!("Parsed SocketAddr '{}' from '{}'", addr.to_string(), host);
 
                 Ok(addr)
             }
@@ -61,7 +61,7 @@ pub mod defaults {
 pub mod config {
     use crate::{
         defaults,
-        utils::{is_env_var, trim_env_key},
+        utils::{derive_socket_addr, is_env_var, trim_env_key},
     };
     use anyhow::Result;
     pub use clap::Parser;
@@ -144,6 +144,12 @@ pub mod config {
     pub struct FuelNodeConfig {
         pub host: String,
         pub port: String,
+    }
+
+    impl FuelNodeConfig {
+        pub fn derive_socket_addr(&self) -> Result<SocketAddr> {
+            derive_socket_addr(&self.host, &self.port)
+        }
     }
 
     impl InjectEnvironment for FuelNodeConfig {

--- a/fuel-indexer/src/service.rs
+++ b/fuel-indexer/src/service.rs
@@ -139,8 +139,12 @@ impl IndexerService {
         } = config;
         let manager = SchemaManager::new(&database_config.to_string()).await?;
 
+        let fuel_node_addr = fuel_node
+            .derive_socket_addr()
+            .expect("Could not parse Fuel node addr for IndexerService.");
+
         Ok(IndexerService {
-            fuel_node_addr: fuel_node.to_string().parse()?,
+            fuel_node_addr,
             manager,
             database_url: database_config.to_string(),
             handles: HashMap::default(),


### PR DESCRIPTION
### Description

- This PR fixes an issue where the fuel node host that was passed to the indexer service was not properly deriving a `SocketAddr` from the hostname supplied. We already had this `derive_socket_addr` used elsewhere but for whatever reason I forgot to add it to this part of the code. This PR fixes that.

### Testing steps
- [ ] The following command should fail on master
```bash
RUST_LOG=info cargo run --bin fuel-indexer -- \
    --postgres-database indexer \
    --fuel-node-host node.swayswap.io \
    --fuel-node-port 443
```
- [ ] The following command should run on this branch
```bash
RUST_LOG=info cargo run --bin fuel-indexer -- \
    --postgres-database indexer \
    --fuel-node-host node.swayswap.io \
    --fuel-node-port 443
```