### PR TITLE
enhancement (fuel-indexer-tests): Add tests for start block

### DIFF
--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -339,7 +339,7 @@ pub mod test_web {
         web, App, Error, HttpResponse, HttpServer, Responder,
     };
     use async_std::sync::Arc;
-    use fuels::prelude::CallParameters;
+    use fuels::prelude::{CallParameters, Provider};
     use std::path::Path;
 
     async fn fuel_indexer_test_blocks(state: web::Data<Arc<AppState>>) -> impl Responder {
@@ -491,6 +491,13 @@ pub mod test_web {
         HttpResponse::Ok()
     }
 
+    async fn fuel_indexer_test_get_block_height() -> impl Responder {
+        let provider = Provider::connect(defaults::FUEL_NODE_ADDR).await.unwrap();
+        let block_height = provider.latest_block_height().await.unwrap();
+
+        HttpResponse::Ok().body(block_height.to_string())
+    }
+
     pub struct AppState {
         pub contract: FuelIndexerTest,
     }
@@ -525,6 +532,10 @@ pub mod test_web {
             .route("/messageout", web::post().to(fuel_indexer_test_messageout))
             .route("/callreturn", web::post().to(fuel_indexer_test_callreturn))
             .route("/multiarg", web::post().to(fuel_indexer_test_multiargs))
+            .route(
+                "/block_height",
+                web::get().to(fuel_indexer_test_get_block_height),
+            )
     }
 
     pub async fn server() -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -487,7 +487,7 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_postgres() {
 
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
-async fn test_index_not_triggered_when_start_block_not_met_postgres() {
+async fn test_index_respects_start_block_postgres() {
     let pool = postgres_connection_pool().await;
     let mut srvc = indexer_service_postgres().await;
 
@@ -503,7 +503,7 @@ async fn test_index_not_triggered_when_start_block_not_met_postgres() {
     let mut manifest: Manifest =
         serde_yaml::from_str(assets::FUEL_INDEXER_TEST_MANIFEST).expect("Bad yaml file.");
 
-    manifest.start_block = Some(block_height + 100);
+    manifest.start_block = Some(block_height + 2);
 
     update_test_manifest_asset_paths(&mut manifest);
 
@@ -529,7 +529,7 @@ async fn test_index_not_triggered_when_start_block_not_met_postgres() {
 
     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
-    let post_check = sqlx::query(&format!(
+    let first_check = sqlx::query(&format!(
         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
         block_height + 1,
     ))
@@ -537,5 +537,29 @@ async fn test_index_not_triggered_when_start_block_not_met_postgres() {
     .await
     .unwrap();
 
-    assert!(post_check.is_none());
+    assert!(first_check.is_none());
+
+    let req = test::TestRequest::post().uri("/ping").to_request();
+    let _ = app.call(req).await;
+
+    sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
+
+    let final_check = sqlx::query(&format!(
+        "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+        block_height + 2,
+    ))
+    .fetch_optional(&mut conn)
+    .await
+    .unwrap();
+
+    assert!(final_check.is_some());
+
+    let row = final_check.unwrap();
+
+    let id: String = row.get(0);
+    let height: i64 = row.get(1);
+    let timestamp: i64 = row.get(2);
+
+    assert_eq!(height, (block_height + 2) as i64);
+    assert!(timestamp > 0);
 }

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -511,11 +511,9 @@ async fn test_index_respects_start_block_postgres() {
         .await
         .expect("Failed to initialize indexer.");
 
-    sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
-
     let mut conn = pool.acquire().await.unwrap();
     let pre_check = sqlx::query(&format!(
-        "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+        "SELECT * FROM fuel_indexer_test.block where height = {}",
         block_height + 1,
     ))
     .fetch_optional(&mut conn)
@@ -530,7 +528,7 @@ async fn test_index_respects_start_block_postgres() {
     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
     let first_check = sqlx::query(&format!(
-        "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+        "SELECT * FROM fuel_indexer_test.block where height = {}",
         block_height + 1,
     ))
     .fetch_optional(&mut conn)
@@ -545,7 +543,7 @@ async fn test_index_respects_start_block_postgres() {
     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
     let final_check = sqlx::query(&format!(
-        "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+        "SELECT * FROM fuel_indexer_test.block where height = {}",
         block_height + 2,
     ))
     .fetch_optional(&mut conn)

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -484,3 +484,58 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_postgres() {
     assert!(block_height >= 1);
     assert!(time >= 1);
 }
+
+#[actix_web::test]
+#[cfg(all(feature = "e2e", feature = "postgres"))]
+async fn test_index_not_triggered_when_start_block_not_met_postgres() {
+    let pool = postgres_connection_pool().await;
+    let mut srvc = indexer_service_postgres().await;
+
+    let contract = connect_to_deployed_contract().await.unwrap();
+    let app = test::init_service(app(contract)).await;
+    let req = test::TestRequest::get().uri("/block_height").to_request();
+    let res = test::call_and_read_body(&app, req).await;
+    let block_height = String::from_utf8(res.to_vec())
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+
+    let mut manifest: Manifest =
+        serde_yaml::from_str(assets::FUEL_INDEXER_TEST_MANIFEST).expect("Bad yaml file.");
+
+    manifest.start_block = Some(block_height + 100);
+
+    update_test_manifest_asset_paths(&mut manifest);
+
+    srvc.register_index_from_manifest(manifest)
+        .await
+        .expect("Failed to initialize indexer.");
+
+    sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
+
+    let mut conn = pool.acquire().await.unwrap();
+    let pre_check = sqlx::query(&format!(
+        "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+        block_height + 1,
+    ))
+    .fetch_optional(&mut conn)
+    .await
+    .unwrap();
+
+    assert!(pre_check.is_none());
+
+    let req = test::TestRequest::post().uri("/ping").to_request();
+    let _ = app.call(req).await;
+
+    sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
+
+    let post_check = sqlx::query(&format!(
+        "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+        block_height + 1,
+    ))
+    .fetch_optional(&mut conn)
+    .await
+    .unwrap();
+
+    assert!(post_check.is_none());
+}

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_sqlite.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_sqlite.rs
@@ -479,7 +479,7 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
 
 // #[actix_web::test]
 // #[cfg(all(feature = "e2e", feature = "sqlite"))]
-// async fn test_index_not_triggered_when_start_block_not_met_sqlite() {
+// async fn test_index_respects_start_block_sqlite() {
 //     let pool = sqlite_connection_pool().await;
 //     let mut srvc = indexer_service_sqlite().await;
 
@@ -495,7 +495,7 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
 //     let mut manifest: Manifest =
 //         serde_yaml::from_str(assets::FUEL_INDEXER_TEST_MANIFEST).expect("Bad yaml file.");
 
-//     manifest.start_block = Some(block_height + 100);
+//     manifest.start_block = Some(block_height + 2);
 
 //     update_test_manifest_asset_paths(&mut manifest);
 
@@ -521,7 +521,7 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
 
 //     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
-//     let post_check = sqlx::query(&format!(
+//     let first_check = sqlx::query(&format!(
 //         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
 //         block_height + 1,
 //     ))
@@ -529,5 +529,29 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
 //     .await
 //     .unwrap();
 
-//     assert!(post_check.is_none());
+//     assert!(first_check.is_none());
+
+//     let req = test::TestRequest::post().uri("/ping").to_request();
+//     let _ = app.call(req).await;
+
+//     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
+
+//     let final_check = sqlx::query(&format!(
+//         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+//         block_height + 2,
+//     ))
+//     .fetch_optional(&mut conn)
+//     .await
+//     .unwrap();
+
+//     assert!(final_check.is_some());
+
+//     let row = final_check.unwrap();
+
+//     let id: String = row.get(0);
+//     let height: i64 = row.get(1);
+//     let timestamp: i64 = row.get(2);
+
+//     assert_eq!(height, (block_height + 2) as i64);
+//     assert!(timestamp > 0);
 // }

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_sqlite.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_sqlite.rs
@@ -503,11 +503,9 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
 //         .await
 //         .expect("Failed to initialize indexer.");
 
-//     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
-
 //     let mut conn = pool.acquire().await.unwrap();
 //     let pre_check = sqlx::query(&format!(
-//         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+//         "SELECT * FROM fuel_indexer_test.block where height = {}",
 //         block_height + 1,
 //     ))
 //     .fetch_optional(&mut conn)
@@ -522,7 +520,7 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
 //     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
 //     let first_check = sqlx::query(&format!(
-//         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+//         "SELECT * FROM fuel_indexer_test.block where height = {}",
 //         block_height + 1,
 //     ))
 //     .fetch_optional(&mut conn)
@@ -537,7 +535,7 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
 //     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
 //     let final_check = sqlx::query(&format!(
-//         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+//         "SELECT * FROM fuel_indexer_test.block where height = {}",
 //         block_height + 2,
 //     ))
 //     .fetch_optional(&mut conn)

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_sqlite.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_sqlite.rs
@@ -476,3 +476,58 @@ async fn test_index_metadata_is_saved_when_indexer_macro_is_called_sqlite() {
     assert!(block_height >= 1);
     assert!(time >= 1);
 }
+
+// #[actix_web::test]
+// #[cfg(all(feature = "e2e", feature = "sqlite"))]
+// async fn test_index_not_triggered_when_start_block_not_met_sqlite() {
+//     let pool = sqlite_connection_pool().await;
+//     let mut srvc = indexer_service_sqlite().await;
+
+//     let contract = connect_to_deployed_contract().await.unwrap();
+//     let app = test::init_service(app(contract)).await;
+//     let req = test::TestRequest::get().uri("/block_height").to_request();
+//     let res = test::call_and_read_body(&app, req).await;
+//     let block_height = String::from_utf8(res.to_vec())
+//         .unwrap()
+//         .parse::<u64>()
+//         .unwrap();
+
+//     let mut manifest: Manifest =
+//         serde_yaml::from_str(assets::FUEL_INDEXER_TEST_MANIFEST).expect("Bad yaml file.");
+
+//     manifest.start_block = Some(block_height + 100);
+
+//     update_test_manifest_asset_paths(&mut manifest);
+
+//     srvc.register_index_from_manifest(manifest)
+//         .await
+//         .expect("Failed to initialize indexer.");
+
+//     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
+
+//     let mut conn = pool.acquire().await.unwrap();
+//     let pre_check = sqlx::query(&format!(
+//         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+//         block_height + 1,
+//     ))
+//     .fetch_optional(&mut conn)
+//     .await
+//     .unwrap();
+
+//     assert!(pre_check.is_none());
+
+//     let req = test::TestRequest::post().uri("/ping").to_request();
+//     let _ = app.call(req).await;
+
+//     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
+
+//     let post_check = sqlx::query(&format!(
+//         "SELECT * FROM fuel_indexer_test.block where height = '{}'",
+//         block_height + 1,
+//     ))
+//     .fetch_optional(&mut conn)
+//     .await
+//     .unwrap();
+
+//     assert!(post_check.is_none());
+// }


### PR DESCRIPTION
Closes #272.

## Changelog
- Adds route to return current block height of test chain
- Adds start block tests for Postgres
- Adds start block tests for SQLite (currently commented out due to #432)

## Testing Plan
CI should pass with new tests.