### PR TITLE
fix(macros, schema): Support optional schema fields

### DIFF
--- a/packages/fuel-indexer-macros/src/schema.rs
+++ b/packages/fuel-indexer-macros/src/schema.rs
@@ -9,6 +9,7 @@ use graphql_parser::schema::{
     Definition, Document, Field, ObjectType, SchemaDefinition, Type, TypeDefinition,
 };
 use lazy_static::lazy_static;
+use proc_macro2::{TokenStream, TokenTree};
 use quote::{format_ident, quote};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -58,10 +59,13 @@ fn process_field<'a>(
     let typ = process_type(types, field_type, true);
     let ident = format_ident! {"{}", name};
 
+    // Type may be nullable, so let's grab the actual column type
+    let (_, column_type) = get_column_type(typ.clone());
+
     let extractor = quote! {
         let item = vec.pop().expect("Missing item in row");
         let #ident = match item {
-            FtColumn::#typ(t) => t,
+            FtColumn::#column_type(t) => t,
             _ => panic!("Invalid column type {:?}", item),
         };
 
@@ -334,4 +338,27 @@ pub(crate) fn process_graphql_schema(
         }
     }
     output
+}
+
+// Note: This may have to change once we support list types -- deekerno
+fn get_column_type(typ: TokenStream) -> (bool, TokenStream) {
+    let mut is_option_type = false;
+    let tokens: TokenStream = typ
+        .into_iter()
+        .filter(|token| {
+            if let TokenTree::Ident(ident) = token {
+                let is_option_token = ident.to_string() == "Option";
+                if is_option_token {
+                    is_option_type = true;
+                    return false;
+                }
+
+                // Keep ident tokens that are not "Option"
+                return true;
+            }
+            false
+        })
+        .collect::<TokenStream>();
+
+    (is_option_type, tokens)
 }

--- a/packages/fuel-indexer-macros/src/schema.rs
+++ b/packages/fuel-indexer-macros/src/schema.rs
@@ -132,21 +132,28 @@ fn process_type_def<'a>(
                 let (mut type_name, mut field_name, mut ext) =
                     process_field(types, field);
 
-                let type_name_str = type_name.to_string();
+                let (is_nullable, mut column_type_name) =
+                    get_column_type(type_name.clone());
 
-                if processed.contains(&type_name_str)
-                    && !primitives.contains(&type_name_str)
+                let mut column_type_name_str = column_type_name.to_string();
+
+                if processed.contains(&column_type_name_str)
+                    && !primitives.contains(&column_type_name_str)
                 {
                     (type_name, field_name, ext) =
                         process_fk_field(types, obj, field, types_map);
+                    column_type_name = type_name.clone();
+                    column_type_name_str = column_type_name.to_string();
                 }
 
-                processed.insert(type_name_str.clone());
+                processed.insert(column_type_name_str);
 
-                let decoder = if COPY_TYPES.contains(type_name_str.as_str()) {
-                    quote! { FtColumn::#type_name(self.#field_name.clone()), }
+                let decoder = quote! { FtColumn::#column_type_name(self.#field_name), };
+
+                let full_field_name = if is_nullable {
+                    quote! { Some(#field_name) }
                 } else {
-                    quote! { FtColumn::#type_name(self.#field_name), }
+                    quote! { #field_name }
                 };
 
                 block = quote! {
@@ -162,7 +169,7 @@ fn process_type_def<'a>(
 
                 construction = quote! {
                     #construction
-                    #field_name,
+                    #field_name: #full_field_name,
                 };
 
                 flattened = quote! {


### PR DESCRIPTION
## Changelog
- Support optional schema fields

## Notes
_This is an unfinished PR. I'm putting it up so that we may be able to pick it up in the future._

Currently, if a schema field is "optional" in the sense that it may or may not have data, we ask the user to store a dummy value instead (e.g. an empty string for `VARCHAR`-backed data types). This change would remove that requirement.

This PR is mostly finished. Struct definitions, constructors, and row extractors are properly created for both concrete and `Option` types. The last (and perhaps most unwieldy) task is to ensure that the `decoder` `TokenStream` for each field of a type allows for both the concrete type that corresponds to that column **and** the `Option` version of that type; this would ensure that each of the type's fields are properly serialized and stored in the database.