### PR TITLE
Add forc-index plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,13 +323,14 @@ jobs:
 
       - name: Build fuel-indexer
         run: |
-          cross build --profile=release --target ${{ matrix.job.target }} -p fuel-indexer -p fuel-indexer-api-server
+          cross build --profile=release --target ${{ matrix.job.target }} -p fuel-indexer -p fuel-indexer-api-server -p forc-index
 
       - name: Strip release binary linux x86_64
         if: matrix.job.platform == 'linux'
         run: |
           strip "target/${{ matrix.job.target }}/release/fuel-indexer"
           strip "target/${{ matrix.job.target }}/release/fuel-indexer-api-server"
+          strip "target/${{ matrix.job.target }}/release/forc-index"
 
       - name: Strip release binary aarch64-linux-gnu
         if: matrix.job.target == 'aarch64-unknown-linux-gnu'
@@ -346,11 +347,18 @@ jobs:
           aarch64-linux-gnu-strip \
           /target/aarch64-unknown-linux-gnu/release/fuel-indexer-api-server
 
+          docker run --rm -v \
+          "$PWD/target:/target:Z" \
+          aarch64-linux-gnu:latest \
+          aarch64-linux-gnu-strip \
+          /target/aarch64-unknown-linux-gnu/release/forc-index
+
       - name: Strip release binary mac
         if: matrix.job.os == 'macos-latest'
         run: |
           strip -x "target/${{ matrix.job.target }}/release/fuel-indexer"
           strip -x "target/${{ matrix.job.target }}/release/fuel-indexer-api-server"
+          strip -x "target/${{ matrix.job.target }}/release/forc-index"
 
       - name: Prepare Binary Artifact
         env:
@@ -367,18 +375,24 @@ jobs:
           # setup artifact filename
           INDEXER_ARTIFACT="fuel-indexer-$FUEL_INDEXER_VERSION-${{ env.TARGET }}"
           API_SERVER_ARTIFACT="fuel-indexer-api-server-$FUEL_INDEXER_VERSION-${{ env.TARGET }}"
+          FORC_INDEX_ARTIFACT="forc-index-$FUEL_INDEXER_VERSION-${{ env.TARGET }}"
           INDEXER_ZIP_FILE_NAME="$INDEXER_ARTIFACT.tar.gz"
           API_SERVER_ZIP_FILE_NAME="$API_SERVER_ARTIFACT.tar.gz"
+          FORC_INDEX_ZIP_FILE_NAME="$FORC_INDEX_ARTIFACT.tar.gz"
           echo "INDEXER_ZIP_FILE_NAME=$INDEXER_ZIP_FILE_NAME" >> $GITHUB_ENV
           echo "API_SERVER_ZIP_FILE_NAME=$API_SERVER_ZIP_FILE_NAME" >> $GITHUB_ENV
+          echo "FORC_INDEX_ZIP_FILE_NAME=$FORC_INDEX_ZIP_FILE_NAME" >> $GITHUB_ENV
 
           # create zip file
           mkdir -pv "$INDEXER_ARTIFACT"
           mkdir -pv "$API_SERVER_ARTIFACT"
+          mkdir -pv "$FORC_INDEX_ARTIFACT"
           cp "target/${{ matrix.job.target }}/release/fuel-indexer" "$INDEXER_ARTIFACT"
           cp "target/${{ matrix.job.target }}/release/fuel-indexer-api-server" "$API_SERVER_ARTIFACT"
+          cp "target/${{ matrix.job.target }}/release/forc-index" "$FORC_INDEX_ARTIFACT"
           tar -czvf "$INDEXER_ZIP_FILE_NAME" "$INDEXER_ARTIFACT"
           tar -czvf "$API_SERVER_ZIP_FILE_NAME" "$API_SERVER_ARTIFACT"
+          tar -czvf "$FORC_INDEX_ZIP_FILE_NAME" "$FORC_INDEX_ARTIFACT"
 
       - name: Upload Indexer Binary Artifact
         uses: actions/upload-release-asset@v1
@@ -398,6 +412,16 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./${{ env.API_SERVER_ZIP_FILE_NAME }}
           asset_name: ${{ env.API_SERVER_ZIP_FILE_NAME }}
+          asset_content_type: application/gzip
+
+      - name: Upload Forc Index Binary Artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ env.FORC_INDEX_ZIP_FILE_NAME }}
+          asset_name: ${{ env.FORC_INDEX_ZIP_FILE_NAME }}
           asset_content_type: application/gzip
 
       - name: Notify if Job Fails
@@ -544,7 +568,7 @@ jobs:
           profile: minimal
           toolchain: stable
           target: wasm32-unknown-unknown
-      
+
       - name: Publish crates
         uses: katyo/publish-crates@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash",
+ "ahash 0.7.6",
  "base64 0.13.1",
  "bitflags",
  "bytes",
@@ -138,10 +138,10 @@ dependencies = [
  "actix-server",
  "actix-service",
  "actix-utils",
- "ahash",
+ "ahash 0.7.6",
  "bytes",
  "bytestring",
- "cfg-if",
+ "cfg-if 1.0.0",
  "derive_more",
  "encoding_rs",
  "futures-core",
@@ -204,7 +204,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug 0.3.0",
@@ -256,6 +256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36"
+dependencies = [
+ "unicode-width",
+ "yansi-term",
 ]
 
 [[package]]
@@ -634,7 +655,7 @@ checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object 0.29.0",
@@ -713,6 +734,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "bitvec"
@@ -873,6 +903,12 @@ name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -1139,7 +1175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "scopeguard",
  "windows-sys 0.33.0",
@@ -1240,7 +1276,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1249,7 +1285,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1259,7 +1295,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1271,7 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset 0.7.1",
  "scopeguard",
@@ -1283,7 +1319,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1293,8 +1329,14 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -1547,7 +1589,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
@@ -1638,6 +1680,15 @@ dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1746,7 +1797,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1888,10 +1939,21 @@ dependencies = [
  "fuel-indexer-schema",
  "fuel-tx",
  "fuels-core",
- "fuels-types",
+ "fuels-types 0.30.0",
  "getrandom 0.2.8",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "extension-trait"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5129068fe3183546eaa0529af88ab0afbcddec2a373db69e94a20b8d5f6c4d74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1926,6 +1988,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "filecheck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe00b427b7c4835f8b82170eb7b9a63634376b63d73b9a9093367e82570bbaa"
+dependencies = [
+ "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2020,58 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "forc-index"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "forc-tracing",
+ "forc-util",
+ "fuel-tx",
+ "fuels-types 0.31.1",
+ "hex",
+ "hyper-rustls 0.23.1",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "forc-tracing"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f161931da6e34e1d5221576b139b837b5de08c412c4ca5c7493d2b4369711e1"
+dependencies = [
+ "ansi_term",
+ "tracing",
+ "tracing-subscriber 0.3.16",
+]
+
+[[package]]
+name = "forc-util"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7769aceca430ea7a3b23a0cf2c17f75bc6d882bd608b97610fa54ab25bc4fde"
+dependencies = [
+ "annotate-snippets",
+ "ansi_term",
+ "anyhow",
+ "dirs 3.0.2",
+ "forc-tracing",
+ "sway-core",
+ "sway-error",
+ "sway-types",
+ "sway-utils",
+ "tracing",
+ "tracing-subscriber 0.3.16",
+ "unicode-xid",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -2033,7 +2163,7 @@ dependencies = [
  "byteorder",
  "clap",
  "derive_more",
- "dirs",
+ "dirs 4.0.0",
  "enum-iterator 1.2.0",
  "env_logger 0.9.3",
  "fuel-block-executor",
@@ -2151,7 +2281,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.0",
  "chrono",
  "clap",
  "fuel-crypto",
@@ -2261,7 +2391,7 @@ dependencies = [
  "fuel-tx",
  "fuels",
  "fuels-core",
- "fuels-types",
+ "fuels-types 0.30.0",
  "graphql-parser",
  "lazy_static",
  "proc-macro-error",
@@ -2348,7 +2478,7 @@ dependencies = [
  "fuel-indexer-schema",
  "fuel-tx",
  "fuels-core",
- "fuels-types",
+ "fuels-types 0.30.0",
  "getrandom 0.2.8",
  "serde",
 ]
@@ -2562,7 +2692,7 @@ dependencies = [
  "fuels-core",
  "fuels-signers",
  "fuels-test-helpers",
- "fuels-types",
+ "fuels-types 0.30.0",
 ]
 
 [[package]]
@@ -2591,7 +2721,7 @@ dependencies = [
  "fuel-tx",
  "fuels-core",
  "fuels-signers",
- "fuels-types",
+ "fuels-types 0.30.0",
  "futures",
  "hex",
  "itertools",
@@ -2619,7 +2749,7 @@ dependencies = [
  "anyhow",
  "fuel-tx",
  "fuel-types",
- "fuels-types",
+ "fuels-types 0.30.0",
  "hex",
  "itertools",
  "lazy_static",
@@ -2650,7 +2780,7 @@ dependencies = [
  "fuel-gql-client",
  "fuel-types",
  "fuels-core",
- "fuels-types",
+ "fuels-types 0.30.0",
  "hex",
  "rand 0.8.5",
  "serde",
@@ -2674,7 +2804,7 @@ dependencies = [
  "fuels-contract",
  "fuels-core",
  "fuels-signers",
- "fuels-types",
+ "fuels-types 0.30.0",
  "hex",
  "portpicker",
  "rand 0.8.5",
@@ -2692,6 +2822,28 @@ name = "fuels-types"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721fa9b7c071ac61e2aafea3e02e7442bef94665843258f795b2dc0658e9f9bb"
+dependencies = [
+ "anyhow",
+ "bech32 0.9.1",
+ "fuel-tx",
+ "hex",
+ "itertools",
+ "lazy_static",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.21.0",
+ "strum_macros 0.21.1",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "fuels-types"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75fcd9b8161d7932bf6b0bb5d9a9d61cde655d983315bf1d534d87775426bf29"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2831,6 +2983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generational-arena"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,7 +3016,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2866,7 +3027,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -2958,7 +3119,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -2967,7 +3128,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash 0.8.2",
 ]
 
 [[package]]
@@ -3095,7 +3265,7 @@ dependencies = [
  "async-std",
  "async-tls",
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "dashmap",
  "deadpool",
  "futures",
@@ -3278,6 +3448,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3314,7 +3498,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3364,7 +3548,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve 0.12.3",
  "sha2 0.10.6",
@@ -3414,7 +3598,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -3431,7 +3615,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -3495,7 +3679,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "value-bag",
 ]
 
@@ -3694,6 +3878,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,7 +4007,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -3826,7 +4021,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -3887,6 +4082,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c0b841ea54f523f7aa556956fbd293bcbe06f2e67d2eb732b7278aaf1d166a"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,6 +4122,60 @@ checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
 dependencies = [
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3957,7 +4233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7d73f1eaed1ca1fb37b54dcc9b38e3b17d6c7b8ecb7abfffcac8d0351f17d4"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-ffi",
@@ -4056,7 +4332,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "memchr",
@@ -4207,6 +4483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rayon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4336,6 +4621,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4809,7 +5095,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -4839,7 +5125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -4851,7 +5137,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -4922,7 +5208,7 @@ dependencies = [
  "fuels",
  "fuels-abigen-macro",
  "fuels-core",
- "fuels-types",
+ "fuels-types 0.30.0",
  "log",
  "pretty_env_logger",
  "rand 0.8.5",
@@ -4949,9 +5235,25 @@ dependencies = [
  "fuel-indexer-schema",
  "fuel-tx",
  "fuels-core",
- "fuels-types",
+ "fuels-types 0.30.0",
  "getrandom 0.2.8",
  "serde",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
 ]
 
 [[package]]
@@ -5031,7 +5333,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "atoi",
  "base64 0.13.1",
  "bitflags",
@@ -5039,7 +5341,7 @@ dependencies = [
  "bytes",
  "crc",
  "crossbeam-queue",
- "dirs",
+ "dirs 4.0.0",
  "dotenvy",
  "either",
  "event-listener",
@@ -5254,7 +5556,7 @@ checksum = "718b1ae6b50351982dedff021db0def601677f2120938b070eadb10ba4038dd7"
 dependencies = [
  "async-std",
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "futures-util",
  "getrandom 0.2.8",
  "http-client",
@@ -5267,6 +5569,128 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "sway-ast"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6bbc71d0cc1f1fcbafbafc123ab15d7cbed869ea817cacf8b468b60402327a"
+dependencies = [
+ "extension-trait",
+ "num-bigint",
+ "num-traits",
+ "sway-types",
+]
+
+[[package]]
+name = "sway-core"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaefee9b20a445a13e04de7534596c9fcbb3019c2a6547566344d07e6d78f0e"
+dependencies = [
+ "derivative",
+ "dirs 3.0.2",
+ "either",
+ "fuel-vm",
+ "fuels-types 0.31.1",
+ "hashbrown 0.13.1",
+ "im",
+ "itertools",
+ "lazy_static",
+ "petgraph",
+ "rustc-hash",
+ "serde",
+ "sha2 0.9.9",
+ "smallvec",
+ "sway-ast",
+ "sway-error",
+ "sway-ir",
+ "sway-parse",
+ "sway-types",
+ "sway-utils",
+ "thiserror",
+ "tracing",
+ "uint",
+ "vec1",
+]
+
+[[package]]
+name = "sway-error"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27513f5b641838a30e8c66ff6b4bb0eb2223a62432971ad757ca9aa6e2c7685"
+dependencies = [
+ "extension-trait",
+ "num-bigint",
+ "num-traits",
+ "sway-ast",
+ "sway-types",
+ "thiserror",
+]
+
+[[package]]
+name = "sway-ir"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c214b6a99036260943ac49ac5cdb3729e00c261f7379f412d6e3bccf9d2f8cf"
+dependencies = [
+ "anyhow",
+ "filecheck",
+ "generational-arena",
+ "peg",
+ "rustc-hash",
+ "sway-ir-macros",
+ "sway-types",
+ "sway-utils",
+]
+
+[[package]]
+name = "sway-ir-macros"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e787e9e8c55cf03e658e406efc4cf84a59e22fdda82ccd481aeaeef126084c1"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sway-parse"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ef65bcf8a810317b3bd3af283cc0dc0c908373ca8c82a2a72e9bff8e98281e"
+dependencies = [
+ "extension-trait",
+ "num-bigint",
+ "num-traits",
+ "phf",
+ "sway-ast",
+ "sway-error",
+ "sway-types",
+ "thiserror",
+ "unicode-xid",
+]
+
+[[package]]
+name = "sway-types"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37923df6f93fd4286132903c5e3154bd80c7c9d9a8f4811c7b382af2c54e96c0"
+dependencies = [
+ "fuel-asm",
+ "fuel-crypto",
+ "fuel-tx",
+ "lazy_static",
+ "serde",
+]
+
+[[package]]
+name = "sway-utils"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f56864bc5e8a3bd9ac51e261392cbfabbc373f3134710927cb685f62610d8bb"
 
 [[package]]
 name = "syn"
@@ -5318,7 +5742,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -5623,7 +6047,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -5761,6 +6185,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5893,6 +6329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec1"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bda7c41ca331fe9a1c278a9e7ee055f4be7f5eb1c2b72f079b4ff8b5fce9d5c"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5944,7 +6386,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -5969,7 +6411,7 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -6019,7 +6461,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "indexmap",
  "js-sys",
  "loupe",
@@ -6132,7 +6574,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "enum-iterator 0.7.0",
  "enumset",
  "leb128",
@@ -6158,7 +6600,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "enumset",
  "leb128",
  "loupe",
@@ -6224,7 +6666,7 @@ checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "corosensei",
  "enum-iterator 0.7.0",
  "indexmap",
@@ -6540,6 +6982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,6 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tracing",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
    "packages/fuel-indexer-tests/components/web",
    "packages/fuel-indexer-types",
    "packages/fuel-indexer",
+   "plugins/forc-index",
 ]
 
 [profile.release]

--- a/plugins/forc-index/Cargo.toml
+++ b/plugins/forc-index/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "forc-index"
+version = "0.1.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/fuel-indexer"
+description = "A `forc` plugin for basic Fuel Indexer interaction."
+
+[dependencies]
+anyhow = "1"
+clap = { version = "3", features = ["derive", "env"] }
+forc-tracing = { version = "0.31", default-features = false }
+forc-util = { version = "0.31" }
+fuel-tx = { version = "0.23", features = ["builder"] }
+fuels-types = "0.31"
+hex = "0.4.3"
+hyper-rustls = { version = "0.23", features = ["http2"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "multipart", "blocking"] }
+serde = "1.0"
+serde_json = "1.0.73"
+serde_yaml = "0.8"
+tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.2", features = ["env-filter"] }
+
+[[bin]]
+name = "forc-index"
+path = "src/bin/forc-index.rs"
+
+[lib]
+path = "src/lib.rs"

--- a/plugins/forc-index/Cargo.toml
+++ b/plugins/forc-index/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = "1.0.73"
 serde_yaml = "0.8"
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.2", features = ["env-filter"] }
 
 [[bin]]
 name = "forc-index"

--- a/plugins/forc-index/README.md
+++ b/plugins/forc-index/README.md
@@ -1,0 +1,37 @@
+# forc-index
+
+A `forc` plugin for basic Fuel Indexer interaction.
+
+## Commands
+
+### `forc index init`
+
+Create a new index project at the provided path. If no path is provided the current working directory will be used.
+
+```bash
+forc index init --namespace fuel
+```
+
+### `forc index new`
+
+Create new index project at the provided path.
+
+```bash
+forc index new --namespace fuel --path /home/fuel/projects
+```
+
+### `forc index start`
+
+Start a local Fuel Indexer service.
+
+```bash
+forc index start --background
+```
+
+### `forc index deploy`
+
+Deploy a given index project to a particular endpoint
+
+```bash
+forc index deploy --url https://index.swaysway.io --manifest my-index.manifest.yaml
+```

--- a/plugins/forc-index/src/bin/forc-index.rs
+++ b/plugins/forc-index/src/bin/forc-index.rs
@@ -1,0 +1,9 @@
+use tracing::error;
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = forc_index::cli::run_cli().await {
+        error!("Error: {:?}", err);
+        std::process::exit(1);
+    }
+}

--- a/plugins/forc-index/src/cli.rs
+++ b/plugins/forc-index/src/cli.rs
@@ -1,0 +1,38 @@
+pub(crate) use crate::commands::{
+    deploy::Command as DeployCommand, init::Command as InitCommand,
+    new::Command as NewCommand, start::Command as StartCommand,
+};
+use clap::{Parser, Subcommand};
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
+
+#[derive(Debug, Parser)]
+#[clap(name = "forc index", about = "Fuel Index Orchestrator", version)]
+struct Opt {
+    /// The command to run
+    #[clap(subcommand)]
+    command: ForcIndex,
+}
+
+#[derive(Subcommand, Debug)]
+enum ForcIndex {
+    Init(InitCommand),
+    New(NewCommand),
+    Deploy(DeployCommand),
+    Start(StartCommand),
+}
+
+pub async fn run_cli() -> Result<(), anyhow::Error> {
+    let opt = Opt::parse();
+    let tracing_options = TracingSubscriberOptions {
+        ..Default::default()
+    };
+
+    init_tracing_subscriber(tracing_options);
+
+    match opt.command {
+        ForcIndex::Init(command) => crate::commands::init::exec(command),
+        ForcIndex::New(command) => crate::commands::new::exec(command),
+        ForcIndex::Deploy(command) => crate::commands::deploy::exec(command),
+        ForcIndex::Start(command) => crate::commands::start::exec(command),
+    }
+}

--- a/plugins/forc-index/src/commands/deploy.rs
+++ b/plugins/forc-index/src/commands/deploy.rs
@@ -1,0 +1,25 @@
+use crate::{ops::forc_index_deploy, utils::defaults};
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in an existing directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// URL at which to upload index assets
+    #[clap(long, default_value = defaults::DEFAULT_INDEXER_URL, help = "URL at which to upload index assets.")]
+    pub url: String,
+
+    /// Path of the index manifest to upload
+    #[clap(long, help = "Path of the index manifest to upload.")]
+    pub manifest: PathBuf,
+
+    /// Authentication header value
+    #[clap(long, help = "Authentication header value.")]
+    pub auth: Option<String>,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_deploy::init(command)?;
+    Ok(())
+}

--- a/plugins/forc-index/src/commands/init.rs
+++ b/plugins/forc-index/src/commands/init.rs
@@ -1,0 +1,30 @@
+use crate::ops::forc_index_init;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in the current directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Name of index
+    #[clap(long, help = "Name of index.")]
+    pub name: Option<String>,
+
+    /// Path at which to create index
+    #[clap(
+        short,
+        long,
+        parse(from_os_str),
+        help = "Path at which to create index."
+    )]
+    pub path: Option<PathBuf>,
+
+    /// Name of the index namespace
+    #[clap(long, help = "Namespace in which index belongs.")]
+    pub namespace: Option<String>,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_init::init(command)?;
+    Ok(())
+}

--- a/plugins/forc-index/src/commands/mod.rs
+++ b/plugins/forc-index/src/commands/mod.rs
@@ -1,0 +1,4 @@
+pub mod deploy;
+pub mod init;
+pub mod new;
+pub mod start;

--- a/plugins/forc-index/src/commands/new.rs
+++ b/plugins/forc-index/src/commands/new.rs
@@ -1,0 +1,24 @@
+use crate::ops::forc_index_new;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in an existing directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Name of index
+    #[clap(long, help = "Name of index.")]
+    pub name: Option<String>,
+
+    /// Path at which to create index
+    pub path: PathBuf,
+
+    /// Name of the index namespace
+    #[clap(long, help = "Namespace in which index belongs.")]
+    pub namespace: Option<String>,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_new::init(command)?;
+    Ok(())
+}

--- a/plugins/forc-index/src/commands/start.rs
+++ b/plugins/forc-index/src/commands/start.rs
@@ -1,0 +1,29 @@
+use crate::ops::forc_index_start;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in an existing directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Log level passed to the Fuel Indexer service.
+    #[clap(long, default_value = "info", value_parser(["info", "debug", "error", "warn"]), help = "Log level passed to the Fuel Indexer service.")]
+    pub log_level: String,
+
+    /// Path to the config file used to start the Fuel Indexer.
+    #[clap(long, help = "Path to the config file used to start the Fuel Indexer.")]
+    pub config: Option<PathBuf>,
+
+    /// Path to the fuel-indexer binary.
+    #[clap(long, help = "Path to the fuel-indexer binary.")]
+    pub bin: Option<PathBuf>,
+
+    /// Whether to run the Fuel Indexer in the background.
+    #[clap(long, help = "Whether to run the Fuel Indexer in the background.")]
+    pub background: bool,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_start::init(command)?;
+    Ok(())
+}

--- a/plugins/forc-index/src/lib.rs
+++ b/plugins/forc-index/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod cli;
+pub(crate) mod commands;
+pub(crate) mod ops;
+pub(crate) mod utils;

--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -1,0 +1,118 @@
+use crate::cli::DeployCommand;
+use reqwest::{
+    blocking::{multipart::Form, Client},
+    header::{HeaderMap, AUTHORIZATION},
+    StatusCode,
+};
+use serde_json::{to_string_pretty, value::Value, Map};
+use std::fs;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use tracing::{error, info};
+
+fn extract_manifest_fields(
+    manifest: serde_yaml::Value,
+) -> anyhow::Result<(String, String, String, String)> {
+    let namespace: String = manifest
+        .get(&serde_yaml::Value::String("namespace".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let identifier: String = manifest
+        .get(&serde_yaml::Value::String("identifier".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let graphql_schema: String = manifest
+        .get(&serde_yaml::Value::String("graphql_schema".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let module: serde_yaml::Value = manifest
+        .get(&serde_yaml::Value::String("module".into()))
+        .unwrap()
+        .to_owned();
+    let module_path: String = module
+        .get(&serde_yaml::Value::String("wasm".into()))
+        .unwrap_or_else(|| {
+            module
+                .get(&serde_yaml::Value::String("native".into()))
+                .unwrap()
+        })
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    Ok((namespace, identifier, graphql_schema, module_path))
+}
+
+pub fn init(command: DeployCommand) -> anyhow::Result<()> {
+    let mut manifest_file = fs::File::open(&command.manifest).unwrap_or_else(|_| {
+        panic!(
+            "Index manifest file at '{}' does not exist",
+            command.manifest.display()
+        )
+    });
+    let mut manifest_contents = String::new();
+    manifest_file.read_to_string(&mut manifest_contents)?;
+    let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_contents)?;
+
+    let (namespace, identifier, graphql_schema, module_path) =
+        extract_manifest_fields(manifest)?;
+
+    let mut manifest_buff = Vec::new();
+    let mut manifest_reader = BufReader::new(manifest_file);
+    manifest_reader.read_to_end(&mut manifest_buff)?;
+
+    let form = Form::new()
+        .file("manifest", Path::new(&command.manifest))?
+        .file("schema", Path::new(&graphql_schema))?
+        .file("wasm", Path::new(&module_path))?;
+
+    let target = format!("{}/api/index/{}/{}", &command.url, &namespace, &identifier);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        command.auth.unwrap_or_else(|| "fuel".into()).parse()?,
+    );
+
+    info!(
+        "\n🚀 Deploying index at {} to {}",
+        &command.manifest.display(),
+        &target
+    );
+
+    let res = Client::new()
+        .post(&target)
+        .multipart(form)
+        .headers(headers)
+        .send()
+        .expect("Failed to deploy index.");
+
+    if res.status() != StatusCode::OK {
+        error!(
+            "\n❌ {} returned a non-200 response code: {:?}",
+            &target,
+            res.status()
+        );
+        return Ok(());
+    }
+
+    let res_json = res
+        .json::<Map<String, Value>>()
+        .expect("Failed to read JSON response.");
+
+    println!("\n{}", to_string_pretty(&res_json)?);
+
+    info!(
+        "\n✅ Successfully deployed index at {} to {} \n",
+        &command.manifest.display(),
+        &target
+    );
+
+    Ok(())
+}

--- a/plugins/forc-index/src/ops/forc_index_init.rs
+++ b/plugins/forc-index/src/ops/forc_index_init.rs
@@ -1,0 +1,146 @@
+use crate::{cli::InitCommand, utils::defaults};
+use anyhow::Context;
+use forc_util::validate_name;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use tracing::{debug, info};
+
+fn print_welcome_message() {
+    let read_the_docs = format!(
+        "Read the Docs:\n- {}\n- {}\n- {}\n- {}\n",
+        "Fuel Indexer: https://github.com/FuelLabs/fuel-indexer",
+        "Fuel Indexer Book: https://fuellabs.github.io/fuel-indexer/latest",
+        "Sway Book: https://fuellabs.github.io/sway/latest",
+        "Rust SDK Book: https://fuellabs.github.io/fuels-rs/latest",
+    );
+
+    let join_the_community = format!(
+        "Join the Community:\n- Follow us {}
+- Ask questions in dev-chat on {}",
+        "@SwayLang: https://twitter.com/fuellabs_",
+        "Discord: https://discord.com/invite/xfpK4Pe"
+    );
+
+    let report_bugs = format!(
+        "Report Bugs:\n- {}",
+        "Fuel Indexer Issues: https://github.com/FuelLabs/fuel-indexer/issues/new"
+    );
+
+    let ascii_tag = r#"
+███████ ██    ██ ███████ ██          ██ ███    ██ ██████  ███████ ██   ██ ███████ ██████  
+██      ██    ██ ██      ██          ██ ████   ██ ██   ██ ██       ██ ██  ██      ██   ██ 
+█████   ██    ██ █████   ██          ██ ██ ██  ██ ██   ██ █████     ███   █████   ██████  
+██      ██    ██ ██      ██          ██ ██  ██ ██ ██   ██ ██       ██ ██  ██      ██   ██ 
+██       ██████  ███████ ███████     ██ ██   ████ ██████  ███████ ██   ██ ███████ ██   ██ 
+                                                                                          
+
+An easy-to-use, flexible indexing service built to go fast. 🚗💨
+    "#;
+
+    info!(
+        "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",
+        ascii_tag, read_the_docs, join_the_community, report_bugs
+    );
+}
+
+pub fn init(command: InitCommand) -> anyhow::Result<()> {
+    let project_dir = match &command.path {
+        Some(p) => PathBuf::from(p),
+        None => std::env::current_dir()
+            .context("❌ Failed to get current directory for forc index init.")?,
+    };
+
+    if !project_dir.is_dir() {
+        anyhow::bail!("❌ '{}' is not a valid directory.", project_dir.display());
+    }
+
+    if project_dir
+        .join(defaults::CARGO_MANIFEST_FILE_NAME)
+        .exists()
+    {
+        anyhow::bail!(
+            "❌ '{}' already includes a Cargo.toml file.",
+            project_dir.display()
+        );
+    }
+
+    debug!(
+        "\nUsing project directory at {}",
+        project_dir.canonicalize()?.display()
+    );
+
+    let project_name = match command.name {
+        Some(name) => name,
+        None => project_dir
+            .file_stem()
+            .context("❌ Failed to infer project name from directory name.")?
+            .to_string_lossy()
+            .into_owned(),
+    };
+
+    validate_name(&project_name, "project name")?;
+
+    // Make a new directory for the project
+    fs::create_dir_all(Path::new(&project_dir).join("src"))?;
+
+    // Write index Cargo manifest
+    let namespace = command
+        .namespace
+        .unwrap_or_else(|| defaults::DEFAULT_NAMESPACE.into());
+    fs::write(
+        Path::new(&project_dir).join(defaults::CARGO_MANIFEST_FILE_NAME),
+        defaults::default_index_cargo_toml(&project_name),
+    )
+    .unwrap();
+
+    // Write index manifest
+    let manifest_filename = format!("{}.manifest.yaml", project_name);
+    fs::write(
+        Path::new(&project_dir).join(&manifest_filename),
+        defaults::default_index_manifest(
+            &namespace,
+            &project_name,
+            fs::canonicalize(Path::new(&project_dir))?.to_str().unwrap(),
+        ),
+    )
+    .unwrap();
+
+    // Write index schema
+    let schema_filename = format!("{}.schema.graphql", &project_name);
+    fs::create_dir_all(Path::new(&project_dir).join("schema"))?;
+    fs::write(
+        Path::new(&project_dir).join("schema").join(schema_filename),
+        defaults::default_index_schema(),
+    )
+    .unwrap();
+
+    // Write lib file
+    fs::write(
+        Path::new(&project_dir)
+            .join("src")
+            .join(defaults::INDEX_LIB_FILENAME),
+        defaults::default_index_lib(
+            &project_name,
+            &manifest_filename,
+            fs::canonicalize(Path::new(&project_dir))?.to_str().unwrap(),
+        ),
+    )
+    .unwrap();
+
+    // Write cargo config with WASM target
+    fs::create_dir_all(Path::new(&project_dir).join(defaults::CARGO_CONFIG_DIR_NAME))?;
+    let _ = fs::write(
+        Path::new(&project_dir)
+            .join(defaults::CARGO_CONFIG_DIR_NAME)
+            .join(defaults::CARGO_CONFIG_FILENAME),
+        defaults::default_cargo_config(),
+    );
+
+    debug!("\n✅ nSuccessfully created index {project_name}");
+
+    print_welcome_message();
+
+    Ok(())
+}

--- a/plugins/forc-index/src/ops/forc_index_new.rs
+++ b/plugins/forc-index/src/ops/forc_index_new.rs
@@ -1,0 +1,31 @@
+use crate::cli::{InitCommand, NewCommand};
+use crate::commands::init;
+use std::path::Path;
+
+pub fn init(command: NewCommand) -> anyhow::Result<()> {
+    let NewCommand {
+        name,
+        namespace,
+        path,
+    } = command;
+
+    let dir_path = Path::new(&path);
+    if dir_path.exists() {
+        anyhow::bail!(
+            "❌ Directory \"{}\" already exists.\nIf you wish to initialise an index project inside \
+            this directory, consider using `forc index init --path {}`",
+            dir_path.canonicalize()?.display(),
+            dir_path.display(),
+        );
+    } else {
+        std::fs::create_dir_all(dir_path)?;
+    }
+
+    let _ = init::exec(InitCommand {
+        name,
+        namespace,
+        path: Some(dir_path.to_path_buf()),
+    });
+
+    Ok(())
+}

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -1,0 +1,47 @@
+use crate::cli::StartCommand;
+use std::path::PathBuf;
+use std::process::Command;
+use tracing::info;
+
+pub fn init(command: StartCommand) -> anyhow::Result<()> {
+    // If the user has a binary path they'd prefer to use, they can specify
+    // it, else just use whichever indexer is in the path - whether that be
+    // ia fuelup or some other means.
+    let binary_path = command.bin.unwrap_or_else(|| {
+        PathBuf::from(
+            String::from_utf8(
+                Command::new("which")
+                    .arg("fuel-indexer")
+                    .output()
+                    .expect("❌ Failed to detect fuel-indexer binary.")
+                    .stdout,
+            )
+            .unwrap(),
+        )
+    });
+
+    let mut cmd = Command::new(&binary_path);
+
+    if let Some(c) = &command.config {
+        cmd.arg("--config").arg(c);
+    }
+
+    let mut proc = cmd
+        .spawn()
+        .expect("❌ Failed to spawn fuel-indexer child process.");
+
+    // Starting the service in the background allows the user to
+    // go and and continue interacting with the service (e.g., forc index deploy)
+    // without having to switch terminals
+    if !command.background {
+        let ecode = proc
+            .wait()
+            .expect("❌ Failed to wait on fuel-indexer process.");
+
+        assert!(ecode.success());
+    }
+
+    info!("\n✅ Successfully started the indexer service.");
+
+    Ok(())
+}

--- a/plugins/forc-index/src/ops/mod.rs
+++ b/plugins/forc-index/src/ops/mod.rs
@@ -1,0 +1,4 @@
+pub mod forc_index_deploy;
+pub mod forc_index_init;
+pub mod forc_index_new;
+pub mod forc_index_start;

--- a/plugins/forc-index/src/utils/defaults.rs
+++ b/plugins/forc-index/src/utils/defaults.rs
@@ -1,0 +1,97 @@
+pub const CARGO_MANIFEST_FILE_NAME: &str = "Cargo.toml";
+pub const INDEX_LIB_FILENAME: &str = "lib.rs";
+pub const DEFAULT_NAMESPACE: &str = "fuel";
+pub const CARGO_CONFIG_DIR_NAME: &str = ".cargo";
+pub const CARGO_CONFIG_FILENAME: &str = "config";
+pub const DEFAULT_INDEXER_URL: &str = "http://127.0.0.1:29987";
+
+pub fn default_index_cargo_toml(index_name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{index_name}"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+fuel-indexer-macros = {{ version = "0.1", default-features = false }}
+fuel-indexer-plugin = {{ version = "0.1" }}
+fuel-indexer-schema = {{ version = "0.1", default-features = false }}
+fuel-tx = "0.23"
+fuels-core = "0.30"
+fuels-types = "0.30"
+getrandom = {{ version = "0.2", features = ["js"] }}
+serde = {{ version = "1.0", default-features = false, features = ["derive"] }}
+"#
+    )
+}
+
+pub fn default_index_manifest(
+    namespace: &str,
+    index_name: &str,
+    project_path: &str,
+) -> String {
+    format!(
+        r#"namespace: {namespace}
+identifier: {index_name}
+# abi: /path/to/your/contract-abi.json
+graphql_schema: {project_path}/schema/{index_name}.schema.graphql
+module:
+  wasm: /path/to/your/index_wasm_module.wasm
+"#
+    )
+}
+
+pub fn default_index_lib(
+    index_name: &str,
+    manifest_filename: &str,
+    path: &str,
+) -> String {
+    format!(
+        r#"extern crate alloc;
+use fuel_indexer_macros::indexer;
+
+#[indexer(manifest = "{path}/{manifest_filename}")]
+pub mod {index_name}_index_mod {{
+
+    fn {index_name}_handler(block: BlockData) {{
+        Logger::info("Processing a block. (>'.')>");
+        for tx in block.transactions.iter() {{
+            let msg = format!("Processing transaction: {{}}", tx.id);
+            Logger::info(&msg);
+        }}
+    }}
+}}
+"#
+    )
+}
+
+pub fn default_index_schema() -> String {
+    r#"schema {
+    query: QueryRoot
+}
+
+type QueryRoot {
+    account: Account
+}
+
+type Account {
+    id: ID!
+    address: Address! @indexed
+    first_seen: UInt8!
+    last_seen: UInt8!
+}
+
+"#
+    .to_string()
+}
+
+pub fn default_cargo_config() -> String {
+    r#"[build]
+target = "wasm32-unknown-unknown"
+"#
+    .to_string()
+}

--- a/plugins/forc-index/src/utils/mod.rs
+++ b/plugins/forc-index/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod defaults;


### PR DESCRIPTION
### Description
- This PR adds the long-awaited Forc Indexer plugin that is invoked via `forc index`
- `forc index` is pretty much based on forc in terms of structure
- There may have been a few things that I left out (it's been a minute since I've committed to forc)
- I'm not really sure how to "hook this in" to forc -- so I just built the binary `cargo build --release -p forc-index` and manually added it to my `~/.fuelup/bin`

### Testings steps
- [ ] I would recommend you pull down the https://github.com/FuelLabs/fuel-indexer/ project
- [ ] And build a `fuel-indexer` binary via `cargo build --release -p fuel-indexer`
  - This will help with the `forc index start` and `forc index deploy` commands
  - This `fuel-indexer` binary has been merged into `fuelup` but haven't had a chance to use it yet 
- [ ] Then maybe just start playing around by following [the `forc index` README](https://github.com/FuelLabs/sway/pull/3408/files#diff-f2a224153badb56732262b7d0bcbf0ab38ea97660a497b02be28408310918dd1)