### PR TITLE
chore: move indexer createion  to executors

### DIFF
--- a/packages/fuel-indexer-macros/src/schema.rs
+++ b/packages/fuel-indexer-macros/src/schema.rs
@@ -450,7 +450,7 @@ fn get_column_type(typ: TokenStream) -> (bool, TokenStream) {
         .into_iter()
         .filter(|token| {
             if let TokenTree::Ident(ident) = token {
-                let is_option_token = ident.to_string() == "Option";
+                let is_option_token = *ident == "Option";
                 if is_option_token {
                     is_option_type = true;
                     return false;

--- a/plugins/forc-index/src/commands/start.rs
+++ b/plugins/forc-index/src/commands/start.rs
@@ -19,9 +19,8 @@ pub struct Command {
     #[clap(long, help = "Whether to run the Fuel Indexer in the background.")]
     pub background: bool,
 
-    // The following options are taken from fuel_indexer_lib::config::IndexerArgs as 
+    // The following options are taken from fuel_indexer_lib::config::IndexerArgs as
     // we should pass all valid start options to the service
-    
     /// Path to the config file used to start the Fuel Indexer.
     #[clap(long, help = "Path to the config file used to start the Fuel Indexer.")]
     pub config: Option<PathBuf>,


### PR DESCRIPTION
### Description
- This is a cleanup PR to make executor creation more idiomatic by moving that functionality to each executor (`WasmExecutor`, `NativeExecutor`)

### Testing steps 
- [ ] N/A, CI should pass

### Changelog
- chore: move indexer createion to executors 