### PR TITLE
chore: add `build.rs` files for docs.rs

### DIFF
--- a/packages/fuel-indexer-database/postgres/build.rs
+++ b/packages/fuel-indexer-database/postgres/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        std::env::set_var("SQLX_OFFLINE", "1");
+    }
+}

--- a/packages/fuel-indexer-database/sqlite/build.rs
+++ b/packages/fuel-indexer-database/sqlite/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        std::env::set_var("SQLX_OFFLINE", "1");
+    }
+}


### PR DESCRIPTION
## Changelog
- Add `build.rs` files to database crates that set the `SQLX_OFFLINE` to true if built for [docs.rs](https://docs.rs)

## Notes
In the [logs for the failing docs.rs builds](https://docs.rs/crate/fuel-indexer/0.2.0/builds/728327), you can see that it fails due to SQLX's compile-time query checking. Since users are unable to set environment variables through `package.metadata.docs.rs`, a `build.rs` file is used to check for the [docs.rs environment](https://github.com/rust-lang/docs.rs/issues/191#issuecomment-654213450) and set the necessary environment variables, which should enable the crate documentation to build successfully.