### PR TITLE
Specify which crates are publishable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
           RUSTFLAGS: -D warnings
 
-  # NOTE: This can possibly figure out how to put this in cargo-verifications later
+  # TODO: https://github.com/FuelLabs/fuel-indexer/issues/269
   cargo-test-workspace-all-features:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
@@ -254,6 +254,7 @@ jobs:
     runs-on: ${{ matrix.job.os }}
     needs:
       - cancel-previous-runs
+      - cargo-verifications
       - cargo-test-workspace-all-features
     if: github.event_name == 'release' && github.event.action == 'published'
      # Only do this job if publishing a release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,8 +538,8 @@ jobs:
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-macros/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-plugin/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-schema/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-types/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer/Cargo.toml
 
       - name: Publish crate
         uses: katyo/publish-crates@v1

--- a/examples/simple-wasm/simple/Cargo.toml
+++ b/examples/simple-wasm/simple/Cargo.toml
@@ -2,6 +2,7 @@
 name = "simple"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fuel-indexer-api-server/Cargo.toml
+++ b/fuel-indexer-api-server/Cargo.toml
@@ -3,7 +3,6 @@ name = "fuel-indexer-api-server"
 version = "0.1.0"
 edition = "2021"
 license = "BUSL-1.1"
-publish = false
 
 [dependencies]
 anyhow = "1.0"

--- a/fuel-indexer-macros/Cargo.toml
+++ b/fuel-indexer-macros/Cargo.toml
@@ -3,8 +3,6 @@ name = "fuel-indexer-macros"
 version = "0.1.0"
 edition = "2021"
 license = "BUSL-1.1"
-publish = false
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package.metadata.cargo-udeps.ignore]
 development = ["fuels", "fuel-indexer-plugin"]

--- a/fuel-indexer-macros/src/indexer.rs
+++ b/fuel-indexer-macros/src/indexer.rs
@@ -571,7 +571,7 @@ pub fn prefix_abi_and_schema_paths(
     if let Some(abi) = abi {
         match std::env::var("COMPILE_TEST_PREFIX") {
             Ok(prefix) => {
-                let prefixed = std::path::Path::new(&prefix).join(&abi);
+                let prefixed = std::path::Path::new(&prefix).join(abi);
                 let abi_string = prefixed
                     .into_os_string()
                     .to_str()

--- a/fuel-indexer-plugin/Cargo.toml
+++ b/fuel-indexer-plugin/Cargo.toml
@@ -3,8 +3,6 @@ name = "fuel-indexer-plugin"
 version = "0.1.0"
 edition = "2021"
 license = "BUSL-1.1"
-publish = false
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 crate-type = ['rlib']

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -3,8 +3,6 @@ name = "fuel-indexer-schema"
 version = "0.1.0"
 edition = "2021"
 license = "BUSL-1.1"
-publish = false
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 bincode = "1.3.3"

--- a/fuel-indexer-tests/components/web/Cargo.toml
+++ b/fuel-indexer-tests/components/web/Cargo.toml
@@ -2,8 +2,7 @@
 name = "fuel-indexer-test-web"
 version = "0.0.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [[bin]]
 name = "web-api"

--- a/fuel-indexer-tests/components/web/src/bin/fuel-node.rs
+++ b/fuel-indexer-tests/components/web/src/bin/fuel-node.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wallet_path_str = wallet_path.as_os_str().to_str().unwrap();
 
     let mut wallet =
-        WalletUnlocked::load_keystore(&wallet_path_str, defaults::WALLET_PASSWORD, None)
+        WalletUnlocked::load_keystore(wallet_path_str, defaults::WALLET_PASSWORD, None)
             .unwrap();
 
     info!(

--- a/fuel-indexer-tests/components/web/src/bin/web-api.rs
+++ b/fuel-indexer-tests/components/web/src/bin/web-api.rs
@@ -180,7 +180,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wallet_path_str = wallet_path.as_os_str().to_str().unwrap();
 
     let mut wallet =
-        WalletUnlocked::load_keystore(&wallet_path_str, defaults::WALLET_PASSWORD, None)
+        WalletUnlocked::load_keystore(wallet_path_str, defaults::WALLET_PASSWORD, None)
             .unwrap();
 
     let provider = Provider::connect(defaults::FUEL_NODE_ADDR).await.unwrap();

--- a/fuel-indexer-tests/tests/service.rs
+++ b/fuel-indexer-tests/tests/service.rs
@@ -31,7 +31,7 @@ async fn test_can_trigger_event_from_contract_and_index_emited_event_in_postgres
     let wallet_path_str = wallet_path.as_os_str().to_str().unwrap();
 
     let mut wallet =
-        WalletUnlocked::load_keystore(&wallet_path_str, defaults::WALLET_PASSWORD, None)
+        WalletUnlocked::load_keystore(wallet_path_str, defaults::WALLET_PASSWORD, None)
             .unwrap();
 
     let bin_path = workdir.join("contracts/simple-wasm/out/debug/contracts.bin");

--- a/fuel-indexer-types/Cargo.toml
+++ b/fuel-indexer-types/Cargo.toml
@@ -3,8 +3,6 @@ name = "fuel-indexer-types"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -3,8 +3,6 @@ name = "fuel-indexer"
 version = "0.1.0"
 edition = "2021"
 license = "BUSL-1.1"
-publish = false
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }


### PR DESCRIPTION
Per Brandon's comment [here](https://fuellabs.slack.com/archives/C01KKBXHATF/p1667439282979879?thread_ts=1667405784.026159&cid=C01KKBXHATF), specifying which crates are publishable and which aren't