### PR TITLE
Publish all crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,6 +531,9 @@ jobs:
           mv ./dasel /usr/local/bin/dasel
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-api-server/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-database/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-database/database-types/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-database/postgres/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-database/sqlite/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-lib/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-macros/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-plugin/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-database-types"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "serde",
  "strum 0.24.1",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-postgres"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-sqlite"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",

--- a/fuel-indexer-database/Cargo.toml
+++ b/fuel-indexer-database/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fuel-indexer-database-types = { path = "./database-types" }
+fuel-indexer-database-types = { version = "0.1.0", path = "./database-types" }
 fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { path = "./postgres" }
-fuel-indexer-sqlite = { path = "./sqlite" }
+fuel-indexer-postgres = { version = "0.1.0", path = "./postgres" }
+fuel-indexer-sqlite = { version = "0.1.0", path = "./sqlite" }
 sqlx = { version = "0.6" }
 thiserror = { version = "1.0" }
 tracing = "0.1"

--- a/fuel-indexer-database/database-types/Cargo.toml
+++ b/fuel-indexer-database/database-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-database-types"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/fuel-indexer-database/postgres/Cargo.toml
+++ b/fuel-indexer-database/postgres/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fuel-indexer-postgres"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fuel-indexer-database-types = { path = "../database-types" }
+fuel-indexer-database-types = { version = "0.1.0", path = "../database-types" }
 fuel-indexer-lib = { version = "0.1", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "offline"] }
 tracing = "0.1"

--- a/fuel-indexer-database/sqlite/Cargo.toml
+++ b/fuel-indexer-database/sqlite/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fuel-indexer-sqlite"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fuel-indexer-database-types = { path = "../database-types" }
+fuel-indexer-database-types = { version = "0.1.0", path = "../database-types" }
 fuel-indexer-lib = { version = "0.1", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "sqlite", "offline", "json"] }
 tracing = "0.1"

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 bincode = "1.3.3"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 fuel-indexer-database = { version = "0.1", path = "../fuel-indexer-database", optional = true }
-fuel-indexer-database-types = { path = "../fuel-indexer-database/database-types" }
+fuel-indexer-database-types = { version = "0.1.0", path = "../fuel-indexer-database/database-types" }
 fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { path = "../fuel-indexer-database/postgres", optional = true }
-fuel-indexer-sqlite = { path = "../fuel-indexer-database/sqlite", optional = true }
+fuel-indexer-postgres = { version = "0.1.0", path = "../fuel-indexer-database/postgres", optional = true }
+fuel-indexer-sqlite = { version = "0.1.0", path = "../fuel-indexer-database/sqlite", optional = true }
 fuel-tx = { version = "0.18", features = ["serde", "alloc"] }
 fuel-types = { version = "0.5", features = ["serde", "alloc"] }
 fuels-core = "0.26"

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -16,11 +16,11 @@ cfg-if = "1.0"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 fuel-gql-client = { version = "0.10" }
 fuel-indexer-database = { version = "0.1", path = "../fuel-indexer-database" }
-fuel-indexer-database-types = { path = "../fuel-indexer-database/database-types" }
+fuel-indexer-database-types = { version = "0.1.0", path = "../fuel-indexer-database/database-types" }
 fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { path = "../fuel-indexer-database/postgres" }
+fuel-indexer-postgres = { version = "0.1.0", path = "../fuel-indexer-database/postgres" }
 fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", features = ["db-models"] }
-fuel-indexer-sqlite = { path = "../fuel-indexer-database/sqlite" }
+fuel-indexer-sqlite = { version = "0.1.0", path = "../fuel-indexer-database/sqlite" }
 fuel-tx = "0.18"
 fuel-types = "0.5"
 futures = "0.3"


### PR DESCRIPTION
- Told you this would take 2 or 3 more tries 🥲 
- Per https://github.com/rust-lang/cargo/issues/6738 - publishing _all_ crates now
- Crate reservation for `fuel-indexer-database-types` is at https://github.com/FuelLabs/crate-reservations/pull/12