### PR TITLE
fix (CI): Re-add cargo-install action to install `cross`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,10 @@ jobs:
         run: rustup override set stable-${{ matrix.job.target }}
       
       - name: Install cross
-        run: cargo install cross
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cross
+          cache-key: '${{ matrix.job.target }}'
 
       - name: Build fuel-indexer
         run: |


### PR DESCRIPTION
## Changelog
- Re-add cargo-install action to install `cross`; there seems to be release issues when using the built-in `cargo`