### PR TITLE
Fix pool usage across the indexer

### DIFF
--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -105,15 +105,9 @@ pub struct GraphQlApi;
 impl GraphQlApi {
     pub async fn run(
         config: IndexerConfig,
-        connection_pool: Option<IndexerConnectionPool>,
+        pool: IndexerConnectionPool,
         tx: Option<Sender<ServiceRequest>>,
     ) {
-        let pool = match connection_pool {
-            Some(p) => p,
-            None => IndexerConnectionPool::connect(&config.database.to_string())
-                .await
-                .expect("Failed to establish connection pool"),
-        };
         let sm = SchemaManager::new(pool.clone());
         let schema_manager = Arc::new(RwLock::new(sm));
         let config = config.clone();

--- a/packages/fuel-indexer-api-server/src/bin/fuel-indexer-api-server.rs
+++ b/packages/fuel-indexer-api-server/src/bin/fuel-indexer-api-server.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use fuel_indexer_api_server::api::GraphQlApi;
+use fuel_indexer_database::IndexerConnectionPool;
 use fuel_indexer_lib::config::{IndexerArgs, IndexerConfig, Parser};
 use tracing::info;
 use tracing_subscriber::filter::EnvFilter;
@@ -27,7 +28,9 @@ pub async fn main() -> Result<()> {
 
     info!("Configuration: {:?}", config);
 
-    GraphQlApi::run(config.clone(), None, None).await;
+    let pool = IndexerConnectionPool::connect(&config.database.to_string()).await?;
+
+    GraphQlApi::run(config.clone(), pool, None).await;
 
     Ok(())
 }

--- a/packages/fuel-indexer-api-server/src/bin/fuel-indexer-api-server.rs
+++ b/packages/fuel-indexer-api-server/src/bin/fuel-indexer-api-server.rs
@@ -27,7 +27,7 @@ pub async fn main() -> Result<()> {
 
     info!("Configuration: {:?}", config);
 
-    GraphQlApi::run(config.clone(), None).await;
+    GraphQlApi::run(config.clone(), None, None).await;
 
     Ok(())
 }

--- a/packages/fuel-indexer-database/src/lib.rs
+++ b/packages/fuel-indexer-database/src/lib.rs
@@ -77,21 +77,20 @@ impl IndexerConnectionPool {
         let url = url.expect("Database URL should be correctly formed");
         match url.scheme() {
             "postgres" => {
+                let connection_options = PgConnectOptions::from_str(database_url)?;
                 let pool = attempt_database_connection(|| {
-                    let connection_options = PgConnectOptions::from_str(database_url)
-                        .expect("Failed to parse Postgres connection options");
-                    sqlx::postgres::PgPoolOptions::new().connect_with(connection_options)
+                    sqlx::postgres::PgPoolOptions::new()
+                        .connect_with(connection_options.clone())
                 })
                 .await;
 
                 Ok(IndexerConnectionPool::Postgres(pool))
             }
             "sqlite" => {
+                let connection_options = SqliteConnectOptions::from_str(database_url)?;
                 let pool = attempt_database_connection(|| {
-                    let connection_options = SqliteConnectOptions::from_str(database_url)
-                        .expect("Failed to parse SQLite connection options");
                     sqlx::sqlite::SqlitePoolOptions::new()
-                        .connect_with(connection_options)
+                        .connect_with(connection_options.clone())
                 })
                 .await;
 

--- a/packages/fuel-indexer-schema/src/db/manager.rs
+++ b/packages/fuel-indexer-schema/src/db/manager.rs
@@ -12,10 +12,8 @@ pub struct SchemaManager {
 }
 
 impl SchemaManager {
-    pub async fn new(db_conn: impl Into<String>) -> IndexerSchemaResult<SchemaManager> {
-        let pool = IndexerConnectionPool::connect(&db_conn.into()).await?;
-
-        Ok(SchemaManager { pool })
+    pub fn new(pool: IndexerConnectionPool) -> SchemaManager {
+        SchemaManager { pool }
     }
 
     pub async fn new_schema(&self, name: &str, schema: &str) -> IndexerSchemaResult<()> {

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -173,5 +173,7 @@ pub async fn indexer_service() -> IndexerService {
         metrics: false,
     };
 
-    IndexerService::new(config, None).await.unwrap()
+    let pool = IndexerConnectionPool::connect(&config.database.to_string());
+
+    IndexerService::new(config, pool, None).await.unwrap()
 }

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -173,7 +173,9 @@ pub async fn indexer_service() -> IndexerService {
         metrics: false,
     };
 
-    let pool = IndexerConnectionPool::connect(&config.database.to_string());
+    let pool = IndexerConnectionPool::connect(&config.database.to_string())
+        .await
+        .expect("Failed to create connection pool");
 
     IndexerService::new(config, pool, None).await.unwrap()
 }

--- a/packages/fuel-indexer-tests/tests/database.rs
+++ b/packages/fuel-indexer-tests/tests/database.rs
@@ -60,9 +60,11 @@ async fn test_schema_manager_generates_and_loads_schema_sqlite() {
 }
 
 async fn generate_schema_then_load_schema_from_wasm_module(database_url: &str) {
-    let manager = SchemaManager::new(database_url)
+    let pool = IndexerConnectionPool::connect(database_url)
         .await
-        .expect("Could not create SchemaManager");
+        .expect("Connection pool error");
+
+    let manager = SchemaManager::new(pool.clone());
 
     // SchemaManager.build calls inject_native_entities_into_schema so since we're using
     // `version` later in this test we need to manually call `inject_native_entities_into_schema` here
@@ -70,10 +72,6 @@ async fn generate_schema_then_load_schema_from_wasm_module(database_url: &str) {
 
     let result = manager.new_schema("test_namespace", GRAPHQL_SCHEMA).await;
     assert!(result.is_ok());
-
-    let pool = IndexerConnectionPool::connect(database_url)
-        .await
-        .expect("Connection pool error");
 
     let version = schema_version(&schema);
     let mut conn = pool

--- a/packages/fuel-indexer/src/bin/fuel-indexer.rs
+++ b/packages/fuel-indexer/src/bin/fuel-indexer.rs
@@ -63,9 +63,7 @@ pub async fn main() -> Result<()> {
         () => (None, None),
     };
 
-    let pool = IndexerConnectionPool::connect(&config.database.to_string())
-        .await
-        .expect("Failed to open connection pool");
+    let pool = IndexerConnectionPool::connect(&config.database.to_string()).await?;
 
     let mut service = IndexerService::new(config.clone(), pool.clone(), rx).await?;
 
@@ -91,7 +89,7 @@ pub async fn main() -> Result<()> {
     let service_handle = tokio::spawn(service.run());
 
     #[cfg(feature = "api-server")]
-    GraphQlApi::run(config, Some(pool.clone()), tx).await;
+    GraphQlApi::run(config, pool, tx).await;
 
     service_handle.await?;
 

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -281,7 +281,7 @@ impl IndexerService {
         pool: IndexerConnectionPool,
         rx: Option<Receiver<ServiceRequest>>,
     ) -> IndexerResult<IndexerService> {
-        let database_url = config.database.to_string().clone();
+        let database_url = config.database.to_string();
 
         let manager = SchemaManager::new(pool.clone());
 
@@ -412,10 +412,12 @@ impl IndexerService {
                             &request.identifier,
                         )
                         .await
-                        .expect(&format!(
-                            "Failed to get id for {}.{}",
-                            &request.namespace, &request.identifier
-                        ));
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "Failed to get id for {}.{}",
+                                &request.namespace, &request.identifier
+                            )
+                        });
 
                         let assets =
                             queries::latest_assets_for_index(&mut conn, &index_id)

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -412,7 +412,10 @@ impl IndexerService {
                             &request.identifier,
                         )
                         .await
-                        .unwrap();
+                        .expect(&format!(
+                            "Failed to get id for {}.{}",
+                            &request.namespace, &request.identifier
+                        ));
 
                         let assets =
                             queries::latest_assets_for_index(&mut conn, &index_id)
@@ -420,7 +423,8 @@ impl IndexerService {
                                 .expect("Could not get latest assets for index");
 
                         let manifest: Manifest =
-                            serde_yaml::from_slice(&assets.manifest.bytes).unwrap();
+                            serde_yaml::from_slice(&assets.manifest.bytes)
+                                .expect("Failed to deserialize manifest");
 
                         let handle = spawn_executor_from_index_asset_registry(
                             self.config.fuel_node.clone(),
@@ -429,7 +433,7 @@ impl IndexerService {
                             assets.wasm.bytes,
                         )
                         .await
-                        .unwrap();
+                        .expect("Failed to spawn executor from index asset registry");
 
                         handles.borrow_mut().insert(manifest.uid(), handle);
                     }

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -269,6 +269,7 @@ fn make_task<T: 'static + Executor + Send + Sync>(
 pub struct IndexerService {
     config: IndexerConfig,
     rx: Option<Receiver<ServiceRequest>>,
+    pool: IndexerConnectionPool,
     manager: SchemaManager,
     database_url: String,
     handles: RefCell<HashMap<String, JoinHandle<()>>>,
@@ -277,15 +278,17 @@ pub struct IndexerService {
 impl IndexerService {
     pub async fn new(
         config: IndexerConfig,
+        pool: IndexerConnectionPool,
         rx: Option<Receiver<ServiceRequest>>,
     ) -> IndexerResult<IndexerService> {
         let database_url = config.database.to_string().clone();
 
-        let manager = SchemaManager::new(&database_url).await?;
+        let manager = SchemaManager::new(pool.clone());
 
         Ok(IndexerService {
             config,
             rx,
+            pool,
             manager,
             database_url,
             handles: RefCell::new(HashMap::default()),
@@ -299,9 +302,7 @@ impl IndexerService {
     ) -> IndexerResult<()> {
         let database_url = self.database_url.clone();
 
-        let pool =
-            IndexerConnectionPool::connect(&self.config.database.to_string()).await?;
-        let mut conn = pool.acquire().await?;
+        let mut conn = self.pool.acquire().await?;
 
         let _ = queries::start_transaction(&mut conn)
             .await
@@ -399,11 +400,11 @@ impl IndexerService {
             while let Some(service_request) = rx.recv().await {
                 match service_request {
                     ServiceRequest::AssetReload(request) => {
-                        let database_url = self.config.database.clone().to_string();
-                        let pool =
-                            IndexerConnectionPool::connect(&database_url).await.unwrap();
-
-                        let mut conn = pool.acquire().await.unwrap();
+                        let mut conn = self
+                            .pool
+                            .acquire()
+                            .await
+                            .expect("Failed to acquire connection from pool");
 
                         let index_id = queries::index_id_for(
                             &mut conn,


### PR DESCRIPTION
_Note: This does not fix SQLite; this is just a cleanup PR while I continue to fix the issue._

## Changelog
- Consolidates pool usage across application; we were creating multiple pools across the indexer, which meant that `max_connections()` and other settings weren't being respected
- Adds pool and connection options; we're now able to change pool and connection settings (e.g. log level), if so desired
- Changes some `unwrap()`s to `expect()`s

## Testing Plan
CI should pass. Starting the service using Postgres should also work as expected.