### PR TITLE
ci: add check-rustc job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
   SQLX_OFFLINE: true
-  RUSTC_VERSION: 1.67
+  RUSTC_VERSION: 1.67.0
 
 jobs:
   cancel-previous-runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,19 +50,16 @@ jobs:
     steps:
       - name: Check rustc version
         run: |
+          # Check rustc version, verify if updated 
           RUSTC_VERSION=$(rustc --version | awk '{print $2}')
           if [ "$RUSTC_VERSION" != "stable" ]; then
-            echo "Updating Rustc to the latest version: the-latest-version"
+            echo "Updating Rustc to the latest version: stable"
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable 
-          fi 
-
-      - name: Verify Rustc installation
-      run: |
-        RUSTC_VERSION=$(rustc --version | awk '{print $2}')
-        if [ "$RUSTC_VERSION" != "stable" ]; then
-          echo "Error: Failed to install the latest Rustc version: $RUSTC_VERSION"
-          exit 1
-        fi
+            RUSTC_VERSION=$(rustc --version | awk '{print $2}')
+            if [ "$RUSTC_VERSION" != "stable" ]; then
+              echo "Error: Failed to install the latest Rustc version: $RUSTC_VERSION"
+              exit 1
+            fi
 
   get-workspace-members:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
       -cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
-      - name: Check Rustc version
       run: |
         RUSTC_VERSION=$(rustc --version | awk '{print $2}')
         if [ "$RUSTC_VERSION" != "stable" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,13 @@ jobs:
       -cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
-      run: |
-        RUSTC_VERSION=$(rustc --version | awk '{print $2}')
-        if [ "$RUSTC_VERSION" != "stable" ]; then
-          echo "Updating Rustc to the latest version: the-latest-version"
-          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable 
-        fi 
+      - name: Check rustc version
+        run: |
+          RUSTC_VERSION=$(rustc --version | awk '{print $2}')
+          if [ "$RUSTC_VERSION" != "stable" ]; then
+            echo "Updating Rustc to the latest version: the-latest-version"
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable 
+          fi 
 
   get-workspace-members:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,19 @@ jobs:
       - name: Run Cargo.toml linter
         run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
 
+  check-rustc:
+    needs:
+      -cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      name: Check Rustc version
+      run: |
+        RUSTC_VERSION=$(rustc --version | awk '{print $2}')
+        if [ "$RUSTC_VERSION" != "stable" ]; then
+          echo "Updating Rustc to the latest version: the-latest-version"
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable 
+        fi 
+
   get-workspace-members:
     needs:
       - cancel-previous-runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check rustc version
         run: |
-          # Check rustc version, log message if it doesn't match env 
+          # Check rustc version, log message and exit if it doesnt match env 
           CURRENT_RUSTC_VERSION=$(rustc --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           if [ "$CURRENT_RUSTC_VERSION" != "$RUSTC_VERSION" ]; then
             echo "Rustc version ($CURRENT_RUSTC_VERSION) does not match the required version ($RUSTC_VERSION)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,12 @@ jobs:
 
   check-rustc:
     needs:
-      -cancel-previous-runs
+      - cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - name: Check rustc version
         run: |
-          # Check rustc version, verify if updated 
+          # Check rustc version, install if not on latest stable
           RUSTC_VERSION=$(rustc --version | awk '{print $2}')
           if [ "$RUSTC_VERSION" != "stable" ]; then
             echo "Updating Rustc to the latest version: stable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,7 @@ jobs:
           if [ "$RUSTC_VERSION" != "stable" ]; then
             echo "Updating Rustc to the latest version: stable"
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable 
-            RUSTC_VERSION=$(rustc --version | awk '{print $2}')
-            if [ "$RUSTC_VERSION" != "stable" ]; then
-              echo "Error: Failed to install the latest Rustc version: $RUSTC_VERSION"
-              exit 1
-            fi
+          fi
 
   get-workspace-members:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       -cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
-      name: Check Rustc version
+      - name: Check Rustc version
       run: |
         RUSTC_VERSION=$(rustc --version | awk '{print $2}')
         if [ "$RUSTC_VERSION" != "stable" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable 
           fi 
 
+      - name: Verify Rustc installation
+      run: |
+        RUSTC_VERSION=$(rustc --version | awk '{print $2}')
+        if [ "$RUSTC_VERSION" != "stable" ]; then
+          echo "Error: Failed to install the latest Rustc version: $RUSTC_VERSION"
+          exit 1
+        fi
+
   get-workspace-members:
     needs:
       - cancel-previous-runs


### PR DESCRIPTION
Closes #530 
 
## Changelog 

• adds new job `check-rustc` to `ci.yml`

## Testing Plan
- The run command for the job executes as expected locally. The CI job has ran and successfully updated to `rustc` to 1.67.

## question 
- Is the rustc installation in the correct directory / environment for deployment?