### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,6 +2362,7 @@ dependencies = [
  "fuels-core",
  "futures",
  "http",
+ "hyper",
  "itertools",
  "serde",
  "serde-scale",
@@ -2448,6 +2449,7 @@ name = "fuel-indexer-schema"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-database-types",
+ "fuel-indexer-lib",
  "fuel-indexer-postgres",
  "fuel-indexer-sqlite",
  "fuel-types 0.3.1",
@@ -3224,6 +3226,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",

--- a/deployment/charts/templates/fuel-indexer-deploy.yaml
+++ b/deployment/charts/templates/fuel-indexer-deploy.yaml
@@ -74,6 +74,13 @@ spec:
             - name: http
               containerPort: {{ .Values.app.target_port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: {{ .Values.app.health_check_port }}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 10
           volumeMounts:
             - name: {{ .Values.app.volume.pvname }}
               mountPath: "{{ .Values.app.volume.mountPath }}"

--- a/deployment/charts/templates/fuel-indexer-deploy.yaml
+++ b/deployment/charts/templates/fuel-indexer-deploy.yaml
@@ -77,7 +77,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /api/health
-              port: {{ .Values.app.health_check_port }}
+              port: {{ .Values.app.target_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 10

--- a/docs/src/examples/hello-indexer.md
+++ b/docs/src/examples/hello-indexer.md
@@ -196,9 +196,9 @@ cargo build --release
 With some data in our indexer, we can now query the API endpoint, remembering that our namespace defined in the manifest file is `hello_namespace`, some example queries will look like this:
 
 ```bash
-curl -s localhost:29987/graph/hello_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { event_counts { id count } }", "params": "b"}'
-curl -s localhost:29987/graph/hello_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { event_counts { id account count } }", "params": "b"}'
-curl -s localhost:29987/graph/hello_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { event_counts { count } }", "params": "b"}'
+curl -s localhost:29987/api/graph/hello_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { event_counts { id count } }", "params": "b"}'
+curl -s localhost:29987/api/graph/hello_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { event_counts { id account count } }", "params": "b"}'
+curl -s localhost:29987/api/graph/hello_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { event_counts { count } }", "params": "b"}'
 ```
 
 With those queries, the response might look something like:

--- a/docs/src/examples/simple-native.md
+++ b/docs/src/examples/simple-native.md
@@ -112,7 +112,7 @@ In this example we just created an entity with `id = 1`
 So that's what we query for
 
 ```
-curl -X POST http://localhost:29987/graph/counter -H 'content-type: application/json' -d '{"query": "query { count(id: 1) { id count timestamp } }", "params": "b"}' | json_pp
+curl -X POST http://localhost:29987/api/graph/counter -H 'content-type: application/json' -d '{"query": "query { count(id: 1) { id count timestamp } }", "params": "b"}' | json_pp
 [
    {
       "count" : 1,

--- a/examples/simple-native/README.md
+++ b/examples/simple-native/README.md
@@ -84,7 +84,7 @@ In this example we just created an entity with `id = 1`
 So that's what we query for
 
 ```
-curl -X POST http://localhost:29987/graph/counter -H 'content-type: application/json' -d '{"query": "query { count(id: 1) { id count timestamp } }", "params": "b"}' | json_pp
+curl -X POST http://localhost:29987/api/graph/counter -H 'content-type: application/json' -d '{"query": "query { count(id: 1) { id count timestamp } }", "params": "b"}' | json_pp
 [
    {
       "count" : 1,

--- a/fuel-indexer-api-server/query_test.sh
+++ b/fuel-indexer-api-server/query_test.sh
@@ -2,13 +2,13 @@
 
 if [ "x$1" == "x1" ]
 then
-    curl -s localhost:29987/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id count } }", "params": "b"}'
+    curl -s localhost:29987/api/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id count } }", "params": "b"}'
 elif [ "x$1" == "x2" ]
 then
-    curl -s localhost:29987/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id account count } }", "params": "b"}'
+    curl -s localhost:29987/api/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id account count } }", "params": "b"}'
 elif [ "x$1" == "x3" ]
 then
-    curl -s localhost:29987/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { count } }", "params": "b"}'
+    curl -s localhost:29987/api/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { count } }", "params": "b"}'
 else
     echo "NOPE!!"
 fi

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 fuel-indexer-database-types = { path = "../database/database-types" }
+fuel-indexer-lib = { path = "../fuel-indexer-lib" }
 fuel-indexer-postgres = { path = "../database/postgres" }
 fuel-indexer-sqlite = { path = "../database/sqlite" }
 fuel-types = { version = "0.3", features = ["serde-types"] }

--- a/fuel-indexer-schema/src/db.rs
+++ b/fuel-indexer-schema/src/db.rs
@@ -1,7 +1,9 @@
 pub mod graphql;
 pub mod models;
 pub mod tables;
+use fuel_indexer_lib::utils::ServiceStatus;
 use sqlx::pool::PoolConnection;
+use std::cmp::Ordering;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
@@ -39,6 +41,9 @@ impl DbType {
     }
 }
 
+use fuel_indexer_postgres as postgres;
+use fuel_indexer_sqlite as sqlite;
+
 impl IndexerConnectionPool {
     pub fn database_type(&self) -> DbType {
         match self {
@@ -71,6 +76,33 @@ impl IndexerConnectionPool {
         }
     }
 
+    pub async fn is_connected(&self) -> sqlx::Result<ServiceStatus> {
+        match self {
+            IndexerConnectionPool::Postgres(p) => {
+                let mut conn = p.acquire().await.expect("Failed to get pool connection");
+                let result = postgres::execute_query(&mut conn, "SELECT true;".to_string())
+                    .await
+                    .expect("Failed to test Postgres connection.");
+
+                match result.cmp(&1) {
+                    Ordering::Equal => Ok(ServiceStatus::OK),
+                    _ => Ok(ServiceStatus::NotOk),
+                }
+            }
+            IndexerConnectionPool::Sqlite(p) => {
+                let mut conn = p.acquire().await.expect("Failed to get pool connection");
+                let result = sqlite::execute_query(&mut conn, "SELECT true;".to_string())
+                    .await
+                    .expect("Failed to test Sqlite connection.");
+
+                match result.cmp(&1) {
+                    Ordering::Equal => Ok(ServiceStatus::OK),
+                    _ => Ok(ServiceStatus::NotOk),
+                }
+            }
+        }
+    }
+
     pub async fn acquire(&self) -> sqlx::Result<IndexerConnection> {
         match self {
             IndexerConnectionPool::Postgres(p) => {
@@ -86,9 +118,6 @@ pub enum IndexerConnection {
     Postgres(Box<PoolConnection<sqlx::Postgres>>),
     Sqlite(PoolConnection<sqlx::Sqlite>),
 }
-
-use fuel_indexer_postgres as postgres;
-use fuel_indexer_sqlite as sqlite;
 
 pub async fn run_migration(database_url: &str) {
     let url = url::Url::parse(database_url);

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -23,6 +23,7 @@ fuel-vm = { version = "0.8" }
 fuels-core = { version = "0.15" }
 futures = "0.3"
 http = "0.2"
+hyper = { version = "0.14", features = ["client", "http2", "http1", "runtime" ]}
 serde = { version = "1.0", features = ["derive"] }
 serde-scale = "0.2"
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/fuel-indexer/runnit.sh
+++ b/fuel-indexer/runnit.sh
@@ -2,13 +2,13 @@
 
 if [ "x$1" == "x1" ]
 then
-    curl localhost:29899/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id count } }", "params": "b"}'
+    curl localhost:29899/api/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id count } }", "params": "b"}'
 elif [ "x$1" == "x2" ]
 then
-    curl localhost:29899/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id account count } }", "params": "b"}'
+    curl localhost:29899/api/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { id account count } }", "params": "b"}'
 elif [ "x$1" == "x3" ]
 then
-    curl localhost:29899/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { count } }", "params": "b"}'
+    curl localhost:29899/api/graph/demo_namespace -XPOST -H 'content-type: application/json' -d '{"query": "query { thing1 { count } }", "params": "b"}'
 else
     echo "NOPE!!"
 fi

--- a/fuel-indexer/src/api.rs
+++ b/fuel-indexer/src/api.rs
@@ -5,7 +5,10 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use fuel_indexer_lib::config::AdjustableConfig;
+use fuel_indexer_lib::{
+    config::AdjustableConfig,
+    utils::{FuelNodeHealthResponse, ServiceStatus},
+};
 use fuel_indexer_schema::db::{
     graphql::{GraphqlError, GraphqlQueryBuilder},
     models, run_migration,
@@ -13,8 +16,10 @@ use fuel_indexer_schema::db::{
     IndexerConnectionPool,
 };
 use http::StatusCode;
+use hyper::Client;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
+use std::{process, process::Command};
 use thiserror::Error;
 use tracing::error;
 
@@ -60,8 +65,56 @@ pub async fn query_graph(
     }
 }
 
-pub async fn health_check() -> StatusCode {
-    StatusCode::OK
+#[allow(unused_variables)]
+pub async fn health_check(
+    Extension(config): Extension<Arc<IndexerConfig>>,
+    Extension(pool): Extension<IndexerConnectionPool>,
+) -> (StatusCode, Json<Value>) {
+    // Get database status
+    let db_status = pool.is_connected().await.unwrap_or(ServiceStatus::NotOk);
+
+    // Get service uptime
+    let proc = Command::new("ps")
+        .arg("-o")
+        .arg("etime")
+        .arg("-p")
+        .arg(process::id().to_string())
+        .output()
+        .expect("Failed to call ps.");
+
+    let mut ps_status: Vec<String> = String::from_utf8_lossy(&proc.stdout)
+        .split('\n')
+        .map(|x| x.trim().to_string())
+        .filter(|x| !x.is_empty())
+        .collect();
+
+    let uptime = ps_status.pop().expect("Malformed stdout.");
+
+    // Get fuel-core status
+    let resp = Client::new()
+        .get(
+            format!("{}/health", config.fuel_node.http_url())
+                .parse()
+                .unwrap(),
+        )
+        .await
+        .expect("Failed to get fuel-client status.");
+
+    let body_bytes = hyper::body::to_bytes(resp.into_body())
+        .await
+        .expect("Failed to parse response body.");
+
+    let fuel_node_health: FuelNodeHealthResponse =
+        serde_json::from_slice(&body_bytes).expect("Failed to parse response.");
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "fuel_core_status": ServiceStatus::from(fuel_node_health),
+            "uptime": uptime,
+            "database_status": db_status,
+        })),
+    )
 }
 
 pub struct GraphQlApi;
@@ -79,15 +132,25 @@ impl GraphQlApi {
             .await
             .expect("Failed to establish connection pool");
 
-        if config.graphql_api.run_migrations {
+        if config.graphql_api.run_migrations.is_some() {
             run_migration(&config.database.to_string()).await;
         }
 
-        let app = Router::new()
-            .route("/graph/:name", post(query_graph))
+        let graph_route = Router::new()
+            .route("/:name", post(query_graph))
             .layer(Extension(schema_manager))
-            .layer(Extension(pool))
-            .route("/health", get(health_check));
+            .layer(Extension(pool.clone()));
+
+        let health_route = Router::new()
+            .route("/health", get(health_check))
+            .layer(Extension(config.clone()))
+            .layer(Extension(pool));
+
+        let api_routes = Router::new()
+            .nest("/graph", graph_route)
+            .nest("/", health_route);
+
+        let app = Router::new().nest("/api", api_routes);
 
         axum::Server::bind(&listen_on)
             .serve(app.into_make_service())

--- a/fuel-indexer/src/api.rs
+++ b/fuel-indexer/src/api.rs
@@ -2,7 +2,7 @@ use crate::{IndexerConfig, SchemaManager};
 use async_std::sync::{Arc, RwLock};
 use axum::{
     extract::{Extension, Json, Path},
-    routing::post,
+    routing::{get, post},
     Router,
 };
 use fuel_indexer_lib::config::AdjustableConfig;
@@ -60,6 +60,10 @@ pub async fn query_graph(
     }
 }
 
+pub async fn health_check() -> StatusCode {
+    StatusCode::OK
+}
+
 pub struct GraphQlApi;
 
 impl GraphQlApi {
@@ -82,7 +86,8 @@ impl GraphQlApi {
         let app = Router::new()
             .route("/graph/:name", post(query_graph))
             .layer(Extension(schema_manager))
-            .layer(Extension(pool));
+            .layer(Extension(pool))
+            .route("/health", get(health_check));
 
         axum::Server::bind(&listen_on)
             .serve(app.into_make_service())

--- a/fuel-indexer/src/service.rs
+++ b/fuel-indexer/src/service.rs
@@ -5,9 +5,8 @@ use crate::{
 use anyhow::Result;
 use async_std::{fs::File, io::ReadExt, sync::Arc};
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginatedResult, PaginationRequest};
-use fuel_indexer_lib::{
-    config::{AdjustableConfig, DatabaseConfig, FuelNodeConfig, GraphQLConfig, IndexerArgs},
-    defaults,
+use fuel_indexer_lib::config::{
+    AdjustableConfig, DatabaseConfig, FuelNodeConfig, GraphQLConfig, IndexerArgs,
 };
 use fuel_tx::Receipt;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt};
@@ -57,23 +56,14 @@ impl IndexerConfig {
     pub fn from_opts(args: IndexerArgs) -> IndexerConfig {
         let database = match args.database.as_str() {
             "postgres" => DatabaseConfig::Postgres {
-                user: args
-                    .postgres_user
-                    .unwrap_or_else(|| defaults::POSTGRES_USER.into()),
+                user: args.postgres_user,
                 password: args.postgres_password,
-                host: args
-                    .postgres_host
-                    .unwrap_or_else(|| defaults::POSTGRES_HOST.into()),
-                port: args
-                    .postgres_port
-                    .unwrap_or_else(|| defaults::POSTGRES_PORT.into()),
+                host: args.postgres_host,
+                port: args.postgres_port,
                 database: args.postgres_database,
             },
             "sqlite" => DatabaseConfig::Sqlite {
-                path: args
-                    .sqlite_database
-                    .unwrap_or_else(|| defaults::SQLITE_DATABASE.into())
-                    .into(),
+                path: args.sqlite_database,
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -83,23 +73,13 @@ impl IndexerConfig {
         IndexerConfig {
             database,
             fuel_node: FuelNodeConfig {
-                host: args
-                    .fuel_node_host
-                    .unwrap_or_else(|| defaults::FUEL_NODE_HOST.into()),
-                port: args
-                    .fuel_node_port
-                    .unwrap_or_else(|| defaults::FUEL_NODE_PORT.into()),
+                host: args.fuel_node_host,
+                port: args.fuel_node_port,
             },
             graphql_api: GraphQLConfig {
-                host: args
-                    .graphql_api_host
-                    .unwrap_or_else(|| defaults::GRAPHQL_API_HOST.into()),
-                port: args
-                    .graphql_api_port
-                    .unwrap_or_else(|| defaults::GRAPHQL_API_PORT.into()),
-                run_migrations: args
-                    .run_migrations
-                    .unwrap_or(defaults::GRAPHQL_API_RUN_MIGRATIONS),
+                host: args.graphql_api_host,
+                port: args.graphql_api_port,
+                run_migrations: args.run_migrations,
             },
         }
     }

--- a/fuel-indexer/tests/test_indexer.rs
+++ b/fuel-indexer/tests/test_indexer.rs
@@ -60,7 +60,7 @@ mod tests {
                 password: Some("my-secret".into()),
                 host: "127.0.0.1".into(),
                 port: "5432".into(),
-                database: None,
+                database: "postgres".to_string(),
             },
             graphql_api: GraphQLConfig::default(),
         };

--- a/tests/e2e/composable-indexer/README.md
+++ b/tests/e2e/composable-indexer/README.md
@@ -18,7 +18,7 @@ curl -X POST http://0.0.0.0:8000/ping
 ### 3. Confirm event was indexed
 
 ```bash
-curl -X POST http://0.0.0.0:29987/graph/composability_test \
+curl -X POST http://0.0.0.0:29987/api/graph/composability_test \
    -H 'content-type: application/json' \
    -d '{"query": "query { message { id ping pong message }}", "params": "b"}' \
    | json_pp

--- a/tests/e2e/composable-indexer/make-test-manifest.bash
+++ b/tests/e2e/composable-indexer/make-test-manifest.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo """
+namespace: composability_test
+graphql_schema: composable-indexer-lib/schema/schema.graphql
+wasm_module: composable-indexer-lib/composable_indexer_lib.wasm
+handlers:
+  - event: LogData
+    handler: function_one
+""" > manifest.yaml


### PR DESCRIPTION
### Description
- This PR adds a healthcheck at `GET - /health` to the GraphQL API component for Ops monitoring

### Testing steps
- [ ] Start the service and `curl -v http://localhost:29987/api/health`

```bash
➜  curl -v http://0.0.0.0:29987/api/health | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 0.0.0.0:29987...
* Connected to 0.0.0.0 (127.0.0.1) port 29987 (#0)
> GET /api/health HTTP/1.1
> Host: 0.0.0.0:29987
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: application/json
< content-length: 65
< date: Thu, 01 Sep 2022 00:23:03 GMT
<
{ [65 bytes data]
100    65  100    65    0     0   4850      0 --:--:-- --:--:-- --:--:-- 10833
* Connection #0 to host 0.0.0.0 left intact
{
   "database_status" : "OK",
   "fuel_core_status" : "OK",
   "uptime" : "06:38"
}
```