### PR TITLE
docs: update book + readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -174,7 +174,7 @@ forc index postgres create postgres --persistent
 ```text
 Downloading, unpacking, and bootstrapping database.
 ▹▸▹▹▹ ⏱  Setting up database...
-                                                                                                                                                                                                                           The files belonging to this database system will be owned by user "rashad".
+
 This user must also own the server process.
 
 The database cluster will be initialized with locale "en_US.UTF-8".
@@ -234,7 +234,7 @@ forc index postgres start postgres
 ```
 
 ```text
-Using database directory at "/Users/rashad/.fuel/idx/postgres"
+Using database directory at "/Users/rashad/.fuel/indexer/postgres"
 
 Starting PostgreSQL.
 
@@ -262,7 +262,7 @@ select
 2023-02-09 16:11:37.460 EST [86881] LOG:  could not receive data from client: Connection reset by peer
 ```
 
-> You can `Ctrl+C` to exit the `forc index postgres start postgres` process, and your database should still be running in the background.
+> You can `Ctrl+C` to exit the `forc index postgres start` process, and your database should still be running in the background.
 
 ### 2.3 Creating a new index
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,8 +3,6 @@
 
 [The Fuel Indexer](./the-fuel-indexer.md)
 
-[Quickstart](./quickstart/index.md)
-
 # Getting Started
 
 - [Dependencies](./getting-started/dependencies/fuelup.md)
@@ -12,6 +10,7 @@
   - [Database](./getting-started/dependencies/database.md)
   - [WASM](./getting-started/dependencies/wasm.md)
   - [Docker](./getting-started/dependencies/docker.md)
+- [Quickstart](./quickstart/index.md)
 - [Starting the Fuel Indexer](./getting-started/starting-the-fuel-indexer.md)
 
 # Examples

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -1,2 +1,2 @@
 <!-- markdownlint-disable MD041 -->
-{{#include ../../README.md:80:363}}
+{{#include ../../README.md:80:413}}


### PR DESCRIPTION
- Moves Quickstart below Dependencies in the book
- bugfix: Updates the book's README inclusion to include the now longer README
- remove long line from postgres create output