### PR TITLE
fix (fuel-indexer): Make sure that handle for old executor is aborted on redeploy

### DIFF
--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -419,7 +419,11 @@ impl IndexerService {
                         .expect("Failed to spawn executor from index asset registry")
                         .0;
 
-                        handles.borrow_mut().insert(manifest.uid(), handle);
+                        if let Some(old_handle) =
+                            handles.borrow_mut().insert(manifest.uid(), handle)
+                        {
+                            old_handle.abort();
+                        };
                     }
 
                     ServiceRequest::IndexStop(request) => {


### PR DESCRIPTION
## Changelog
- Ensures that currently running handle is aborted if index is redeployed

## Testing Plan
On master:

1. Start the indexer with an index.
2. Generate test data and verify that data is indexed.
3. `forc index deploy` with the same manifest.
4. `forc index stop` with the same manifest.
5. Generate test data again; one should see that the data is still being indexed.

On this branch:

1. Start the indexer with an index.
2. Generate test data and verify that data is indexed.
3. `forc index deploy` with the same manifest.
4. `forc index stop` with the same manifest.
5. Generate test data again; one should see that the data is **not** indexed.