### PR TITLE
underscore project name

### DIFF
--- a/plugins/forc-index/src/ops/forc_index_init.rs
+++ b/plugins/forc-index/src/ops/forc_index_init.rs
@@ -1,4 +1,4 @@
-use crate::{cli::InitCommand, utils::defaults};
+use crate::{cli::InitCommand, utils::{defaults, dasherize_to_underscore}};
 use anyhow::Context;
 use forc_util::validate_name;
 use std::{
@@ -29,7 +29,7 @@ fn print_welcome_message() {
     );
 
     let ascii_tag = r#"
-███████ ██    ██ ███████ ██          ██ ███    ██ ██████  ███████ ██   ██ ███████ ██████  
+███████ ██    ██ ███████ ██          ██ ███    ██ ██████  ███████ ██   ██ ███████ ██████ 
 ██      ██    ██ ██      ██          ██ ████   ██ ██   ██ ██       ██ ██  ██      ██   ██ 
 █████   ██    ██ █████   ██          ██ ██ ██  ██ ██   ██ █████     ███   █████   ██████  
 ██      ██    ██ ██      ██          ██ ██  ██ ██ ██   ██ ██       ██ ██  ██      ██   ██ 
@@ -79,6 +79,9 @@ pub fn init(command: InitCommand) -> anyhow::Result<()> {
             .to_string_lossy()
             .into_owned(),
     };
+
+    // Indexer expects underscores not dashes
+    let project_name = dasherize_to_underscore(&project_name);
 
     validate_name(&project_name, "project name")?;
 

--- a/plugins/forc-index/src/ops/forc_index_init.rs
+++ b/plugins/forc-index/src/ops/forc_index_init.rs
@@ -1,4 +1,7 @@
-use crate::{cli::InitCommand, utils::{defaults, dasherize_to_underscore}};
+use crate::{
+    cli::InitCommand,
+    utils::{dasherize_to_underscore, defaults},
+};
 use anyhow::Context;
 use forc_util::validate_name;
 use std::{

--- a/plugins/forc-index/src/utils/mod.rs
+++ b/plugins/forc-index/src/utils/mod.rs
@@ -1,1 +1,5 @@
 pub mod defaults;
+
+pub(crate) fn dasherize_to_underscore(s: &str) -> String {
+    str::replace(s, "-", "_")
+}


### PR DESCRIPTION
### Description
- Small bug in the plugin where the project name is not underscored for files/paths

### Testing steps
- [ ] `forc new hello-index`
  - Schema and manifest filenames should be underscored