### PR TITLE
No restart on asset upload

### DIFF
--- a/fuel-indexer-api-server/src/main.rs
+++ b/fuel-indexer-api-server/src/main.rs
@@ -29,7 +29,7 @@ pub async fn main() -> Result<()> {
 
     info!("Configuration: {:?}", config);
 
-    GraphQlApi::run(config.clone()).await;
+    GraphQlApi::run(config.clone(), None).await;
 
     Ok(())
 }

--- a/fuel-indexer-database/postgres/src/lib.rs
+++ b/fuel-indexer-database/postgres/src/lib.rs
@@ -476,6 +476,23 @@ pub async fn asset_already_exists(
     }
 }
 
+pub async fn index_id_for(
+    conn: &mut PoolConnection<Postgres>,
+    namespace: &str,
+    identifier: &str,
+) -> sqlx::Result<i64> {
+    let query = format!(
+        "SELECT id FROM index_registry WHERE namespace = '{}' AND identifier = '{}'",
+        namespace, identifier
+    );
+
+    let row = sqlx::query(&query).fetch_one(conn).await?;
+
+    let id: i64 = row.get(0);
+
+    Ok(id)
+}
+
 pub async fn start_transaction(
     conn: &mut PoolConnection<Postgres>,
 ) -> sqlx::Result<usize> {

--- a/fuel-indexer-database/sqlite/src/lib.rs
+++ b/fuel-indexer-database/sqlite/src/lib.rs
@@ -588,6 +588,23 @@ pub async fn asset_already_exists(
     }
 }
 
+pub async fn index_id_for(
+    conn: &mut PoolConnection<Sqlite>,
+    namespace: &str,
+    identifier: &str,
+) -> sqlx::Result<i64> {
+    let query = format!(
+        "SELECT id FROM index_registry WHERE namespace = '{}' AND identifier = '{}'",
+        namespace, identifier
+    );
+
+    let row = sqlx::query(&query).fetch_one(conn).await?;
+
+    let id: i64 = row.get(0);
+
+    Ok(id)
+}
+
 pub async fn start_transaction(conn: &mut PoolConnection<Sqlite>) -> sqlx::Result<usize> {
     execute_query(conn, "BEGIN".into()).await
 }

--- a/fuel-indexer-database/src/queries.rs
+++ b/fuel-indexer-database/src/queries.rs
@@ -312,6 +312,21 @@ pub async fn asset_already_exists(
     }
 }
 
+pub async fn index_id_for(
+    conn: &mut IndexerConnection,
+    namespace: &str,
+    identifier: &str,
+) -> sqlx::Result<i64> {
+    match conn {
+        IndexerConnection::Postgres(ref mut c) => {
+            postgres::index_id_for(c, namespace, identifier).await
+        }
+        IndexerConnection::Sqlite(ref mut c) => {
+            sqlite::index_id_for(c, namespace, identifier).await
+        }
+    }
+}
+
 pub async fn start_transaction(conn: &mut IndexerConnection) -> sqlx::Result<usize> {
     match conn {
         IndexerConnection::Postgres(ref mut c) => postgres::start_transaction(c).await,

--- a/fuel-indexer-lib/src/lib.rs
+++ b/fuel-indexer-lib/src/lib.rs
@@ -13,6 +13,12 @@ pub mod utils {
     const MAX_DATABASE_CONNECTION_ATTEMPTS: usize = 5;
     const INITIAL_RETRY_DELAY_SECS: u64 = 2;
 
+    #[derive(Debug)]
+    pub struct AssetReloadRequest {
+        pub namespace: String,
+        pub identifier: String,
+    }
+
     pub fn sha256_digest(blob: &Vec<u8>) -> String {
         let mut hasher = Sha256::new();
         hasher.update(blob.as_slice());
@@ -129,4 +135,6 @@ pub mod defaults {
     pub const SQLITE_DATABASE: &str = "sqlite.db";
 
     pub const GRAPHQL_API_RUN_MIGRATIONS: Option<bool> = None;
+
+    pub const ASSET_REFRESH_CHANNEL_SIZE: usize = 100;
 }

--- a/fuel-indexer-tests/tests/service.rs
+++ b/fuel-indexer-tests/tests/service.rs
@@ -83,7 +83,7 @@ async fn test_can_trigger_event_from_contract_and_index_emited_event_in_postgres
         graphql_api: GraphQLConfig::default(),
     };
 
-    let mut indexer_service = IndexerService::new(config).await.unwrap();
+    let mut indexer_service = IndexerService::new(config, None).await.unwrap();
 
     let manifest: Manifest = serde_yaml::from_str(MANIFEST).expect("Bad yaml file");
 

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 serde_yaml = "0.8"
 sqlx = "0.6"
 thiserror = "1.0"
-tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["env-filter"] }
 wasmer = "2.0"

--- a/fuel-indexer/src/config.rs
+++ b/fuel-indexer/src/config.rs
@@ -168,6 +168,13 @@ impl From<SocketAddr> for FuelNodeConfig {
     }
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<SocketAddr> for FuelNodeConfig {
+    fn into(self) -> SocketAddr {
+        format!("{}:{}", self.host, self.port).parse().unwrap()
+    }
+}
+
 impl std::string::ToString for FuelNodeConfig {
     fn to_string(&self) -> String {
         format!("{}:{}", self.host, self.port)

--- a/fuel-indexer/src/service.rs
+++ b/fuel-indexer/src/service.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{IndexerConfig, MutableConfig},
+    config::{FuelNodeConfig, IndexerConfig},
     manifest::Module,
     Executor, IndexerResult, Manifest, NativeIndexExecutor, SchemaManager,
     WasmIndexExecutor,
@@ -10,14 +10,17 @@ use fuel_gql_client::client::{
 };
 use fuel_indexer_database::{queries, IndexerConnectionPool};
 use fuel_indexer_database_types::IndexAssetType;
+use fuel_indexer_lib::utils::AssetReloadRequest;
 use fuel_indexer_schema::{Address, BlockData, Bytes32};
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::future::Future;
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::{
+    sync::mpsc::Receiver,
     task::JoinHandle,
     time::{sleep, Duration},
 };
@@ -26,33 +29,205 @@ use tracing::{debug, error, info, warn};
 
 const RETRY_LIMIT: usize = 5;
 
+async fn spawn_executor_from_manifest(
+    fuel_node: FuelNodeConfig,
+    manifest: &Manifest,
+    run_once: bool,
+    database_url: String,
+) -> IndexerResult<(Arc<AtomicBool>, JoinHandle<()>, Option<Vec<u8>>)> {
+    let start_block = manifest.start_block;
+
+    match manifest.module {
+        Module::Wasm(ref module) => {
+            let mut bytes = Vec::<u8>::new();
+            let mut file = File::open(module).await?;
+            file.read_to_end(&mut bytes).await?;
+
+            let executor =
+                WasmIndexExecutor::new(database_url, manifest.to_owned(), bytes.clone())
+                    .await?;
+            let kill_switch = Arc::new(AtomicBool::new(run_once));
+            let handle = tokio::spawn(make_task(
+                fuel_node.into(),
+                kill_switch.clone(),
+                executor,
+                start_block,
+            ));
+
+            Ok((kill_switch, handle, Some(bytes)))
+        }
+        Module::Native(ref path) => {
+            let path = path.clone();
+            let executor =
+                NativeIndexExecutor::new(&database_url, manifest.to_owned(), path)
+                    .await?;
+            let kill_switch = Arc::new(AtomicBool::new(run_once));
+            let handle = tokio::spawn(make_task(
+                fuel_node.into(),
+                kill_switch.clone(),
+                executor,
+                start_block,
+            ));
+
+            Ok((kill_switch, handle, None))
+        }
+    }
+}
+
+async fn spawn_executor_from_index_asset_registry(
+    fuel_node: FuelNodeConfig,
+    db_url: String,
+    manifest: &Manifest,
+    run_once: bool,
+    wasm_bytes: Vec<u8>,
+) -> IndexerResult<(Arc<AtomicBool>, JoinHandle<()>)> {
+    let start_block = manifest.start_block;
+
+    match manifest.module {
+        Module::Wasm(ref _module) => {
+            let executor =
+                WasmIndexExecutor::new(db_url, manifest.to_owned(), wasm_bytes).await?;
+            let kill_switch = Arc::new(AtomicBool::new(run_once));
+            let handle = tokio::spawn(make_task(
+                fuel_node.into(),
+                kill_switch.clone(),
+                executor,
+                start_block,
+            ));
+
+            Ok((kill_switch, handle))
+        }
+        Module::Native(ref path) => {
+            let path = path.clone();
+            let executor =
+                NativeIndexExecutor::new(&db_url, manifest.to_owned(), path).await?;
+            let kill_switch = Arc::new(AtomicBool::new(run_once));
+            let handle = tokio::spawn(make_task(
+                fuel_node.into(),
+                kill_switch.clone(),
+                executor,
+                start_block,
+            ));
+
+            Ok((kill_switch, handle))
+        }
+    }
+}
+
+fn make_task<T: 'static + Executor + Send + Sync>(
+    fuel_node_addr: SocketAddr,
+    kill_switch: Arc<AtomicBool>,
+    mut executor: T,
+    start_block: Option<u64>,
+) -> impl Future<Output = ()> {
+    let mut next_cursor = None;
+    let mut next_block = start_block.unwrap_or(1);
+    let client = FuelClient::from(fuel_node_addr);
+
+    async move {
+        let mut retry_count = 0;
+
+        loop {
+            debug!("Fetching paginated results from {:?}", next_cursor);
+            // TODO: can we have a "start at height" option?
+            let PaginatedResult {
+                cursor, results, ..
+            } = client
+                .blocks(PaginationRequest {
+                    cursor: next_cursor.clone(),
+                    results: 10,
+                    direction: PageDirection::Forward,
+                })
+                .await
+                .expect("Failed to retrieve blocks");
+
+            debug!("Processing {} results", results.len());
+
+            let mut block_info = Vec::new();
+            for block in results.into_iter().rev() {
+                if block.height.0 != next_block {
+                    continue;
+                }
+                next_block = block.height.0 + 1;
+
+                // NOTE: for now assuming we have a single contract instance,
+                // we'll need to watch contract creation events here in
+                // case an indexer would be interested in processing it.
+                let mut transactions = Vec::new();
+                for trans in block.transactions {
+                    match client.receipts(&trans.id.to_string()).await {
+                        Ok(r) => {
+                            transactions.push(r);
+                        }
+                        Err(e) => {
+                            error!("Client communication error {:?}", e);
+                        }
+                    }
+                }
+
+                let block = BlockData {
+                    height: block.height.0,
+                    id: Bytes32::from(block.id),
+                    time: block.time.timestamp(),
+                    producer: Address::from(block.producer),
+                    transactions,
+                };
+
+                block_info.push(block);
+            }
+
+            let result = executor.handle_events(block_info).await;
+
+            if let Err(e) = result {
+                error!("Indexer executor failed {e:?}, retrying.");
+                sleep(Duration::from_secs(5)).await;
+                retry_count += 1;
+                if retry_count < RETRY_LIMIT {
+                    continue;
+                } else {
+                    error!("Indexer failed after retries, giving up!");
+                    break;
+                }
+            }
+
+            next_cursor = cursor;
+            if next_cursor.is_none() {
+                info!("No next page, sleeping");
+                sleep(Duration::from_secs(5)).await;
+            };
+            retry_count = 0;
+
+            if kill_switch.load(Ordering::SeqCst) {
+                break;
+            }
+        }
+    }
+}
+
 pub struct IndexerService {
     config: IndexerConfig,
-    fuel_node_addr: SocketAddr,
+    rx: Option<Receiver<AssetReloadRequest>>,
     manager: SchemaManager,
     database_url: String,
-    handles: HashMap<String, JoinHandle<()>>,
+    handles: RefCell<HashMap<String, JoinHandle<()>>>,
     killers: HashMap<String, Arc<AtomicBool>>,
 }
 
 impl IndexerService {
-    pub async fn new(config: IndexerConfig) -> IndexerResult<IndexerService> {
+    pub async fn new(
+        config: IndexerConfig,
+        rx: Option<Receiver<AssetReloadRequest>>,
+    ) -> IndexerResult<IndexerService> {
         let database_url = config.database.to_string().clone();
 
         let manager = SchemaManager::new(&database_url).await?;
 
-        let fuel_node_addr = config
-            .fuel_node
-            .clone()
-            .derive_socket_addr()
-            .expect("Could not parse Fuel node addr for IndexerService.");
-
         Ok(IndexerService {
             config,
-            fuel_node_addr,
+            rx,
             manager,
             database_url,
-            handles: HashMap::default(),
+            handles: RefCell::new(HashMap::default()),
             killers: HashMap::default(),
         })
     }
@@ -89,13 +264,13 @@ impl IndexerService {
 
                 self.manager.new_schema(&namespace, &schema).await?;
 
-                let (kill_switch, handle, wasm_bytes) = self
-                    .spawn_executor_from_manifest(
-                        &manifest,
-                        run_once,
-                        database_url.clone(),
-                    )
-                    .await?;
+                let (kill_switch, handle, wasm_bytes) = spawn_executor_from_manifest(
+                    self.config.fuel_node.clone(),
+                    &manifest,
+                    run_once,
+                    database_url.clone(),
+                )
+                .await?;
 
                 let mut items = vec![
                     (IndexAssetType::Wasm, wasm_bytes.unwrap()),
@@ -122,7 +297,7 @@ impl IndexerService {
                 }
 
                 info!("Registered indexer {}", identifier);
-                self.handles.insert(namespace.clone(), handle);
+                self.handles.borrow_mut().insert(namespace.clone(), handle);
                 self.killers.insert(namespace, kill_switch);
             }
             None => {
@@ -134,16 +309,19 @@ impl IndexerService {
                         serde_yaml::from_slice(&assets.manifest.bytes)
                             .expect("Could not read manifest in registry.");
 
-                    let (kill_switch, handle) = self
-                        .spawn_executor_from_index_asset_registry(
-                            &manifest,
-                            run_once,
-                            assets.wasm.bytes,
-                        )
-                        .await?;
+                    let (kill_switch, handle) = spawn_executor_from_index_asset_registry(
+                        self.config.fuel_node.clone(),
+                        self.config.database.to_string(),
+                        &manifest,
+                        run_once,
+                        assets.wasm.bytes,
+                    )
+                    .await?;
 
                     info!("Registered indexer {}", manifest.uid());
-                    self.handles.insert(manifest.namespace.clone(), handle);
+                    self.handles
+                        .borrow_mut()
+                        .insert(manifest.namespace.clone(), handle);
                     self.killers.insert(manifest.namespace, kill_switch);
                 }
             }
@@ -159,97 +337,6 @@ impl IndexerService {
         Ok(())
     }
 
-    async fn spawn_executor_from_manifest(
-        &self,
-        manifest: &Manifest,
-        run_once: bool,
-        database_url: String,
-    ) -> IndexerResult<(Arc<AtomicBool>, JoinHandle<()>, Option<Vec<u8>>)> {
-        let start_block = manifest.start_block;
-
-        match manifest.module {
-            Module::Wasm(ref module) => {
-                let mut bytes = Vec::<u8>::new();
-                let mut file = File::open(module).await?;
-                file.read_to_end(&mut bytes).await?;
-
-                let executor = WasmIndexExecutor::new(
-                    database_url,
-                    manifest.to_owned(),
-                    bytes.clone(),
-                )
-                .await?;
-                let kill_switch = Arc::new(AtomicBool::new(run_once));
-                let handle = tokio::spawn(self.make_task(
-                    kill_switch.clone(),
-                    executor,
-                    start_block,
-                ));
-
-                Ok((kill_switch, handle, Some(bytes)))
-            }
-            Module::Native(ref path) => {
-                let path = path.clone();
-                let executor =
-                    NativeIndexExecutor::new(&database_url, manifest.to_owned(), path)
-                        .await?;
-                let kill_switch = Arc::new(AtomicBool::new(run_once));
-                let handle = tokio::spawn(self.make_task(
-                    kill_switch.clone(),
-                    executor,
-                    start_block,
-                ));
-
-                Ok((kill_switch, handle, None))
-            }
-        }
-    }
-
-    async fn spawn_executor_from_index_asset_registry(
-        &self,
-        manifest: &Manifest,
-        run_once: bool,
-        wasm_bytes: Vec<u8>,
-    ) -> IndexerResult<(Arc<AtomicBool>, JoinHandle<()>)> {
-        let start_block = manifest.start_block;
-
-        match manifest.module {
-            Module::Wasm(ref _module) => {
-                let executor = WasmIndexExecutor::new(
-                    self.database_url.clone(),
-                    manifest.to_owned(),
-                    wasm_bytes,
-                )
-                .await?;
-                let kill_switch = Arc::new(AtomicBool::new(run_once));
-                let handle = tokio::spawn(self.make_task(
-                    kill_switch.clone(),
-                    executor,
-                    start_block,
-                ));
-
-                Ok((kill_switch, handle))
-            }
-            Module::Native(ref path) => {
-                let path = path.clone();
-                let executor = NativeIndexExecutor::new(
-                    &self.database_url,
-                    manifest.to_owned(),
-                    path,
-                )
-                .await?;
-                let kill_switch = Arc::new(AtomicBool::new(run_once));
-                let handle = tokio::spawn(self.make_task(
-                    kill_switch.clone(),
-                    executor,
-                    start_block,
-                ));
-
-                Ok((kill_switch, handle))
-            }
-        }
-    }
-
     pub fn stop_indexer(&mut self, executor_name: &str) {
         if let Some(killer) = self.killers.remove(executor_name) {
             killer.store(true, Ordering::SeqCst);
@@ -258,101 +345,68 @@ impl IndexerService {
         }
     }
 
-    fn make_task<T: 'static + Executor + Send + Sync>(
-        &self,
-        kill_switch: Arc<AtomicBool>,
-        mut executor: T,
-        start_block: Option<u64>,
-    ) -> impl Future<Output = ()> {
-        let mut next_cursor = None;
-        let mut next_block = start_block.unwrap_or(1);
-        let client = FuelClient::from(self.fuel_node_addr);
+    pub async fn run(self) {
+        let IndexerService {
+            handles,
+            mut rx,
+            mut killers,
+            ..
+        } = self;
+        let mut futs = FuturesUnordered::from_iter(handles.take().into_values());
+        let mut wait = true;
 
-        async move {
-            let mut retry_count = 0;
+        loop {
+            if let Some(fut) = futs.next().await {
+                debug!("Retired a future {fut:?}");
+                wait = false;
+            }
 
-            loop {
-                debug!("Fetching paginated results from {:?}", next_cursor);
-                // TODO: can we have a "start at height" option?
-                let PaginatedResult {
-                    cursor, results, ..
-                } = client
-                    .blocks(PaginationRequest {
-                        cursor: next_cursor.clone(),
-                        results: 10,
-                        direction: PageDirection::Forward,
-                    })
+            if let Some(ref mut rx) = rx {
+                if let Some(request) = rx.recv().await {
+                    debug!("Retired a future {request:?}");
+                    wait = false;
+
+                    let database_url = self.config.database.clone().to_string();
+                    let pool =
+                        IndexerConnectionPool::connect(&database_url).await.unwrap();
+
+                    let mut conn = pool.acquire().await.unwrap();
+
+                    let index_id = queries::index_id_for(
+                        &mut conn,
+                        &request.namespace,
+                        &request.identifier,
+                    )
                     .await
-                    .expect("Failed to retrieve blocks");
+                    .unwrap();
 
-                debug!("Processing {} results", results.len());
+                    let assets = queries::latest_assets_for_index(&mut conn, &index_id)
+                        .await
+                        .expect("Could not get latest assets for index");
 
-                let mut block_info = Vec::new();
-                for block in results.into_iter().rev() {
-                    if block.height.0 != next_block {
-                        continue;
-                    }
-                    next_block = block.height.0 + 1;
+                    let manifest: Manifest =
+                        serde_yaml::from_slice(&assets.manifest.bytes).unwrap();
 
-                    // NOTE: for now assuming we have a single contract instance,
-                    // we'll need to watch contract creation events here in
-                    // case an indexer would be interested in processing it.
-                    let mut transactions = Vec::new();
-                    for trans in block.transactions {
-                        match client.receipts(&trans.id.to_string()).await {
-                            Ok(r) => {
-                                transactions.push(r);
-                            }
-                            Err(e) => {
-                                error!("Client communication error {:?}", e);
-                            }
-                        }
-                    }
+                    let (kill_switch, handle) = spawn_executor_from_index_asset_registry(
+                        self.config.fuel_node.clone(),
+                        self.config.database.to_string(),
+                        &manifest,
+                        false,
+                        assets.wasm.bytes,
+                    )
+                    .await
+                    .unwrap();
 
-                    let block = BlockData {
-                        height: block.height.0,
-                        id: Bytes32::from(block.id),
-                        time: block.time.timestamp(),
-                        producer: Address::from(block.producer),
-                        transactions,
-                    };
-
-                    block_info.push(block);
-                }
-
-                let result = executor.handle_events(block_info).await;
-
-                if let Err(e) = result {
-                    error!("Indexer executor failed {e:?}, retrying.");
-                    sleep(Duration::from_secs(5)).await;
-                    retry_count += 1;
-                    if retry_count < RETRY_LIMIT {
-                        continue;
-                    } else {
-                        error!("Indexer failed after retries, giving up!");
-                        break;
-                    }
-                }
-
-                next_cursor = cursor;
-                if next_cursor.is_none() {
-                    info!("No next page, sleeping");
-                    sleep(Duration::from_secs(5)).await;
-                };
-                retry_count = 0;
-
-                if kill_switch.load(Ordering::SeqCst) {
-                    break;
+                    handles
+                        .borrow_mut()
+                        .insert(request.namespace.clone(), handle);
+                    killers.insert(request.namespace, kill_switch);
                 }
             }
-        }
-    }
 
-    pub async fn run(self) {
-        let IndexerService { handles, .. } = self;
-        let mut futs = FuturesUnordered::from_iter(handles.into_values());
-        while let Some(fut) = futs.next().await {
-            debug!("Retired a future {fut:?}");
+            if wait {
+                sleep(Duration::from_secs(1)).await;
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
- This PR implements new executor construction after asset upload, thus preventing a service restart

### Testing steps
- Unit test is TBD as it would be quite involved (would require its own assets/index/etc)

UAT
- [ ] Refresh DB `dropdb postgres && createdb postgres && DATABASE_URL=postgres://postgres@localhost bash scripts/run_migrations.bash`
- [ ] Start fuel component `cd fuel-indexer-tests/components/web && cargo run --bin fuel-node` 
- [ ] Start the web component `cd fuel-indexer-tests/components/web && cargo run --bin web-api`
- [ ] Start the indexer with no indices `cargo run --bin fuel-indexer`
- [ ] Upload assets

```bash
curl -v http://127.0.0.1:29987/api/index/fuel_indexer_test/index1 \
    -F "manifest=@fuel-indexer-tests/assets/fuel_indexer_test.yaml" \
    -F "wasm=@fuel-indexer-tests/assets/fuel_indexer_test.wasm" \
    -F "schema=@fuel-indexer-tests/assets/fuel_indexer_test.graphql" \
    -H 'Content-type: multipart/form-data' -H "Authorization: foo" | json_pp
```
- [ ] Trigger an event `curl -v -X POST http://127.0.0.1:8000/ping`
- [ ] Make request to ensure event was indexed

```bash
curl -X POST http://127.0.0.1:29987/api/graph/fuel_indexer_test \
   -H 'content-type: application/json' \
   -d '{"query": "query { message { id ping pong message }}", "params": "b"}' | json_pp
```