### PR TITLE
update ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,51 @@ env:
 jobs:
   cancel-previous-runs:
     runs-on: ubuntu-latest
-
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
+  cargo-toml-fmt-check:
+    needs:
+      - cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Install Cargo.toml linter
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-toml-lint
+          version: '0.1'
+      - name: Run Cargo.toml linter
+        run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+
+  get-workspace-members:
+    needs: 
+      - cancel-previous-runs
+      - cargo-toml-fmt-check
+    runs-on: ubuntu-latest
+    outputs:
+      members: ${{ steps.set-members.outputs.members }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - id: set-members
+        run: |
+          # install dasel
+          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+          members=$(cat Cargo.toml | dasel -r toml -w json 'workspace.members' | jq -r ".[]" | xargs -I '{}' dasel -f {}/Cargo.toml 'package.name' | jq -R '[.]' | jq -s -c 'add')
+          echo "members=$members" >> $GITHUB_OUTPUT
+
   mdbook-build:
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +78,9 @@ jobs:
           mdbook-version: '0.4.17'
 
   mdbook-lint:
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
+      - mdbook-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +92,9 @@ jobs:
           markdownlint --config .markdownlintrc **/*.md docs/src/
 
   cargo-unused-deps-check:
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
+      - cargo-toml-fmt-check
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -87,25 +127,10 @@ jobs:
           command: udeps
           args: --locked --all-targets --all-features
 
-  cargo-toml-fmt-check:
-    needs: cancel-previous-runs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v1
-      - name: Install Cargo.toml linter
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-toml-lint
-          version: '0.1'
-      - name: Run Cargo.toml linter
-        run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
-
   cargo-build-wasm-example:
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
+      - cargo-toml-fmt-check
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -131,21 +156,6 @@ jobs:
           command: build
           args: -p fuel-indexer-test --release --target wasm32-unknown-unknown
 
-  get-workspace-members:
-    runs-on: ubuntu-latest
-    outputs:
-      members: ${{ steps.set-members.outputs.members }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - id: set-members
-        run: |
-          # install dasel
-          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
-          mv ./dasel /usr/local/bin/dasel
-          members=$(cat Cargo.toml | dasel -r toml -w json 'workspace.members' | jq -r ".[]" | xargs -I '{}' dasel -f {}/Cargo.toml 'package.name' | jq -R '[.]' | jq -s -c 'add')
-          echo "members=$members" >> $GITHUB_OUTPUT
-
   cargo-verifications:
     runs-on: ubuntu-latest
     services:
@@ -160,12 +170,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     needs:
       - cancel-previous-runs
-      - cargo-toml-fmt-check
       - cargo-build-wasm-example
       - get-workspace-members
     strategy:
       matrix:
-        package: ${{fromJSON(needs.get-workspace-members.outputs.members)}}
+        package: ${{ fromJSON(needs.get-workspace-members.outputs.members) }}
         include:
           - command: fmt
             args: --all --verbose -- --check
@@ -213,7 +222,10 @@ jobs:
   # TODO: https://github.com/FuelLabs/fuel-indexer/issues/269
   cargo-test-workspace-all-features:
     if: github.event_name != 'release' && github.event.action != 'published'
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
+      - cargo-build-wasm-example
+      - get-workspace-members
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -256,13 +268,78 @@ jobs:
       - run: cargo test --locked --workspace --all-features --all-targets
       - run: bash scripts/utils/kill_test_components.bash
 
+  publish-docker-image:
+    needs:
+      - cancel-previous-runs
+      - cargo-verifications
+    if: github.event_name == 'release' || github.event.action == 'published'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # This is a way to make this job run after publish-crates even if it's skipped on master or pr branches
+      # https://stackoverflow.com/a/69252812/680811
+      - name: fail if any dependent jobs failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/fuellabs/fuel-indexer
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{raw}}
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the ghcr.io registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the image to ghcr.io
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: deployment/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Notify if Job Fails
+        uses: ravsamhq/notify-slack-action@v1
+        if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: '{workflow} has {status_message}'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>'
+          footer: ''
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
+
   publish-fuel-indexer-binaries:
-    name: Release fuel-indexer binaries
     runs-on: ${{ matrix.job.os }}
     needs:
       - cancel-previous-runs
       - cargo-verifications
-      - cargo-test-workspace-all-features
+      - publish-docker-image
     if: github.event_name == 'release' && github.event.action == 'published'
      # Only do this job if publishing a release
     strategy:
@@ -438,75 +515,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
-  publish-docker-image:
-    needs: cargo-toml-fmt-check
-    if: github.event_name == 'release' || github.event.action == 'published'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      # This is a way to make this job run after publish-crates even if it's skipped on master or pr branches
-      # https://stackoverflow.com/a/69252812/680811
-      - name: fail if any dependent jobs failed
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/fuellabs/fuel-indexer
-          tags: |
-            type=sha
-            type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{raw}}
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/master' }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Log in to the ghcr.io registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push the image to ghcr.io
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: deployment/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Notify if Job Fails
-        uses: ravsamhq/notify-slack-action@v1
-        if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: '{workflow} has {status_message}'
-          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>'
-          footer: ''
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
-
   validation-complete:
     needs:
       - cargo-verifications
-      - cargo-test-workspace-all-features
-      - mdbook-build
     runs-on: ubuntu-latest
     steps:
       - run: true
@@ -532,7 +543,6 @@ jobs:
   publish:
     # Only do this job if publishing a release and validations pass.
     needs:
-      - validation-complete
       - publish-fuel-indexer-binaries
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
@@ -592,7 +602,6 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/master'
     needs:
-      - publish-docker-image
       - publish-fuel-indexer-binaries
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description
- Updates CI workflow
  - v0.1.8 did not publish because `publish` was dependent on `cargo-test-workspace-all-features` which does not run on when cutting a release
- New workflow is a bit more clean/streamlined
  - PR CI time is ~30mins w/ longest job `cargo-test-workspace-all-features` taking around 23 mins (~75% of the time)

#### Old workflow

<img width="1248" alt="Screen Shot 2022-12-01 at 11 27 51 AM" src="https://user-images.githubusercontent.com/17253182/205106687-0daafa66-c87c-4f2b-8483-9ad25a8fd322.png">


#### New workflow

<img width="1215" alt="Screen Shot 2022-12-01 at 2 01 48 PM" src="https://user-images.githubusercontent.com/17253182/205137739-d16dc703-537c-4b71-854b-60fc18dadb7f.png">
