### PR TITLE
fix: update docker deps

### DIFF
--- a/ci/Dockerfile.aarch64-unknown-linux-gnu-clang
+++ b/ci/Dockerfile.aarch64-unknown-linux-gnu-clang
@@ -14,6 +14,7 @@ RUN dpkg --add-architecture arm64 && \
     git \
     libclang-8-dev \
     libpq-dev \
+    libssl-dev:arm64 \
     lld \
     llvm \
     pkg-config \

--- a/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
+++ b/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
@@ -13,13 +13,10 @@ RUN apt-get update && \
     git \
     libclang-dev \
     libpq-dev \
+    libssl-dev \
     lld \
     llvm \
     pkg-config \
     tzdata \
     wget \
     && apt-get clean
-
-# https://stackoverflow.com/a/72633324
-RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -50,10 +50,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     && apt-get autoremove -y \
     && apt-get clean -y
 
-# https://stackoverflow.com/a/72633324
-RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-
 COPY --from=builder /build/target/release/fuel-indexer .
 COPY --from=builder /build/target/release/fuel-indexer.d .
 


### PR DESCRIPTION
### Description
- [`v0.3.0` release broke](https://github.com/FuelLabs/fuel-indexer/actions/runs/4206237935) due to non-existent deps
  - I'm thinking the base image was changed? But image link in Dockerfile is a 404
- This PR updates Docker deps for `libssl`

### Testing steps 
- [ ] Ensure cross builds work
  - [ ] `cd ci/bash build_images.sh && cd ..`
  - [ ] `cross build --profile=release --target x86_64-unknown-linux-gnu -p fuel-indexer -p fuel-indexer-api-server -p forc-index`
  - [ ] `cross build --profile=release --target aarch64-unknown-linux-gnu -p fuel-indexer -p fuel-indexer-api-server -p forc-index`
- [ ] Ensure main Dockerfile works `docker build -t fuel-indexer/local:latest -f deployment/Dockerfile .`

### Changelog
- fix: update docker deps