### PR TITLE
Implement infallible web api routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,6 @@ name = "fuel-indexer-database-types"
 version = "0.1.0"
 dependencies = [
  "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/fuel-indexer-database/database-types/Cargo.toml
+++ b/fuel-indexer-database/database-types/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = "1.0"

--- a/fuel-indexer-database/database-types/src/lib.rs
+++ b/fuel-indexer-database/database-types/src/lib.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use thiserror::Error;
 
 #[derive(Debug)]
 pub struct RootColumns {
@@ -230,12 +229,33 @@ pub enum IndexAssetType {
     Schema,
 }
 
+impl IndexAssetType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            IndexAssetType::Wasm => "wasm",
+            IndexAssetType::Manifest => "manifest",
+            IndexAssetType::Schema => "schema",
+        }
+    }
+}
+
 impl ToString for IndexAssetType {
     fn to_string(&self) -> String {
         match self {
             IndexAssetType::Wasm => "wasm".to_string(),
             IndexAssetType::Manifest => "manifest".to_string(),
             IndexAssetType::Schema => "schema".to_string(),
+        }
+    }
+}
+
+impl From<&str> for IndexAssetType {
+    fn from(a: &str) -> Self {
+        match a {
+            "wasm" => Self::Wasm,
+            "manifest" => Self::Manifest,
+            "schema" => Self::Schema,
+            _ => panic!("Unrecognized IndexAssetType."),
         }
     }
 }
@@ -262,12 +282,4 @@ impl RegisteredIndex {
     pub fn uid(&self) -> String {
         format!("{}.{}", self.namespace, self.identifier)
     }
-}
-
-#[derive(Debug, Error)]
-pub enum QueryError {
-    #[error("No transaction is open")]
-    NoTransactionError,
-    #[error("Unknown error")]
-    Unknown,
 }

--- a/fuel-indexer-database/postgres/src/lib.rs
+++ b/fuel-indexer-database/postgres/src/lib.rs
@@ -312,11 +312,11 @@ pub async fn registered_indices(
 pub async fn index_asset_version(
     conn: &mut PoolConnection<Postgres>,
     index_id: &i64,
-    asset_type: IndexAssetType,
+    asset_type: &IndexAssetType,
 ) -> sqlx::Result<i64> {
     match sqlx::query(&format!(
         "SELECT COUNT(*) FROM index_asset_registry_{} WHERE index_id = {}",
-        asset_type.to_string(),
+        asset_type.as_str(),
         index_id,
     ))
     .fetch_one(conn)
@@ -341,7 +341,7 @@ pub async fn register_index_asset(
 
     let digest = sha256_digest(&bytes);
 
-    if let Some(asset) = asset_already_exists(conn, asset_type.clone(), &bytes, &index.id).await? {
+    if let Some(asset) = asset_already_exists(conn, &asset_type, &bytes, &index.id).await? {
         info!(
             "Asset({:?}) for Index({}) already registered.",
             asset_type,
@@ -350,7 +350,7 @@ pub async fn register_index_asset(
         return Ok(asset);
     }
 
-    let current_version = index_asset_version(conn, &index.id, asset_type.clone())
+    let current_version = index_asset_version(conn, &index.id, &asset_type)
         .await
         .expect("Failed to get asset version.");
 
@@ -440,7 +440,7 @@ pub async fn latest_assets_for_index(
 
 pub async fn asset_already_exists(
     conn: &mut PoolConnection<Postgres>,
-    asset_type: IndexAssetType,
+    asset_type: &IndexAssetType,
     bytes: &Vec<u8>,
     index_id: &i64,
 ) -> sqlx::Result<Option<IndexAsset>> {

--- a/fuel-indexer-database/sqlite/src/lib.rs
+++ b/fuel-indexer-database/sqlite/src/lib.rs
@@ -421,11 +421,11 @@ pub async fn registered_indices(
 pub async fn index_asset_version(
     conn: &mut PoolConnection<Sqlite>,
     index_id: &i64,
-    asset_type: IndexAssetType,
+    asset_type: &IndexAssetType,
 ) -> sqlx::Result<i64> {
     match sqlx::query(&format!(
         "SELECT COUNT(*) FROM index_asset_registry_{} WHERE index_id = {}",
-        asset_type.to_string(),
+        asset_type.as_str(),
         index_id,
     ))
     .fetch_one(conn)
@@ -450,7 +450,7 @@ pub async fn register_index_asset(
 
     let digest = sha256_digest(&bytes);
 
-    if let Some(asset) = asset_already_exists(conn, asset_type.clone(), &bytes, &index.id).await? {
+    if let Some(asset) = asset_already_exists(conn, &asset_type, &bytes, &index.id).await? {
         info!(
             "Asset({:?}) for Index({}) already registered.",
             asset_type,
@@ -459,7 +459,7 @@ pub async fn register_index_asset(
         return Ok(asset);
     }
 
-    let current_version = index_asset_version(conn, &index.id, asset_type.clone())
+    let current_version = index_asset_version(conn, &index.id, &asset_type)
         .await
         .expect("Failed to get asset version.");
 
@@ -549,7 +549,7 @@ pub async fn latest_assets_for_index(
 
 pub async fn asset_already_exists(
     conn: &mut PoolConnection<Sqlite>,
-    asset_type: IndexAssetType,
+    asset_type: &IndexAssetType,
     bytes: &Vec<u8>,
     index_id: &i64,
 ) -> sqlx::Result<Option<IndexAsset>> {

--- a/fuel-indexer-database/src/lib.rs
+++ b/fuel-indexer-database/src/lib.rs
@@ -1,24 +1,31 @@
+pub use fuel_indexer_database_types::*;
 use fuel_indexer_lib::utils::ServiceStatus;
 use fuel_indexer_postgres as postgres;
 use fuel_indexer_sqlite as sqlite;
-use sqlx::pool::PoolConnection;
+use sqlx::{pool::PoolConnection, Error as SqlxError};
 use std::cmp::Ordering;
 use thiserror::Error;
 
 pub mod queries;
 
-#[derive(Debug)]
-pub enum IndexerConnection {
-    Postgres(Box<PoolConnection<sqlx::Postgres>>),
-    Sqlite(PoolConnection<sqlx::Sqlite>),
-}
-
-#[derive(Clone, Debug, Error)]
-pub enum DatabaseError {
+#[derive(Debug, Error)]
+pub enum IndexerDatabaseError {
     #[error("Invalid connection string: {0:?}")]
     InvalidConnectionString(String),
     #[error("Database backend not supported: {0:?}")]
     BackendNotSupported(String),
+    #[error("No transaction is open.")]
+    NoTransactionError,
+    #[error("Error from sqlx: {0:#?}")]
+    SqlxError(#[from] SqlxError),
+    #[error("Unknown error")]
+    Unknown,
+}
+
+#[derive(Debug)]
+pub enum IndexerConnection {
+    Postgres(Box<PoolConnection<sqlx::Postgres>>),
+    Sqlite(PoolConnection<sqlx::Sqlite>),
 }
 
 #[derive(Clone, Debug)]
@@ -56,10 +63,14 @@ impl IndexerConnectionPool {
         }
     }
 
-    pub async fn connect(database_url: &str) -> Result<IndexerConnectionPool, DatabaseError> {
+    pub async fn connect(
+        database_url: &str,
+    ) -> Result<IndexerConnectionPool, IndexerDatabaseError> {
         let url = url::Url::parse(database_url);
         if url.is_err() {
-            return Err(DatabaseError::InvalidConnectionString(database_url.into()));
+            return Err(IndexerDatabaseError::InvalidConnectionString(
+                database_url.into(),
+            ));
         }
         let url = url.expect("Database URL should be correctly formed");
 
@@ -76,7 +87,7 @@ impl IndexerConnectionPool {
                     .expect("Could not connect to sqlite backend!");
                 Ok(IndexerConnectionPool::Sqlite(pool))
             }
-            err => Err(DatabaseError::BackendNotSupported(err.into())),
+            err => Err(IndexerDatabaseError::BackendNotSupported(err.into())),
         }
     }
 

--- a/fuel-indexer-database/src/lib.rs
+++ b/fuel-indexer-database/src/lib.rs
@@ -122,7 +122,7 @@ impl IndexerConnectionPool {
 async fn attempt_connection(
     database_url: &str,
     scheme: &str,
-) -> Result<IndexerConnectionPool, DatabaseError> {
+) -> Result<IndexerConnectionPool, IndexerDatabaseError> {
     let mut remaining_retries = DB_CONN_ATTEMPTS;
     let mut delay = DB_CONN_RETRY_FACTOR;
 
@@ -173,6 +173,6 @@ async fn attempt_connection(
 
             Ok(IndexerConnectionPool::Sqlite(pool))
         }
-        err => Err(DatabaseError::BackendNotSupported(err.into())),
+        err => Err(IndexerDatabaseError::BackendNotSupported(err.into())),
     }
 }

--- a/fuel-indexer-database/src/queries.rs
+++ b/fuel-indexer-database/src/queries.rs
@@ -201,7 +201,7 @@ pub async fn registered_indices(
 pub async fn index_asset_version(
     conn: &mut IndexerConnection,
     index_id: &i64,
-    asset_type: IndexAssetType,
+    asset_type: &IndexAssetType,
 ) -> sqlx::Result<i64> {
     match conn {
         IndexerConnection::Postgres(ref mut c) => {
@@ -259,7 +259,7 @@ pub async fn latest_assets_for_index(
 
 pub async fn asset_already_exists(
     conn: &mut IndexerConnection,
-    asset_type: IndexAssetType,
+    asset_type: &IndexAssetType,
     bytes: &Vec<u8>,
     index_id: &i64,
 ) -> sqlx::Result<Option<IndexAsset>> {

--- a/fuel-indexer-lib/src/lib.rs
+++ b/fuel-indexer-lib/src/lib.rs
@@ -66,7 +66,7 @@ pub mod utils {
         }
     }
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Default)]
     pub struct FuelNodeHealthResponse {
         up: bool,
     }

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -33,5 +33,5 @@ db-models = [
     "thiserror",
     "fuel-indexer-postgres",
     "fuel-indexer-sqlite",
-    "fuel-indexer-database"
+    "fuel-indexer-database",
 ]

--- a/fuel-indexer/src/lib.rs
+++ b/fuel-indexer/src/lib.rs
@@ -13,7 +13,7 @@ pub use api::GraphQlApi;
 pub use config::IndexerConfig;
 pub use database::{Database, SchemaManager};
 pub use executor::{Executor, IndexEnv, NativeIndexExecutor, WasmIndexExecutor};
-pub use fuel_indexer_database::DatabaseError;
+pub use fuel_indexer_database::IndexerDatabaseError;
 pub use fuel_indexer_schema::{BlockData, FtColumn};
 pub use fuel_types::{Address, ContractId};
 pub use manifest::{Manifest, Module};
@@ -45,7 +45,7 @@ pub enum IndexerError {
     #[error("Indexer transaction error {0:?}")]
     TxError(#[from] crate::executor::TxError),
     #[error("Database error {0:?}")]
-    DatabaseError(#[from] DatabaseError),
+    DatabaseError(#[from] IndexerDatabaseError),
     #[error("Invalid address {0:?}")]
     InvalidAddress(#[from] std::net::AddrParseError),
     #[error("Join Error {0:?}")]


### PR DESCRIPTION
### Description
- Updated version of https://github.com/FuelLabs/fuel-indexer/pull/220
- This PR makes the GraphQL API routes infallible

### Testing steps
- [ ] Make requests against the GraphQL endpoints that would produce panics on master (should log errors and return general JSON messages accordingly)