### PR TITLE
Add fuel-indexer-test version + make versions more specific

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,11 +539,13 @@ jobs:
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-plugin/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-schema/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer/Cargo.toml
+
       - name: Publish crate
         uses: katyo/publish-crates@v1
         with:
           publish-delay: 30000
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          
       - name: Notify Slack On Failure
         uses: ravsamhq/notify-slack-action@v1
         if: always()

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -93,9 +93,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1", default-features = false }
+fuel-indexer-macros = { version = "0.1.0", default-features = false }
 fuel-indexer-plugin = "0.1"
-fuel-indexer-schema = { version = "0.1", default-features = false }
+fuel-indexer-schema = { version = "0.1.0", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/examples/block-explorer/explorer-index/Cargo.toml
+++ b/examples/block-explorer/explorer-index/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1", path = "../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1", path = "../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1", path = "../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1.0", path = "../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1.0", path = "../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1.0", path = "../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/examples/simple-wasm/simple-wasm/Cargo.toml
+++ b/examples/simple-wasm/simple-wasm/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1", path = "../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1", path = "../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1", path = "../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1.0", path = "../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1.0", path = "../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1.0", path = "../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/fuel-indexer-api-server/Cargo.toml
+++ b/fuel-indexer-api-server/Cargo.toml
@@ -19,9 +19,9 @@ path = "src/main.rs"
 anyhow = "1.0"
 async-std = "1"
 axum = "0.4"
-fuel-indexer = { version = "0.1", path = "../fuel-indexer" }
-fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
-fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer = { version = "0.1.0", path = "../fuel-indexer" }
+fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
+fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", features = ["db-models"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 serde_yaml = "0.8"

--- a/fuel-indexer-database/Cargo.toml
+++ b/fuel-indexer-database/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 fuel-indexer-database-types = { version = "0.1.0", path = "./database-types" }
-fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
 fuel-indexer-postgres = { version = "0.1.0", path = "./postgres" }
 fuel-indexer-sqlite = { version = "0.1.0", path = "./sqlite" }
 sqlx = { version = "0.6" }

--- a/fuel-indexer-database/postgres/Cargo.toml
+++ b/fuel-indexer-database/postgres/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 fuel-indexer-database-types = { version = "0.1.0", path = "../database-types" }
-fuel-indexer-lib = { version = "0.1", path = "../../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1.0", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "offline"] }
 tracing = "0.1"

--- a/fuel-indexer-database/sqlite/Cargo.toml
+++ b/fuel-indexer-database/sqlite/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 fuel-indexer-database-types = { version = "0.1.0", path = "../database-types" }
-fuel-indexer-lib = { version = "0.1", path = "../../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1.0", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "sqlite", "offline", "json"] }
 tracing = "0.1"

--- a/fuel-indexer-macros/Cargo.toml
+++ b/fuel-indexer-macros/Cargo.toml
@@ -13,8 +13,8 @@ development = ["fuels", "fuel-indexer-plugin"]
 proc-macro = true
 
 [dependencies]
-fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = { version = "0.26" }
 fuels-types = { version = "0.26" }
@@ -29,7 +29,7 @@ sha2 = "0.9.5"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-fuel-indexer-plugin = { version = "0.1", path = "../fuel-indexer-plugin" }
+fuel-indexer-plugin = { version = "0.1.0", path = "../fuel-indexer-plugin" }
 fuels = { version = "0.26" }
 trybuild = "1.0"
 

--- a/fuel-indexer-plugin/Cargo.toml
+++ b/fuel-indexer-plugin/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 crate-type = ['rlib']
 
 [dependencies]
-fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", default-features = false }

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 [dependencies]
 bincode = "1.3.3"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
-fuel-indexer-database = { version = "0.1", path = "../fuel-indexer-database", optional = true }
+fuel-indexer-database = { version = "0.1.0", path = "../fuel-indexer-database", optional = true }
 fuel-indexer-database-types = { version = "0.1.0", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
 fuel-indexer-postgres = { version = "0.1.0", path = "../fuel-indexer-database/postgres", optional = true }
 fuel-indexer-sqlite = { version = "0.1.0", path = "../fuel-indexer-database/sqlite", optional = true }
 fuel-tx = { version = "0.18", features = ["serde", "alloc"] }

--- a/fuel-indexer-tests/Cargo.toml
+++ b/fuel-indexer-tests/Cargo.toml
@@ -25,9 +25,9 @@ harness = true
 [dependencies]
 async-std = "1"
 chrono = { version = "0.4", features = ["serde"] }
-fuel-indexer = { version = "0.1", path = "./../fuel-indexer" }
-fuel-indexer-database = { version = "0.1", path = "./../fuel-indexer-database" }
-fuel-indexer-schema = { version = "0.1", path = "./../fuel-indexer-schema" }
+fuel-indexer = { version = "0.1.0", path = "./../fuel-indexer" }
+fuel-indexer-database = { version = "0.1.0", path = "./../fuel-indexer-database" }
+fuel-indexer-schema = { version = "0.1.0", path = "./../fuel-indexer-schema" }
 fuel-tx = "0.18"
 fuel-types = "0.5"
 fuels = { version = "0.26", features = ["fuel-core-lib"] }

--- a/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
+++ b/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1", path = "../../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1", path = "../../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1", path = "../../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1.0", path = "../../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1.0", path = "../../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1.0", path = "../../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/fuel-indexer-tests/components/web/Cargo.toml
+++ b/fuel-indexer-tests/components/web/Cargo.toml
@@ -18,8 +18,8 @@ actix-web = { version = "4", default-features = false }
 anyhow = { version = "1.0", default-features = false }
 async-std = "1"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
-fuel-indexer-lib = { version = "0.1", path = "../../../fuel-indexer-lib" }
-fuel-indexer-tests = { path = "./../../../fuel-indexer-tests" }
+fuel-indexer-lib = { version = "0.1.0", path = "../../../fuel-indexer-lib" }
+fuel-indexer-tests = { version = "0.0.0", path = "./../../../fuel-indexer-tests" }
 fuel-tx = "0.18"
 fuel-types = "0.5"
 fuels = { version = "0.26", features = ["fuel-core-lib"] }

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -15,11 +15,11 @@ bincode = "1.3.3"
 cfg-if = "1.0"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 fuel-gql-client = { version = "0.10" }
-fuel-indexer-database = { version = "0.1", path = "../fuel-indexer-database" }
+fuel-indexer-database = { version = "0.1.0", path = "../fuel-indexer-database" }
 fuel-indexer-database-types = { version = "0.1.0", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
 fuel-indexer-postgres = { version = "0.1.0", path = "../fuel-indexer-database/postgres" }
-fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", features = ["db-models"] }
 fuel-indexer-sqlite = { version = "0.1.0", path = "../fuel-indexer-database/sqlite" }
 fuel-tx = "0.18"
 fuel-types = "0.5"


### PR DESCRIPTION
- Gonna give this one last try
- If this doesn't work might have to hold off on a release until the `fuel-indexer-test-web` component is removed in https://github.com/FuelLabs/fuel-indexer/issues/269