### PR TITLE
enhancement: forc index relative paths

### DIFF
--- a/plugins/forc-index/src/commands/init.rs
+++ b/plugins/forc-index/src/commands/init.rs
@@ -19,16 +19,17 @@ pub struct Command {
     )]
     pub path: Option<PathBuf>,
 
-    /// Name of the index namespace
+    /// Namespace in which index belongs.
     #[clap(long, help = "Namespace in which index belongs.")]
     pub namespace: String,
 
-    /// Whether to initialize an index with native execution enabled
-    #[clap(
-        long,
-        help = "Whether to initialize an index with native execution enabled."
-    )]
+    /// Initialize an index with native execution enabled.
+    #[clap(long, help = "Initialize an index with native execution enabled.")]
     pub native: bool,
+
+    /// Resolve index asset filepaths using absolute paths.
+    #[clap(long, help = "Resolve index asset filepaths using absolute paths.")]
+    pub absolute_paths: bool,
 }
 
 pub fn exec(command: Command) -> Result<()> {

--- a/plugins/forc-index/src/commands/new.rs
+++ b/plugins/forc-index/src/commands/new.rs
@@ -23,6 +23,10 @@ pub struct Command {
         help = "Whether to initialize an index with native execution enabled."
     )]
     pub native: bool,
+
+    /// Resolve index asset filepaths using absolute paths.
+    #[clap(long, help = "Resolve index asset filepaths using absolute paths.")]
+    pub absolute_paths: bool,
 }
 
 pub fn exec(command: Command) -> Result<()> {

--- a/plugins/forc-index/src/ops/forc_index_init.rs
+++ b/plugins/forc-index/src/ops/forc_index_init.rs
@@ -1,6 +1,9 @@
 use crate::{
     cli::InitCommand,
-    utils::{dasherize_to_underscore, defaults},
+    utils::{
+        dasherize_to_underscore, default_manifest_filename, default_schema_filename,
+        defaults,
+    },
 };
 use anyhow::Context;
 use forc_util::validate_name;
@@ -66,7 +69,15 @@ An easy-to-use, flexible indexing service built to go fast. 🚗💨
 }
 
 pub fn init(command: InitCommand) -> anyhow::Result<()> {
-    let project_dir = match &command.path {
+    let InitCommand {
+        name,
+        path,
+        namespace,
+        native,
+        absolute_paths,
+    } = command;
+
+    let project_dir = match &path {
         Some(p) => PathBuf::from(p),
         None => std::env::current_dir()
             .context("❌ Failed to get current directory for forc index init.")?,
@@ -91,7 +102,7 @@ pub fn init(command: InitCommand) -> anyhow::Result<()> {
         project_dir.canonicalize()?.display()
     );
 
-    let project_name = match command.name {
+    let project_name = match name {
         Some(name) => name,
         None => project_dir
             .file_stem()
@@ -108,7 +119,7 @@ pub fn init(command: InitCommand) -> anyhow::Result<()> {
     // Make a new directory for the project
     fs::create_dir_all(Path::new(&project_dir).join("src"))?;
 
-    let default_toml = if command.native {
+    let default_toml = if native {
         defaults::default_native_index_cargo_toml(&project_name)
     } else {
         defaults::default_index_cargo_toml(&project_name)
@@ -121,20 +132,27 @@ pub fn init(command: InitCommand) -> anyhow::Result<()> {
     )
     .unwrap();
 
+    let proj_abspath = if absolute_paths {
+        Some(fs::canonicalize(Path::new(&project_dir))?)
+    } else {
+        None
+    };
+
+    let manifest_filename = default_manifest_filename(&project_name);
+    let schema_filename = default_schema_filename(&project_name);
+
     // Write index manifest
-    let manifest_filename = format!("{project_name}.manifest.yaml",);
     fs::write(
         Path::new(&project_dir).join(&manifest_filename),
         defaults::default_index_manifest(
-            &command.namespace,
+            &namespace,
+            &schema_filename,
             &project_name,
-            fs::canonicalize(Path::new(&project_dir))?.to_str().unwrap(),
+            proj_abspath.as_ref(),
         ),
-    )
-    .unwrap();
+    )?;
 
     // Write index schema
-    let schema_filename = format!("{}.schema.graphql", &project_name);
     fs::create_dir_all(Path::new(&project_dir).join("schema"))?;
     fs::write(
         Path::new(&project_dir).join("schema").join(schema_filename),
@@ -150,13 +168,13 @@ pub fn init(command: InitCommand) -> anyhow::Result<()> {
         defaults::default_index_lib(
             &project_name,
             &manifest_filename,
-            fs::canonicalize(Path::new(&project_dir))?.to_str().unwrap(),
+            proj_abspath.as_ref(),
         ),
     )
     .unwrap();
 
     // Write cargo config with WASM target
-    if !command.native {
+    if !native {
         fs::create_dir_all(
             Path::new(&project_dir).join(defaults::CARGO_CONFIG_DIR_NAME),
         )?;

--- a/plugins/forc-index/src/ops/forc_index_new.rs
+++ b/plugins/forc-index/src/ops/forc_index_new.rs
@@ -8,6 +8,7 @@ pub fn init(command: NewCommand) -> anyhow::Result<()> {
         native,
         namespace,
         path,
+        absolute_paths,
     } = command;
 
     let dir_path = Path::new(&path);
@@ -26,6 +27,7 @@ pub fn init(command: NewCommand) -> anyhow::Result<()> {
         name,
         native,
         namespace,
+        absolute_paths,
         path: Some(dir_path.to_path_buf()),
     });
 

--- a/plugins/forc-index/src/utils/mod.rs
+++ b/plugins/forc-index/src/utils/mod.rs
@@ -68,3 +68,11 @@ pub(crate) fn project_dir_info(
     let manifest = root.join(manifest.unwrap_or(&mani_name));
     Ok((root, manifest, name))
 }
+
+pub(crate) fn default_manifest_filename(name: &str) -> String {
+    format!("{name}.manifest.yaml")
+}
+
+pub(crate) fn default_schema_filename(name: &str) -> String {
+    format!("{name}.schema.graphql")
+}


### PR DESCRIPTION
### Description
- This PR defaults `forc index` to using relative paths for assets
- Also adds an `--absolute-paths` flag to `init` and `new` so the user can use absolute paths if they'd like

### Testing steps
- [ ] Rebuild the plugin  `cargo build --release -p forc-index && cp target/release/forc-index ~/.fuelup/bin`
- [ ] Test default behavior `forc-index new foo --namespace bar && cd foo && cat/foo.manifest.yaml`
- [ ] Test absolute path behavior `forc-index new foo --namespace bar --absolute-paths && cd foo && cat foo.manifest.yaml`

### Changelog 
- enhancement: forc index relative paths