### PR TITLE
ci test: remove workspace flag from cargo-verifications matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,15 +171,15 @@ jobs:
           - command: clippy
             args: --all-features --all-targets
           - command: check
-            args: --all-features --locked --workspace --all-targets
+            args: --all-features --locked --all-targets
           - command: build
-            args: --locked --workspace --all-features --all-targets
+            args: --locked --all-features --all-targets
           - command: test
-            args: --locked --workspace
+            args: --locked
           - command: test
-            args: --locked --all-targets --no-default-features --workspace
+            args: --locked --all-targets --no-default-features
           - command: test
-            args: --locked --all-targets --features postgres --workspace
+            args: --locked --all-targets --features postgres
 
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45


### PR DESCRIPTION
It looks like we're running the full test suite as many times as there are packages. 🤔 testing some adjustments to see what the actions output is.