### PR TITLE
enhancement: add QEMU to virtualize build for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64'
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3


### PR DESCRIPTION
Closes #543.

## Changelog
- Add `setup-qemu-action` to CI to allow for virtualization of other architectures so we can build Docker images for said archs
-- [GitHub Actions only supports `x86_64` architecture natively](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).

## Testing Plan
A successful build can be found here in `ci-dummy-test` (note that it did not push the images due to that repo not having the necessary keys): https://github.com/FuelLabs/ci-dummy-test/actions/runs/4105997153/jobs/7083646660; one can see that the images built successfully, but were unable to be pushed. Compare it to the failed build on `fuel-indexer` here: https://github.com/FuelLabs/fuel-indexer/actions/runs/4105012619/jobs/7081289587.