### PR TITLE
fix: various forc index fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -236,7 +236,7 @@ services:
       retries: 5
       start_period: 80s
   fuel-indexer:
-    image: ghcr.io/fuellabs/fuel-indexer:latest
+    image: ghcr.io/fuellabs/fuel-indexer:v0.2.0
     command: bash -c "sleep 2 && ./fuel-indexer --fuel-node-host node-beta-2.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0"
     ports:
       - "29987:29987"

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -177,7 +177,7 @@ services:
       retries: 5
       start_period: 80s
   fuel-indexer:
-    image: ghcr.io/fuellabs/fuel-indexer:latest
+    image: ghcr.io/fuellabs/fuel-indexer:v0.2.0
     command: bash -c "sleep 2 && ./fuel-indexer --fuel-node-host node-beta-2.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0"
     ports:
       - "29987:29987"

--- a/plugins/forc-index/src/utils/defaults.rs
+++ b/plugins/forc-index/src/utils/defaults.rs
@@ -121,11 +121,13 @@ type QueryRoot {
 type Block {
     id: ID!
     height: UInt8!
+    hash: Bytes32! @unique
 }
 
 type Tx {
     id: ID!
     block: Block!
+    hash: Bytes32! @unique
 }
 
 "#

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 5
       start_period: 80s
   fuel-indexer:
-    image: ghcr.io/fuellabs/fuel-indexer:latest
+    image: ghcr.io/fuellabs/fuel-indexer:v0.2.0
     command: bash -c "sleep 2 && ./fuel-indexer --fuel-node-host node-beta-2.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0"
     ports:
       - "29987:29987"


### PR DESCRIPTION
### Description
- This PR fixes a few small bugs
  - https://github.com/FuelLabs/fuel-indexer/issues/512
  - Uses the latest version tag `v0.2.0` instead of the `latest` tag for the `fuel-indexer` docker image (see https://github.com/FuelLabs/fuel-indexer/issues/513)
  - Adds `hash` to the objects in the GraphQL schema for `forc index new`

### Testing steps
- [ ] Build `forc index` and try some commands

`forc index check` should now show the proper emoji when an exec is not found:
```text
+--------+------------------------+------------------------------------------------------------------+
| Status |       Component        |                             Details                              |
+--------+------------------------+------------------------------------------------------------------+
|   ⛔️   | fuel-indexer binary    |  Can't locate fuel-indexer                                       |
+--------+------------------------+------------------------------------------------------------------+
|   ⛔️   | fuel-indexer service   |  Failed to detect service at Port(29987).                        |
+--------+------------------------+------------------------------------------------------------------+
|   ✅   | psql                   |  /usr/local/bin/psql                                             |
+--------+------------------------+------------------------------------------------------------------+
|   ✅   | sqlite                 |  /usr/bin/sqlite3                                                |
+--------+------------------------+------------------------------------------------------------------+
|   ✅   | fuel-core              |  /Users/rashad/.fuelup/bin/fuel-core                             |
+--------+------------------------+------------------------------------------------------------------+
|   ✅   | docker                 |  /usr/local/bin/docker                                           |
+--------+------------------------+------------------------------------------------------------------+
|   ✅   | fuelup                 |  /Users/rashad/.fuelup/bin/fuelup                                |
+--------+------------------------+------------------------------------------------------------------+
|   ⛔️   | wasm-snip              |  Can't locate wasm-snip                                          |
+--------+------------------------+------------------------------------------------------------------+
```

`forc index new` should now generate schema with `hash` included:

```graphql
schema {
    query: QueryRoot
}

type QueryRoot {
    block: Block
    tx: Tx
}

type Block {
    id: ID!
    height: UInt8!
    hash: Bytes32! @unique
}

type Tx {
    id: ID!
    block: Block!
    hash: Bytes32! @unique
}
```

### Changelog
- fix: various forc index fixes