### PR TITLE
v0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-api-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-database"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-database-types"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "strum 0.24.1",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-lib"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-plugin",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-metrics"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "lazy_static",
  "prometheus",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-plugin"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-schema",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-postgres"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-schema"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bincode",
  "chrono",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-sqlite"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-indexer-types"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "chrono",
  "fuel-indexer-lib",

--- a/fuel-indexer-api-server/Cargo.toml
+++ b/fuel-indexer-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-api-server"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/Cargo.toml
+++ b/fuel-indexer-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-database"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/database-types/Cargo.toml
+++ b/fuel-indexer-database/database-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-database-types"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/postgres/Cargo.toml
+++ b/fuel-indexer-database/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-postgres"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-database/sqlite/Cargo.toml
+++ b/fuel-indexer-database/sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-sqlite"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-lib/Cargo.toml
+++ b/fuel-indexer-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-lib"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-macros/Cargo.toml
+++ b/fuel-indexer-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-macros"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-metrics/Cargo.toml
+++ b/fuel-indexer-metrics/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "fuel-indexer-metrics"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
+license = "BUSL-1.1"
+repository = "https://github.com/FuelLabs/fuel-indexer"
+description = "Fuel Indexer Metrics"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fuel-indexer-plugin/Cargo.toml
+++ b/fuel-indexer-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-plugin"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-schema/Cargo.toml
+++ b/fuel-indexer-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-schema"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer-types/Cargo.toml
+++ b/fuel-indexer-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-types"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/fuel-indexer/Cargo.toml
+++ b/fuel-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"


### PR DESCRIPTION
### Description
- `fuel-indexer-metrics` was missing some metadata fields in the manifest so publishing failed 🙄 
- Bumping to v0.1.7 because some crates were published w/ v0.1.6