### PR TITLE
enhancement: build docker images for x86_64, ARM, and M1 archs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,9 @@ jobs:
           flavor: |
             latest=${{ github.ref == 'refs/heads/master' }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
 
       - name: Log in to the ghcr.io registry
         uses: docker/login-action@v1
@@ -316,6 +318,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
 
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v2


### PR DESCRIPTION
Closes #543.

## Changelog
Adds `platforms` flag to Docker image build and push steps. 64-bit platforms are covered; see https://github.com/containerd/containerd/blob/v1.4.3/platforms/database.go#L83 for how the platforms are decoded.

See https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images for more information.

## Testing Plan
There's not a great way to test this on your own computer as it's more for availability's sake. But I was able to build different architectures on my system by running the same commands that are being run in CI. Start by creating a `Dockerfile` with the following content:

```
FROM debian:bullseye-slim
CMD uname -p
```

Enable experimental features on Docker Desktop and build your image normally with the architecture auto-detection: `docker buildx build -t regular_build .`, and run the image with `docker run regular_build`. Then, build an image for a different platform by running `docker buildx build --platform linux/arm/v7 -t test_build .`, and then run the new image with `docker run test_build`. The returned architecture string should be different.