### PR TITLE
v0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,12 +549,14 @@ jobs:
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer-types/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer/Cargo.toml
 
-      - name: Publish crate
+      - name: Install WASM target
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           target: wasm32-unknown-unknown
+      
+      - name: Publish crates
         uses: katyo/publish-crates@v1
         with:
           publish-delay: 30000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,15 +550,15 @@ jobs:
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer/Cargo.toml
 
       - name: Publish crate
-      - uses: katyo/publish-crates@v1
-        with:
-          publish-delay: 30000
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           target: wasm32-unknown-unknown
+        uses: katyo/publish-crates@v1
+        with:
+          publish-delay: 30000
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Notify Slack On Failure
         uses: ravsamhq/notify-slack-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,10 +550,15 @@ jobs:
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} fuel-indexer/Cargo.toml
 
       - name: Publish crate
-        uses: katyo/publish-crates@v1
+      - uses: katyo/publish-crates@v1
         with:
           publish-delay: 30000
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
 
       - name: Notify Slack On Failure
         uses: ravsamhq/notify-slack-action@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-api-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-database"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-database-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "strum 0.24.1",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-lib"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-plugin",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-plugin"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-schema",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-postgres"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-schema"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bincode",
  "chrono",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-sqlite"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "fuel-indexer-lib",

--- a/fuel-indexer-api-server/Cargo.toml
+++ b/fuel-indexer-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-api-server"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/Cargo.toml
+++ b/fuel-indexer-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-database"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/database-types/Cargo.toml
+++ b/fuel-indexer-database/database-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-database-types"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/postgres/Cargo.toml
+++ b/fuel-indexer-database/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-postgres"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/sqlite/Cargo.toml
+++ b/fuel-indexer-database/sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-sqlite"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-lib/Cargo.toml
+++ b/fuel-indexer-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-lib"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-macros/Cargo.toml
+++ b/fuel-indexer-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-plugin/Cargo.toml
+++ b/fuel-indexer-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-plugin"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-schema"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-types/Cargo.toml
+++ b/fuel-indexer-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-types"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"


### PR DESCRIPTION
- Yet another unexpected workflow failure https://github.com/FuelLabs/fuel-indexer/actions/runs/3394348501/jobs/5643586839
- Looks like due to the wasm32 target not being installed
  - Can reproduce the error locally if I remove the wasm32 target -- so this should fix for fuel-indexer-plugins
    - fuel-indexer-plugins seems to be the only crate that has this issue
- PR adds a wasm32 target to the publish step