### PR TITLE
fix (CI): Remove `--target` flag from `cargo install cross`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
         run: rustup override set stable-${{ matrix.job.target }}
       
       - name: Install cross
-        run: cargo install cross --target ${{ matrix.job.target }}
+        run: cargo install cross
 
       - name: Build fuel-indexer
         run: |


### PR DESCRIPTION
It looks like the target flag during the `cargo install cross` step is causing some issues: https://github.com/FuelLabs/fuel-indexer/actions/runs/3898047114/jobs/6657141825