### PR TITLE
Add `forc index stop`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ dependencies = [
  "clap",
  "forc-tracing",
  "forc-util",
+ "fuel-indexer-lib",
  "fuel-tx",
  "fuels-types 0.31.1",
  "hex",

--- a/plugins/forc-index/Cargo.toml
+++ b/plugins/forc-index/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }
 forc-tracing = { version = "0.31", default-features = false }
 forc-util = { version = "0.31" }
+fuel-indexer-lib = { version = "0.1", path = "../../packages/fuel-indexer-lib" }
 fuel-tx = { version = "0.23", features = ["builder"] }
 fuels-types = "0.31"
 hex = "0.4.3"

--- a/plugins/forc-index/src/cli.rs
+++ b/plugins/forc-index/src/cli.rs
@@ -1,6 +1,7 @@
 pub(crate) use crate::commands::{
     deploy::Command as DeployCommand, init::Command as InitCommand,
     new::Command as NewCommand, start::Command as StartCommand,
+    stop::Command as StopCommand,
 };
 use clap::{Parser, Subcommand};
 use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
@@ -19,6 +20,7 @@ enum ForcIndex {
     New(NewCommand),
     Deploy(DeployCommand),
     Start(StartCommand),
+    Stop(StopCommand),
 }
 
 pub async fn run_cli() -> Result<(), anyhow::Error> {
@@ -34,5 +36,6 @@ pub async fn run_cli() -> Result<(), anyhow::Error> {
         ForcIndex::New(command) => crate::commands::new::exec(command),
         ForcIndex::Deploy(command) => crate::commands::deploy::exec(command),
         ForcIndex::Start(command) => crate::commands::start::exec(command),
+        ForcIndex::Stop(command) => crate::commands::stop::exec(command),
     }
 }

--- a/plugins/forc-index/src/commands/deploy.rs
+++ b/plugins/forc-index/src/commands/deploy.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Create a new Forc project in an existing directory.
+/// Deploy an index asset bundle to a remote or locally running indexer server.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// URL at which to upload index assets

--- a/plugins/forc-index/src/commands/init.rs
+++ b/plugins/forc-index/src/commands/init.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Create a new Forc project in the current directory.
+/// Create a new indexer project in the current directory.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// Name of index

--- a/plugins/forc-index/src/commands/mod.rs
+++ b/plugins/forc-index/src/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod deploy;
 pub mod init;
 pub mod new;
 pub mod start;
+pub mod stop;

--- a/plugins/forc-index/src/commands/new.rs
+++ b/plugins/forc-index/src/commands/new.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Create a new Forc project in an existing directory.
+/// Create a new indexer project in a new directory.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// Name of index

--- a/plugins/forc-index/src/commands/start.rs
+++ b/plugins/forc-index/src/commands/start.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Create a new Forc project in an existing directory.
+/// Start a local indexer service.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// Log level passed to the Fuel Indexer service.

--- a/plugins/forc-index/src/commands/stop.rs
+++ b/plugins/forc-index/src/commands/stop.rs
@@ -1,0 +1,25 @@
+use crate::{ops::forc_index_stop, utils::defaults};
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Stop a running index.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// URL at which index is deployed
+    #[clap(long, default_value = defaults::DEFAULT_INDEXER_URL, help = "URL at which to upload index assets.")]
+    pub url: String,
+
+    /// Path of the index manifest to be parsed
+    #[clap(long, help = "Path of the index manifest to be parsed.")]
+    pub manifest: PathBuf,
+
+    /// Authentication header value
+    #[clap(long, help = "Authentication header value.")]
+    pub auth: Option<String>,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_stop::init(command)?;
+    Ok(())
+}

--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -1,4 +1,4 @@
-use crate::cli::DeployCommand;
+use crate::{cli::DeployCommand, utils::extract_manifest_fields};
 use reqwest::{
     blocking::{multipart::Form, Client},
     header::{HeaderMap, AUTHORIZATION},
@@ -9,45 +9,6 @@ use std::fs;
 use std::io::{BufReader, Read};
 use std::path::Path;
 use tracing::{error, info};
-
-fn extract_manifest_fields(
-    manifest: serde_yaml::Value,
-) -> anyhow::Result<(String, String, String, String)> {
-    let namespace: String = manifest
-        .get(&serde_yaml::Value::String("namespace".into()))
-        .unwrap()
-        .as_str()
-        .unwrap()
-        .to_string();
-    let identifier: String = manifest
-        .get(&serde_yaml::Value::String("identifier".into()))
-        .unwrap()
-        .as_str()
-        .unwrap()
-        .to_string();
-    let graphql_schema: String = manifest
-        .get(&serde_yaml::Value::String("graphql_schema".into()))
-        .unwrap()
-        .as_str()
-        .unwrap()
-        .to_string();
-    let module: serde_yaml::Value = manifest
-        .get(&serde_yaml::Value::String("module".into()))
-        .unwrap()
-        .to_owned();
-    let module_path: String = module
-        .get(&serde_yaml::Value::String("wasm".into()))
-        .unwrap_or_else(|| {
-            module
-                .get(&serde_yaml::Value::String("native".into()))
-                .unwrap()
-        })
-        .as_str()
-        .unwrap()
-        .to_string();
-
-    Ok((namespace, identifier, graphql_schema, module_path))
-}
 
 pub fn init(command: DeployCommand) -> anyhow::Result<()> {
     let mut manifest_file = fs::File::open(&command.manifest).unwrap_or_else(|_| {

--- a/plugins/forc-index/src/ops/forc_index_stop.rs
+++ b/plugins/forc-index/src/ops/forc_index_stop.rs
@@ -1,0 +1,61 @@
+use crate::cli::StopCommand;
+use crate::utils::extract_manifest_fields;
+use reqwest::{
+    blocking::Client,
+    header::{HeaderMap, AUTHORIZATION},
+    StatusCode,
+};
+use serde_json::{to_string_pretty, value::Value, Map};
+use std::fs;
+use std::io::Read;
+use tracing::{error, info};
+
+pub fn init(command: StopCommand) -> anyhow::Result<()> {
+    let mut manifest_file = fs::File::open(&command.manifest).unwrap_or_else(|_| {
+        panic!(
+            "Index manifest file at '{}' does not exist",
+            command.manifest.display()
+        )
+    });
+
+    let mut manifest_contents = String::new();
+    manifest_file.read_to_string(&mut manifest_contents)?;
+    let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_contents)?;
+
+    let (namespace, identifier, _, _) = extract_manifest_fields(manifest)?;
+
+    let target = format!("{}/api/index/{}/{}", &command.url, &namespace, &identifier);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        command.auth.unwrap_or_else(|| "fuel".into()).parse()?,
+    );
+
+    info!("\n🛑 Stopping index at {}", &target);
+
+    let res = Client::new()
+        .delete(&target)
+        .headers(headers)
+        .send()
+        .expect("Failed to deploy index.");
+
+    if res.status() != StatusCode::OK {
+        error!(
+            "\n❌ {} returned a non-200 response code: {:?}",
+            &target,
+            res.status()
+        );
+        return Ok(());
+    }
+
+    let res_json = res
+        .json::<Map<String, Value>>()
+        .expect("Failed to read JSON response.");
+
+    println!("\n{}", to_string_pretty(&res_json)?);
+
+    info!("\n✅ Successfully stopped index at {} \n", &target);
+
+    Ok(())
+}

--- a/plugins/forc-index/src/ops/mod.rs
+++ b/plugins/forc-index/src/ops/mod.rs
@@ -2,3 +2,4 @@ pub mod forc_index_deploy;
 pub mod forc_index_init;
 pub mod forc_index_new;
 pub mod forc_index_start;
+pub mod forc_index_stop;

--- a/plugins/forc-index/src/utils/mod.rs
+++ b/plugins/forc-index/src/utils/mod.rs
@@ -3,3 +3,42 @@ pub mod defaults;
 pub(crate) fn dasherize_to_underscore(s: &str) -> String {
     str::replace(s, "-", "_")
 }
+
+pub(crate) fn extract_manifest_fields(
+    manifest: serde_yaml::Value,
+) -> anyhow::Result<(String, String, String, String)> {
+    let namespace: String = manifest
+        .get(&serde_yaml::Value::String("namespace".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let identifier: String = manifest
+        .get(&serde_yaml::Value::String("identifier".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let graphql_schema: String = manifest
+        .get(&serde_yaml::Value::String("graphql_schema".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let module: serde_yaml::Value = manifest
+        .get(&serde_yaml::Value::String("module".into()))
+        .unwrap()
+        .to_owned();
+    let module_path: String = module
+        .get(&serde_yaml::Value::String("wasm".into()))
+        .unwrap_or_else(|| {
+            module
+                .get(&serde_yaml::Value::String("native".into()))
+                .unwrap()
+        })
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    Ok((namespace, identifier, graphql_schema, module_path))
+}


### PR DESCRIPTION
Closes #396.

## Changelog
- Add `forc index stop` command
- Move `extract_manifest_fields` to utils
- Clean up docstrings for other commands

## Testing Steps
1. `cargo build --release -p forc-index`
2. `cp target/release/forc-index ~/.fuelup/bin`
3. Start an index and verify that it indexes data
4. `forc index stop --manifest [same_manifest_as_running_index] --auth foo`
5. Logging should say that index has been stopped.
6. Verify that indexer no longer indexes data.