### PR TITLE
v0.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
+  SQLX_OFFLINE: true
 
 jobs:
   cancel-previous-runs:
@@ -251,7 +252,7 @@ jobs:
 
       - name: Cargo Test Workspace
         uses: actions-rs/cargo@v1
-      - run: RUSTFLAGS='-D warnings' SQLX_OFFLINE=1 cargo test --locked --workspace --all-features --all-targets
+      - run: cargo test --locked --workspace --all-features --all-targets
       - run: bash scripts/utils/kill_test_components.bash
 
   publish-fuel-indexer-binaries:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-api-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-database"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-database-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "strum 0.24.1",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-lib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-plugin",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-plugin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-schema",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-postgres"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-schema"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-sqlite"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "fuel-indexer-lib",

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -93,9 +93,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.1", default-features = false }
+fuel-indexer-macros = { version = "0.1", default-features = false }
 fuel-indexer-plugin = "0.1"
-fuel-indexer-schema = { version = "0.1.1", default-features = false }
+fuel-indexer-schema = { version = "0.1", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -93,9 +93,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.0", default-features = false }
+fuel-indexer-macros = { version = "0.1.1", default-features = false }
 fuel-indexer-plugin = "0.1"
-fuel-indexer-schema = { version = "0.1.0", default-features = false }
+fuel-indexer-schema = { version = "0.1.1", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/examples/block-explorer/explorer-index/Cargo.toml
+++ b/examples/block-explorer/explorer-index/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.0", path = "../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1.0", path = "../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1.0", path = "../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1.1", path = "../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1.1", path = "../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1.1", path = "../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/examples/block-explorer/explorer-index/Cargo.toml
+++ b/examples/block-explorer/explorer-index/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.1", path = "../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1.1", path = "../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1.1", path = "../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1", path = "../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1", path = "../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1", path = "../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/examples/simple-wasm/simple-wasm/Cargo.toml
+++ b/examples/simple-wasm/simple-wasm/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.0", path = "../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1.0", path = "../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1.0", path = "../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1.1", path = "../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1.1", path = "../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1.1", path = "../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/examples/simple-wasm/simple-wasm/Cargo.toml
+++ b/examples/simple-wasm/simple-wasm/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.1", path = "../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1.1", path = "../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1.1", path = "../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1", path = "../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1", path = "../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1", path = "../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/fuel-indexer-api-server/Cargo.toml
+++ b/fuel-indexer-api-server/Cargo.toml
@@ -10,10 +10,10 @@ description = "Fuel Indexer API Server"
 anyhow = "1.0"
 async-std = "1"
 axum = { version = "0.4", features = ["multipart"] }
-fuel-indexer-database = { version = "0.1.1", path = "../fuel-indexer-database" }
-fuel-indexer-database-types = { version = "0.1.1", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
-fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer-database = { version = "0.1", path = "../fuel-indexer-database" }
+fuel-indexer-database-types = { version = "0.1", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
+fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", features = ["db-models"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http2", "http1", "runtime" ]}
 hyper-tls = "0.5"

--- a/fuel-indexer-api-server/Cargo.toml
+++ b/fuel-indexer-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-api-server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -10,10 +10,10 @@ description = "Fuel Indexer API Server"
 anyhow = "1.0"
 async-std = "1"
 axum = { version = "0.4", features = ["multipart"] }
-fuel-indexer-database = { version = "0.1.0", path = "../fuel-indexer-database" }
-fuel-indexer-database-types = { version = "0.1.0", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
-fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer-database = { version = "0.1.1", path = "../fuel-indexer-database" }
+fuel-indexer-database-types = { version = "0.1.1", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
+fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", features = ["db-models"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http2", "http1", "runtime" ]}
 hyper-tls = "0.5"

--- a/fuel-indexer-database/Cargo.toml
+++ b/fuel-indexer-database/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "fuel-indexer-database"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Database"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.1.0", path = "./database-types" }
-fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.1.0", path = "./postgres" }
-fuel-indexer-sqlite = { version = "0.1.0", path = "./sqlite" }
+fuel-indexer-database-types = { version = "0.1.1", path = "./database-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.1.1", path = "./postgres" }
+fuel-indexer-sqlite = { version = "0.1.1", path = "./sqlite" }
 sqlx = { version = "0.6" }
 thiserror = { version = "1.0" }
 tracing = "0.1"

--- a/fuel-indexer-database/Cargo.toml
+++ b/fuel-indexer-database/Cargo.toml
@@ -7,10 +7,10 @@ repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Database"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.1.1", path = "./database-types" }
-fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.1.1", path = "./postgres" }
-fuel-indexer-sqlite = { version = "0.1.1", path = "./sqlite" }
+fuel-indexer-database-types = { version = "0.1", path = "./database-types" }
+fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.1", path = "./postgres" }
+fuel-indexer-sqlite = { version = "0.1", path = "./sqlite" }
 sqlx = { version = "0.6" }
 thiserror = { version = "1.0" }
 tracing = "0.1"

--- a/fuel-indexer-database/database-types/Cargo.toml
+++ b/fuel-indexer-database/database-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-database-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/postgres/Cargo.toml
+++ b/fuel-indexer-database/postgres/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fuel-indexer-postgres"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Postgres"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.1.0", path = "../database-types" }
-fuel-indexer-lib = { version = "0.1.0", path = "../../fuel-indexer-lib" }
+fuel-indexer-database-types = { version = "0.1.1", path = "../database-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "offline"] }
 tracing = "0.1"

--- a/fuel-indexer-database/postgres/Cargo.toml
+++ b/fuel-indexer-database/postgres/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Postgres"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.1.1", path = "../database-types" }
-fuel-indexer-lib = { version = "0.1.1", path = "../../fuel-indexer-lib" }
+fuel-indexer-database-types = { version = "0.1", path = "../database-types" }
+fuel-indexer-lib = { version = "0.1", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "offline"] }
 tracing = "0.1"

--- a/fuel-indexer-database/sqlite/Cargo.toml
+++ b/fuel-indexer-database/sqlite/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fuel-indexer-sqlite"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Sqlite"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.1.0", path = "../database-types" }
-fuel-indexer-lib = { version = "0.1.0", path = "../../fuel-indexer-lib" }
+fuel-indexer-database-types = { version = "0.1.1", path = "../database-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "sqlite", "offline", "json"] }
 tracing = "0.1"

--- a/fuel-indexer-database/sqlite/Cargo.toml
+++ b/fuel-indexer-database/sqlite/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Sqlite"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.1.1", path = "../database-types" }
-fuel-indexer-lib = { version = "0.1.1", path = "../../fuel-indexer-lib" }
+fuel-indexer-database-types = { version = "0.1", path = "../database-types" }
+fuel-indexer-lib = { version = "0.1", path = "../../fuel-indexer-lib" }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "sqlite", "offline", "json"] }
 tracing = "0.1"

--- a/fuel-indexer-lib/Cargo.toml
+++ b/fuel-indexer-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-lib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-macros/Cargo.toml
+++ b/fuel-indexer-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -13,9 +13,9 @@ development = ["fuels", "fuel-indexer-plugin"]
 proc-macro = true
 
 [dependencies]
-fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", default-features = false }
-fuel-indexer-types = { version = "0.1.0", path = "../fuel-indexer-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }
 fuel-tx = "0.18"
 fuels-core = { version = "0.26" }
 fuels-types = { version = "0.26" }
@@ -30,7 +30,7 @@ sha2 = "0.9.5"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-fuel-indexer-plugin = { version = "0.1.0", path = "../fuel-indexer-plugin" }
+fuel-indexer-plugin = { version = "0.1.1", path = "../fuel-indexer-plugin" }
 fuels = { version = "0.26" }
 trybuild = "1.0"
 

--- a/fuel-indexer-macros/Cargo.toml
+++ b/fuel-indexer-macros/Cargo.toml
@@ -13,9 +13,9 @@ development = ["fuels", "fuel-indexer-plugin"]
 proc-macro = true
 
 [dependencies]
-fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", default-features = false }
-fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }
+fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-types = { version = "0.1", path = "../fuel-indexer-types" }
 fuel-tx = "0.18"
 fuels-core = { version = "0.26" }
 fuels-types = { version = "0.26" }
@@ -30,7 +30,7 @@ sha2 = "0.9.5"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-fuel-indexer-plugin = { version = "0.1.1", path = "../fuel-indexer-plugin" }
+fuel-indexer-plugin = { version = "0.1", path = "../fuel-indexer-plugin" }
 fuels = { version = "0.26" }
 trybuild = "1.0"
 

--- a/fuel-indexer-plugin/Cargo.toml
+++ b/fuel-indexer-plugin/Cargo.toml
@@ -10,6 +10,6 @@ description = "Fuel Indexer Plugin"
 crate-type = ['rlib']
 
 [dependencies]
-fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", default-features = false }
-fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }
+fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-types = { version = "0.1", path = "../fuel-indexer-types" }

--- a/fuel-indexer-plugin/Cargo.toml
+++ b/fuel-indexer-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-plugin"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -10,6 +10,6 @@ description = "Fuel Indexer Plugin"
 crate-type = ['rlib']
 
 [dependencies]
-fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", default-features = false }
-fuel-indexer-types = { version = "0.1.0", path = "../fuel-indexer-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -9,12 +9,12 @@ description = "Fuel Indexer Schema"
 [dependencies]
 bincode = "1.3.3"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
-fuel-indexer-database = { version = "0.1.1", path = "../fuel-indexer-database", optional = true }
-fuel-indexer-database-types = { version = "0.1.1", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.1.1", path = "../fuel-indexer-database/postgres", optional = true }
-fuel-indexer-sqlite = { version = "0.1.1", path = "../fuel-indexer-database/sqlite", optional = true }
-fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }
+fuel-indexer-database = { version = "0.1", path = "../fuel-indexer-database", optional = true }
+fuel-indexer-database-types = { version = "0.1", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.1", path = "../fuel-indexer-database/postgres", optional = true }
+fuel-indexer-sqlite = { version = "0.1", path = "../fuel-indexer-database/sqlite", optional = true }
+fuel-indexer-types = { version = "0.1", path = "../fuel-indexer-types" }
 fuel-tx = { version = "0.18", features = ["serde", "alloc"] }
 fuel-types = { version = "0.5", features = ["serde", "alloc"] }
 fuels-core = "0.26"

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-schema"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -9,12 +9,12 @@ description = "Fuel Indexer Schema"
 [dependencies]
 bincode = "1.3.3"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
-fuel-indexer-database = { version = "0.1.0", path = "../fuel-indexer-database", optional = true }
-fuel-indexer-database-types = { version = "0.1.0", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.1.0", path = "../fuel-indexer-database/postgres", optional = true }
-fuel-indexer-sqlite = { version = "0.1.0", path = "../fuel-indexer-database/sqlite", optional = true }
-fuel-indexer-types = { version = "0.1.0", path = "../fuel-indexer-types" }
+fuel-indexer-database = { version = "0.1.1", path = "../fuel-indexer-database", optional = true }
+fuel-indexer-database-types = { version = "0.1.1", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.1.1", path = "../fuel-indexer-database/postgres", optional = true }
+fuel-indexer-sqlite = { version = "0.1.1", path = "../fuel-indexer-database/sqlite", optional = true }
+fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }
 fuel-tx = { version = "0.18", features = ["serde", "alloc"] }
 fuel-types = { version = "0.5", features = ["serde", "alloc"] }
 fuels-core = "0.26"

--- a/fuel-indexer-tests/Cargo.toml
+++ b/fuel-indexer-tests/Cargo.toml
@@ -25,11 +25,11 @@ harness = true
 [dependencies]
 async-std = "1"
 chrono = { version = "0.4", features = ["serde"] }
-fuel-indexer = { version = "0.1.0", path = "./../fuel-indexer" }
-fuel-indexer-database = { version = "0.1.0", path = "./../fuel-indexer-database" }
-fuel-indexer-lib = { version = "0.1.0", path = "./../fuel-indexer-lib" }
-fuel-indexer-schema = { version = "0.1.0", path = "./../fuel-indexer-schema" }
-fuel-indexer-types = { version = "0.1.0", path = "./../fuel-indexer-types" }
+fuel-indexer = { version = "0.1.1", path = "./../fuel-indexer" }
+fuel-indexer-database = { version = "0.1.1", path = "./../fuel-indexer-database" }
+fuel-indexer-lib = { version = "0.1.1", path = "./../fuel-indexer-lib" }
+fuel-indexer-schema = { version = "0.1.1", path = "./../fuel-indexer-schema" }
+fuel-indexer-types = { version = "0.1.1", path = "./../fuel-indexer-types" }
 fuel-tx = "0.18"
 fuel-types = "0.5"
 fuels = { version = "0.26", features = ["fuel-core-lib"] }

--- a/fuel-indexer-tests/Cargo.toml
+++ b/fuel-indexer-tests/Cargo.toml
@@ -25,11 +25,11 @@ harness = true
 [dependencies]
 async-std = "1"
 chrono = { version = "0.4", features = ["serde"] }
-fuel-indexer = { version = "0.1.1", path = "./../fuel-indexer" }
-fuel-indexer-database = { version = "0.1.1", path = "./../fuel-indexer-database" }
-fuel-indexer-lib = { version = "0.1.1", path = "./../fuel-indexer-lib" }
-fuel-indexer-schema = { version = "0.1.1", path = "./../fuel-indexer-schema" }
-fuel-indexer-types = { version = "0.1.1", path = "./../fuel-indexer-types" }
+fuel-indexer = { version = "0.1", path = "./../fuel-indexer" }
+fuel-indexer-database = { version = "0.1", path = "./../fuel-indexer-database" }
+fuel-indexer-lib = { version = "0.1", path = "./../fuel-indexer-lib" }
+fuel-indexer-schema = { version = "0.1", path = "./../fuel-indexer-schema" }
+fuel-indexer-types = { version = "0.1", path = "./../fuel-indexer-types" }
 fuel-tx = "0.18"
 fuel-types = "0.5"
 fuels = { version = "0.26", features = ["fuel-core-lib"] }

--- a/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
+++ b/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.0", path = "../../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1.0", path = "../../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1.0", path = "../../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1.1", path = "../../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1.1", path = "../../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1.1", path = "../../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
+++ b/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.1.1", path = "../../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.1.1", path = "../../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.1.1", path = "../../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.1", path = "../../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.1", path = "../../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.1", path = "../../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.18"
 fuels-core = "0.26"
 fuels-types = "0.26"

--- a/fuel-indexer-tests/components/web/Cargo.toml
+++ b/fuel-indexer-tests/components/web/Cargo.toml
@@ -17,7 +17,7 @@ actix-web = { version = "4", default-features = false }
 anyhow = { version = "1.0", default-features = false }
 async-std = "1"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
-fuel-indexer-lib = { version = "0.1.0", path = "../../../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1.1", path = "../../../fuel-indexer-lib" }
 fuel-indexer-tests = { version = "0.0.0", path = "./../../../fuel-indexer-tests" }
 fuel-tx = "0.18"
 fuel-types = "0.5"

--- a/fuel-indexer-tests/components/web/Cargo.toml
+++ b/fuel-indexer-tests/components/web/Cargo.toml
@@ -17,7 +17,7 @@ actix-web = { version = "4", default-features = false }
 anyhow = { version = "1.0", default-features = false }
 async-std = "1"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
-fuel-indexer-lib = { version = "0.1.1", path = "../../../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1", path = "../../../fuel-indexer-lib" }
 fuel-indexer-tests = { version = "0.0.0", path = "./../../../fuel-indexer-tests" }
 fuel-tx = "0.18"
 fuel-types = "0.5"

--- a/fuel-indexer-types/Cargo.toml
+++ b/fuel-indexer-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -8,7 +8,7 @@ description = "Fuel Indexer Types"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
 fuel-tx = { version = "0.18", features = ["serde"] }
 fuel-types = "0.5"
 fuels-core = "0.26"

--- a/fuel-indexer-types/Cargo.toml
+++ b/fuel-indexer-types/Cargo.toml
@@ -8,7 +8,7 @@ description = "Fuel Indexer Types"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
 fuel-tx = { version = "0.18", features = ["serde"] }
 fuel-types = "0.5"
 fuels-core = "0.26"

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -15,14 +15,14 @@ bincode = "1.3.3"
 cfg-if = "1.0"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 fuel-gql-client = { version = "0.10" }
-fuel-indexer-api-server = { version = "0.1.0", path = "../fuel-indexer-api-server", optional = true }
-fuel-indexer-database = { version = "0.1.0", path = "../fuel-indexer-database" }
-fuel-indexer-database-types = { version = "0.1.0", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1.0", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.1.0", path = "../fuel-indexer-database/postgres" }
-fuel-indexer-schema = { version = "0.1.0", path = "../fuel-indexer-schema", features = ["db-models"] }
-fuel-indexer-sqlite = { version = "0.1.0", path = "../fuel-indexer-database/sqlite" }
-fuel-indexer-types = { version = "0.1.0", path = "../fuel-indexer-types" }
+fuel-indexer-api-server = { version = "0.1.1", path = "../fuel-indexer-api-server", optional = true }
+fuel-indexer-database = { version = "0.1.1", path = "../fuel-indexer-database" }
+fuel-indexer-database-types = { version = "0.1.1", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.1.1", path = "../fuel-indexer-database/postgres" }
+fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer-sqlite = { version = "0.1.1", path = "../fuel-indexer-database/sqlite" }
+fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }
 fuel-tx = "0.18"
 fuel-types = "0.5"
 futures = "0.3"

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -15,14 +15,14 @@ bincode = "1.3.3"
 cfg-if = "1.0"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 fuel-gql-client = { version = "0.10" }
-fuel-indexer-api-server = { version = "0.1.1", path = "../fuel-indexer-api-server", optional = true }
-fuel-indexer-database = { version = "0.1.1", path = "../fuel-indexer-database" }
-fuel-indexer-database-types = { version = "0.1.1", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.1.1", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.1.1", path = "../fuel-indexer-database/postgres" }
-fuel-indexer-schema = { version = "0.1.1", path = "../fuel-indexer-schema", features = ["db-models"] }
-fuel-indexer-sqlite = { version = "0.1.1", path = "../fuel-indexer-database/sqlite" }
-fuel-indexer-types = { version = "0.1.1", path = "../fuel-indexer-types" }
+fuel-indexer-api-server = { version = "0.1", path = "../fuel-indexer-api-server", optional = true }
+fuel-indexer-database = { version = "0.1", path = "../fuel-indexer-database" }
+fuel-indexer-database-types = { version = "0.1", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.1", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.1", path = "../fuel-indexer-database/postgres" }
+fuel-indexer-schema = { version = "0.1", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer-sqlite = { version = "0.1", path = "../fuel-indexer-database/sqlite" }
+fuel-indexer-types = { version = "0.1", path = "../fuel-indexer-types" }
 fuel-tx = "0.18"
 fuel-types = "0.5"
 futures = "0.3"


### PR DESCRIPTION
- A few crates were published successfully https://crates.io/search?page=2&q=fuel-indexer
- However, looks like `SQLX_OFFLINE` needs to be set even on the `publish` step
- Also updated crates to use short version of dependencies `0.1` versus `0.1.1` to prevent having to always change that logic