### PR TITLE
ci: add check-is-release-branch step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   REGISTRY: ghcr.io
   SQLX_OFFLINE: true
   RUSTC_VERSION: 1.67.0
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
 
 jobs:
   cancel-previous-runs:
@@ -273,12 +274,29 @@ jobs:
       - name: Stop testing components
         run: kill -9 $(lsof -ti:4000)
 
-  check-forc-index:
+  check-is-release-branch:
     if: github.event_name != 'release' && github.event.action != 'published'
     needs:
       - cancel-previous-runs
       - cargo-toml-fmt-check
       - check-rustc
+    runs-on: ubuntu-latest
+    outputs: 
+      is_release_branch: ${{ steps.check-release-branch.outputs.is_release_branch }}
+    steps:
+      - name: Check for Release Branch
+        id: check-release-branch
+        run: |
+          if [[ ${BRANCH_NAME} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "is_release_branch=true" >> $GITHUB_OUTPUT
+          else
+            echo "Not a release branch ^(^.^)^"
+          fi
+
+  check-forc-index:
+    if: needs.check-is-release-branch.outputs.is_release_branch != 'true'
+    needs:
+      - check-is-release-branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Description
- Add a check on CI to no build the plugin if it's a release branch
- You can see that this step works in the positive case, on this test branch's action https://github.com/FuelLabs/fuel-indexer/actions/runs/4204895463/jobs/7296222119
- You can see that this step works in the negative case, on this PR