### PR TITLE
Add retry to database connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,8 @@ dependencies = [
  "fuel-indexer-sqlite",
  "sqlx",
  "thiserror",
+ "tokio",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
  "sqlx",
+ "tokio",
  "tracing",
 ]
 
@@ -2514,6 +2515,7 @@ dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
  "sqlx",
+ "tokio",
  "tracing",
 ]
 

--- a/fuel-indexer-database/Cargo.toml
+++ b/fuel-indexer-database/Cargo.toml
@@ -12,4 +12,6 @@ fuel-indexer-postgres = { path = "./postgres" }
 fuel-indexer-sqlite = { path = "./sqlite" }
 sqlx = { version = "0.6" }
 thiserror = { version = "1.0" }
+tokio = { version = "1.8", features = ["time"] }
+tracing = "0.1"
 url = "2.2"

--- a/fuel-indexer-database/postgres/Cargo.toml
+++ b/fuel-indexer-database/postgres/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 fuel-indexer-database-types = { path = "../database-types" }
 fuel-indexer-lib = { path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "offline"] }
+tokio = { version = "1.8", features = ["time"] }
 tracing = "0.1"

--- a/fuel-indexer-database/sqlite/Cargo.toml
+++ b/fuel-indexer-database/sqlite/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 fuel-indexer-database-types = { path = "../database-types" }
 fuel-indexer-lib = { path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "sqlite", "offline", "json"] }
+tokio = { version = "1.8", features = ["time"] }
 tracing = "0.1"

--- a/fuel-indexer-database/src/lib.rs
+++ b/fuel-indexer-database/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 pub mod queries;
 
 const RETRY_LIMIT: usize = 5;
-const INITIAL_RETRY_DELAY: u64 = 15;
+const INITIAL_RETRY_DELAY: u64 = 2;
 
 #[derive(Debug)]
 pub enum IndexerConnection {


### PR DESCRIPTION
## Description
Adds retry to database connection attempt so that the indexer service does not immediately crash on start if a connection can't be made. Closes #208.