### PR TITLE
v0.1.0-isolate-crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+    
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,9 @@ jobs:
           - command: build
             args: --locked --workspace --all-features --all-targets
           - command: test
-            args: --locked --workspace --all-features
+            args: --locked --workspace
           - command: test
-            args: --locked --all-targets --no-default-features --workspace --all-features
+            args: --locked --all-targets --no-default-features --workspace
 
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   DATABASE_URL: postgres://postgres:my-secret@localhost:5432
+  DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,21 @@ jobs:
         with:
           command: build
           args: -p fuel-indexer-test --release --target wasm32-unknown-unknown
-        env:
-          RUSTFLAGS: '-D warnings'
+
+  get-workspace-members:
+    runs-on: ubuntu-latest
+    outputs:
+      members: ${{ steps.set-members.outputs.members }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - id: set-members
+        run: |
+          # install dasel
+          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+          members=$(cat Cargo.toml | dasel -r toml -w json 'workspace.members' | jq -r ".[]" | xargs -I '{}' dasel -f {}/Cargo.toml 'package.name' | jq -R '[.]' | jq -s -c 'add')
+          echo "members=$members" >> $GITHUB_OUTPUT
 
   cargo-verifications:
     runs-on: ubuntu-latest
@@ -147,33 +160,24 @@ jobs:
       - cancel-previous-runs
       - cargo-toml-fmt-check
       - cargo-build-wasm-example
+      - get-workspace-members
     strategy:
       matrix:
+        package: ${{fromJSON(needs.get-workspace-members.outputs.members)}}
         include:
           - command: fmt
             args: --all --verbose -- --check
-            env:
-              RUSTFLAGS: '-D warnings'
           - command: clippy
             args: --all-features --all-targets
-            env:
-              RUSTFLAGS: '-D warnings'
           - command: check
-            args: --locked --workspace --all-features --all-targets
-            env:
-              RUSTFLAGS: '-D warnings'
+            args: --all-features --locked --workspace --all-targets
           - command: build
             args: --locked --workspace --all-features --all-targets
-            env:
-              RUSTFLAGS: '-D warnings'
           - command: test
-            args: --locked --workspace
-            env:
-              RUSTFLAGS: '-D warnings'
+            args: --locked --workspace --all-features
           - command: test
-            args: --locked --all-targets --no-default-features --workspace
-            env:
-              RUSTFLAGS: '-D warnings'
+            args: --locked --all-targets --no-default-features --workspace --all-features
+
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
     continue-on-error: ${{ matrix.skip-error || false }}
@@ -316,7 +320,7 @@ jobs:
       - name: Build fuel-indexer
         run: |
           cross build --profile=release --target ${{ matrix.job.target }} -p fuel-indexer -p fuel-indexer-api-server
-  
+
       - name: Strip release binary linux x86_64
         if: matrix.job.platform == 'linux'
         run: strip "target/${{ matrix.job.target }}/release/fuel-indexer"
@@ -495,7 +499,7 @@ jobs:
 
   notify-slack-on-failure:
     if: ${{ always() }} && github.ref == 'refs/heads/master'
-    needs: 
+    needs:
       - validation-complete
     runs-on: ubuntu-latest
     steps:
@@ -513,7 +517,7 @@ jobs:
 
   publish:
     # Only do this job if publishing a release and validations pass.
-    needs: 
+    needs:
       - validation-complete
       - publish-fuel-indexer-binaries
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -521,7 +525,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-    
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -548,7 +552,7 @@ jobs:
         with:
           publish-delay: 30000
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          
+
       - name: Notify Slack On Failure
         uses: ravsamhq/notify-slack-action@v1
         if: always()

--- a/fuel-indexer-database/database-types/Cargo.toml
+++ b/fuel-indexer-database/database-types/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 strum = { version = "0.24", default-features = false, features = ["derive"] }

--- a/fuel-indexer-lib/Cargo.toml
+++ b/fuel-indexer-lib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0", default-features = false }
+anyhow = "1.0"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/fuel-indexer-types/Cargo.toml
+++ b/fuel-indexer-types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
-fuel-tx = "0.18"
+fuel-tx = { version = "0.18", features = ["serde"] }
 fuel-types = "0.5"
 fuels-core = "0.26"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }


### PR DESCRIPTION
### Description
- Yet another v0.1.0 release error
- Turns out this was related to an issue where although the crates build OK and pass CI -- when built in isolation they would fail (thus the release error)
- This PR used [`cargo-make`](https://github.com/sagiegurari/cargo-make) to individually build each crate
  - As you can see, a few manifest files had to be updated
- Also introduces the `get-workspace-members` step (same as fuel-rs) in order to build each crate individually on CI going forward

### Testing steps
- [ ] CI should pass