### PR TITLE
enhancement: add default body limit to post routes

### DIFF
--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -123,6 +123,7 @@ impl GraphQlApi {
 
         let graph_route = Router::new()
             .route("/:namespace/:identifier", post(query_graph))
+            .layer(DefaultBodyLimit::max(10000))
             .layer(Extension(schema_manager.clone()))
             .layer(Extension(pool.clone()));
 

--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -4,7 +4,7 @@ use crate::uses::{
 };
 use async_std::sync::{Arc, RwLock};
 use axum::{
-    extract::{Extension, Json},
+    extract::{DefaultBodyLimit, Extension, Json},
     http::StatusCode,
     middleware,
     response::{IntoResponse, Response},
@@ -23,6 +23,7 @@ use thiserror::Error;
 use tokio::sync::mpsc::{error::SendError, Sender};
 use tower_http::{
     cors::{Any, CorsLayer},
+    limit::RequestBodyLimitLayer,
     trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
     LatencyUnit,
 };
@@ -127,6 +128,7 @@ impl GraphQlApi {
 
         let index_routes = Router::new()
             .route("/:namespace/:identifier", post(register_index_assets))
+            .layer(DefaultBodyLimit::max(10000))
             .route_layer(middleware::from_fn(authorize_middleware))
             .layer(Extension(tx.clone()))
             .layer(Extension(schema_manager))


### PR DESCRIPTION
Closes #448 

## Changelog 
Adds `DefaultBodyLimit::max(10000)` to post routes.

## Testing 
We could add an intergration test for this, but that would mean adding a large Wasm file to the repo. I could also smoke test manually using Postman. If postman (or something similar) is used to sanity test the api, is there a collection that already exists?