### PR TITLE
fix: readd docker latest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,18 +276,12 @@ jobs:
   publish-docker-image:
     needs:
       - cancel-previous-runs
-    if: github.event_name == 'release' || github.event.action == 'published'
+    if: github.event_name == 'release' || github.event.action == 'published' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      # This is a way to make this job run after publish-crates even if it's skipped on master or pr branches
-      # https://stackoverflow.com/a/69252812/680811
-      - name: fail if any dependent jobs failed
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -326,7 +320,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify if Job Fails
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
### Description
- This PR adds back functionality that publishes a `latest` tag to the image registry for the `fuel-indexer` image
- This originally went missing in https://github.com/FuelLabs/fuel-indexer/pull/370 when we updated CI to not publish docker images on PRs (so external contributors could get their PRs merged)
- This PR updates current functionality to publish a `latest` tag on merges to master

### Testing steps
- [ ] N/A

### Changelog 
- fix: readd latest docker tag