### PR TITLE
chore: ensure proper testing and analysis of packages on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,21 +165,13 @@ jobs:
     strategy:
       matrix:
         package: ${{ fromJSON(needs.get-workspace-members.outputs.members) }}
+        command: [clippy]
+        args: [--all-targets]
         include:
           - command: fmt
             args: --all --verbose -- --check
-          - command: clippy
-            args: --all-features --all-targets
-          - command: check
-            args: --all-features --locked --workspace --all-targets
-          - command: build
-            args: --locked --workspace --all-features --all-targets
           - command: test
-            args: --locked --workspace
-          - command: test
-            args: --locked --all-targets --no-default-features --workspace
-          - command: test
-            args: --locked --all-targets --features postgres --workspace
+            args: --locked --all-targets --all-features --workspace
 
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
@@ -192,11 +184,15 @@ jobs:
           toolchain: stable
       - run: cargo install sqlx-cli
       - run: bash scripts/run_migrations.bash
-      - name: ${{ matrix.command }} ${{ matrix.args }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: ${{ matrix.command }}
-          args: ${{ matrix.args }}
+
+      - name: Cargo Workspace Checks
+        if: ${{ !matrix.package }}
+        run: cargo ${{ matrix.command }} ${{ matrix.args }}
+
+      - name: Cargo Package Checks
+        if: ${{ matrix.package }}
+        run: cargo ${{ matrix.command }} -p ${{ matrix.package }} ${{ matrix.args }}
+
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v2
         if: always() && github.ref == 'refs/heads/master'
@@ -209,10 +205,9 @@ jobs:
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
-          RUSTFLAGS: -D warnings
 
   # TODO: https://github.com/FuelLabs/fuel-indexer/issues/269
-  cargo-test-workspace-all-features:
+  cargo-test-e2e:
     if: github.event_name != 'release' && github.event.action != 'published'
     needs:
       - cancel-previous-runs
@@ -337,11 +332,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: 'arm64'
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,24 +204,14 @@ jobs:
       - cargo-toml-fmt-check
       - check-rustc
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_PASSWORD: my-secret
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-      - name: cargo clippy --all-targets
-        run: cargo clippy --all-targets
+      - name: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features
 
   cargo-fmt-check:
     if: github.event_name != 'release' && github.event.action != 'published'
@@ -230,16 +220,6 @@ jobs:
       - cargo-toml-fmt-check
       - check-rustc
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_PASSWORD: my-secret
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,14 +164,15 @@ jobs:
     if: github.event_name != 'release' && github.event.action != 'published'
     strategy:
       matrix:
-        # package: ${{ fromJSON(needs.get-workspace-members.outputs.members) }}
         include:
           - command: clippy
             args: --all-targets
           - command: fmt
             args: --all --verbose -- --check
+          # Excluding fuel-indexer-tests package as the SDK macros cause
+          # failing tests; the package is properly tested in the next job.
           - command: test
-            args: --locked --all-targets --workspace
+            args: --locked --all-targets --workspace --exclude fuel-indexer-tests
 
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
@@ -206,7 +207,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
-  e2e-tests:
+  e2e-and-integration-tests:
     if: github.event_name != 'release' && github.event.action != 'published'
     needs:
       - cancel-previous-runs
@@ -249,7 +250,7 @@ jobs:
             cp simple_wasm.wasm packages/fuel-indexer-tests/assets/
 
       - name: Run E2E and integration tests
-        run: cargo test --features e2e,postgres -p fuel-indexer-tests -- --test-threads=1
+        run: cargo test --locked --all-targets --features e2e,postgres -p fuel-indexer-tests -- --test-threads=1
 
   check-is-release-branch:
     if: github.event_name != 'release' && github.event.action != 'published' && github.ref != 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,14 +164,14 @@ jobs:
     if: github.event_name != 'release' && github.event.action != 'published'
     strategy:
       matrix:
-        package: ${{ fromJSON(needs.get-workspace-members.outputs.members) }}
-        command: [clippy]
-        args: [--all-targets]
+        # package: ${{ fromJSON(needs.get-workspace-members.outputs.members) }}
         include:
+          - command: clippy
+            args: --all-targets
           - command: fmt
             args: --all --verbose -- --check
           - command: test
-            args: --locked --all-targets --all-features --workspace
+            args: --locked --all-targets --workspace
 
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
@@ -206,8 +206,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
-  # TODO: https://github.com/FuelLabs/fuel-indexer/issues/269
-  cargo-test-e2e:
+  e2e-tests:
     if: github.event_name != 'release' && github.event.action != 'published'
     needs:
       - cancel-previous-runs
@@ -249,25 +248,8 @@ jobs:
             bash scripts/stripper.bash simple_wasm.wasm && \
             cp simple_wasm.wasm packages/fuel-indexer-tests/assets/
 
-      - name: Build fuel-node
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p fuel-node --locked
-        env:
-          RUSTFLAGS: '-D warnings'
-
-      - name: Start test web components
-        run: |
-          CARGO_MANIFEST_DIR=$PWD/packages/fuel-indexer-tests/ target/debug/fuel-node \
-            --chain-config packages/fuel-indexer-tests/assets/test-chain-config.json \
-            --contract-bin packages/fuel-indexer-tests/contracts/fuel-indexer-test/out/debug/fuel-indexer-test.bin &
-
-      - uses: actions-rs/cargo@v1
-      - name: Cargo e2e tests
-        run: bash packages/fuel-indexer-tests/scripts/e2e.bash
-      - name: Stop testing components
-        run: kill -9 $(lsof -ti:4000)
+      - name: Run E2E and integration tests
+        run: cargo test --features e2e,postgres -p fuel-indexer-tests -- --test-threads=1
 
   check-is-release-branch:
     if: github.event_name != 'release' && github.event.action != 'published' && github.ref != 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
   mdbook-build:
     needs:
       - cancel-previous-runs
-      - check-rustc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -114,6 +113,7 @@ jobs:
     needs:
       - cancel-previous-runs
       - cargo-toml-fmt-check
+      - check-rustc
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -164,15 +164,9 @@ jobs:
     if: github.event_name != 'release' && github.event.action != 'published'
     strategy:
       matrix:
-        include:
-          - command: clippy
-            args: --all-targets
-          - command: fmt
-            args: --all --verbose -- --check
-          # Excluding fuel-indexer-tests package as the SDK macros cause
-          # failing tests; the package is properly tested in the next job.
-          - command: test
-            args: --locked --all-targets --workspace --exclude fuel-indexer-tests
+        command: [build]
+        args: [--locked --all-features --all-targets]
+        package: ${{ fromJSON(needs.get-workspace-members.outputs.members) }}
 
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
@@ -186,11 +180,7 @@ jobs:
       - run: cargo install sqlx-cli
       - run: bash scripts/run_migrations.bash
 
-      - name: Cargo Workspace Checks
-        if: ${{ !matrix.package }}
-        run: cargo ${{ matrix.command }} ${{ matrix.args }}
-
-      - name: Cargo Package Checks
+      - name: cargo ${{ matrix.command }} -p ${{ matrix.package }} ${{ matrix.args }}
         if: ${{ matrix.package }}
         run: cargo ${{ matrix.command }} -p ${{ matrix.package }} ${{ matrix.args }}
 
@@ -207,11 +197,90 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
-  e2e-and-integration-tests:
+  cargo-clippy:
     if: github.event_name != 'release' && github.event.action != 'published'
     needs:
       - cancel-previous-runs
-      - get-workspace-members
+      - cargo-toml-fmt-check
+      - check-rustc
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_PASSWORD: my-secret
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: cargo clippy --all-targets
+        run: cargo clippy --all-targets
+
+  cargo-fmt-check:
+    if: github.event_name != 'release' && github.event.action != 'published'
+    needs:
+      - cancel-previous-runs
+      - cargo-toml-fmt-check
+      - check-rustc
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_PASSWORD: my-secret
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: cargo fmt --all --verbose -- --check
+        run: cargo fmt --all --verbose -- --check
+
+  cargo-test-unit-tests:
+    if: github.event_name != 'release' && github.event.action != 'published'
+    needs:
+      - cancel-previous-runs
+      - cargo-toml-fmt-check
+      - check-rustc
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_PASSWORD: my-secret
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests
+        run: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests
+
+  cargo-test-e2e-and-integration-tests:
+    if: github.event_name != 'release' && github.event.action != 'published'
+    needs:
+      - cancel-previous-runs
+      - cargo-toml-fmt-check
+      - check-rustc
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/packages/fuel-indexer-macros/src/indexer.rs
+++ b/packages/fuel-indexer-macros/src/indexer.rs
@@ -681,13 +681,13 @@ pub fn prefix_abi_and_schema_paths(
 
 pub fn get_abi_tokens(
     namespace: &str,
-    abi: &String,
+    abi: &str,
     is_native: bool,
 ) -> proc_macro2::TokenStream {
     match Abigen::generate(
         vec![AbigenTarget {
             name: namespace.to_string(),
-            abi: abi.clone(),
+            abi: abi.to_owned(),
             program_type: ProgramType::Contract,
         }],
         !is_native,

--- a/packages/fuel-indexer-plugin/Cargo.toml
+++ b/packages/fuel-indexer-plugin/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ['rlib']
 anyhow = { version = "1.0", default-features = false, optional = true }
 async-trait = { version = "0.1", optional = true }
 bincode = { version = "1.3.3", optional = true }
-fuel-indexer = { version = "0.4", path = "../fuel-indexer", default-features = false,  optional = true }
+fuel-indexer = { version = "0.4", path = "../fuel-indexer", default-features = false, features = ["api-server"], optional = true }
 fuel-indexer-api-server = { version = "0.4", path = "../fuel-indexer-api-server", default-features = false, optional = true }
 fuel-indexer-database = { version = "0.4", path = "../fuel-indexer-database", default-features = false, optional = true }
 fuel-indexer-lib = { version = "0.4", path = "../fuel-indexer-lib", default-features = false }

--- a/packages/fuel-indexer-tests/components/fuel-node/src/main.rs
+++ b/packages/fuel-indexer-tests/components/fuel-node/src/main.rs
@@ -50,9 +50,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .host
         .unwrap_or_else(|| defaults::FUEL_NODE_ADDR.to_string());
 
-    let _contract_id = setup_test_fuel_node(chain_config, Some(contract_bin), Some(host))
+    setup_test_fuel_node(chain_config, Some(contract_bin), Some(host))
         .await
         .unwrap();
+
     std::thread::sleep(defaults::SLEEP);
 
     Ok(())

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -284,7 +284,7 @@ pub async fn connect_to_deployed_contract(
 
     let provider = Provider::connect(defaults::FUEL_NODE_ADDR).await.unwrap();
 
-    wallet.set_provider(provider.clone());
+    wallet.set_provider(provider);
 
     println!(
         "Wallet({}) keystore at: {}",
@@ -298,7 +298,7 @@ pub async fn connect_to_deployed_contract(
 
     let contract = FuelIndexerTest::new(contract_id.clone(), wallet);
 
-    println!("Using contract at {}", contract_id.to_string());
+    println!("Using contract at {}", contract_id);
 
     Ok(contract)
 }

--- a/packages/fuel-indexer-tests/src/lib.rs
+++ b/packages/fuel-indexer-tests/src/lib.rs
@@ -35,7 +35,7 @@ pub mod defaults {
     // to return the contract ID won't give us the ID until the task is completed.
     pub const CURRENT_TEST_CONTRACT_ID_STR: &str =
         "fuel1u47xjlucyjf2hkn874675fgdfue0vmyne72ucch74jcgu457rluq236j5e";
-    pub const MAX_BODY: usize = 1024 * 1024 * 5; // 5MB in bytes
+    pub const MAX_BODY: usize = 5242880; // 5MB in bytes
 }
 
 pub mod utils {

--- a/packages/fuel-indexer-tests/src/lib.rs
+++ b/packages/fuel-indexer-tests/src/lib.rs
@@ -35,7 +35,7 @@ pub mod defaults {
     // to return the contract ID won't give us the ID until the task is completed.
     pub const CURRENT_TEST_CONTRACT_ID_STR: &str =
         "fuel1u47xjlucyjf2hkn874675fgdfue0vmyne72ucch74jcgu457rluq236j5e";
-    pub const MAX_BODY: usize = 5242880; // 5MB in bytes
+    pub const MAX_BODY: usize = 1024 * 1024 * 5; // 5MB in bytes
 }
 
 pub mod utils {

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -152,15 +152,6 @@ async fn test_can_trigger_and_index_blocks_and_transactions_postgres() {
     let fuel_node_handle = tokio::spawn(setup_example_test_fuel_node());
 
     let pool = postgres_connection_pool().await;
-    let mut conn = pool.acquire().await.unwrap();
-    let result = sqlx::query("DELETE FROM fuel_indexer_test_index1.tx")
-        .execute(&mut conn)
-        .await
-        .unwrap();
-    let result = sqlx::query("DELETE FROM fuel_indexer_test_index1.block")
-        .execute(&mut conn)
-        .await
-        .unwrap();
 
     let mut srvc = indexer_service_postgres().await;
     let mut manifest: Manifest =
@@ -174,23 +165,32 @@ async fn test_can_trigger_and_index_blocks_and_transactions_postgres() {
 
     let contract = connect_to_deployed_contract().await.unwrap();
     let app = test::init_service(app(contract)).await;
+    let req = test::TestRequest::get().uri("/block_height").to_request();
+    let res = test::call_and_read_body(&app, req).await;
+    let block_height = String::from_utf8(res.to_vec())
+        .unwrap()
+        .parse::<i64>()
+        .unwrap();
+
     let req = test::TestRequest::post().uri("/block").to_request();
     let _ = app.call(req).await;
     fuel_node_handle.abort();
 
     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
-    let row =
-        sqlx::query("SELECT * FROM fuel_indexer_test_index1.block WHERE height = 1")
-            .fetch_one(&mut conn)
-            .await
-            .unwrap();
+    let mut conn = pool.acquire().await.unwrap();
+    let row = sqlx::query(
+        "SELECT * FROM fuel_indexer_test_index1.block ORDER BY timestamp DESC LIMIT 1",
+    )
+    .fetch_one(&mut conn)
+    .await
+    .unwrap();
 
     let id: i64 = row.get(0);
     let height: i64 = row.get(1);
     let timestamp: i64 = row.get(2);
 
-    assert_eq!(height, 1);
+    assert_eq!(height, block_height + 1);
     assert!(timestamp > 0);
 
     let row = sqlx::query(&format!(

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -152,6 +152,16 @@ async fn test_can_trigger_and_index_blocks_and_transactions_postgres() {
     let fuel_node_handle = tokio::spawn(setup_example_test_fuel_node());
 
     let pool = postgres_connection_pool().await;
+    let mut conn = pool.acquire().await.unwrap();
+    let result = sqlx::query("DELETE FROM fuel_indexer_test_index1.tx")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    let result = sqlx::query("DELETE FROM fuel_indexer_test_index1.block")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
     let mut srvc = indexer_service_postgres().await;
     let mut manifest: Manifest =
         serde_yaml::from_str(assets::FUEL_INDEXER_TEST_MANIFEST).expect("Bad yaml file.");
@@ -170,7 +180,6 @@ async fn test_can_trigger_and_index_blocks_and_transactions_postgres() {
 
     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
 
-    let mut conn = pool.acquire().await.unwrap();
     let row =
         sqlx::query("SELECT * FROM fuel_indexer_test_index1.block WHERE height = 1")
             .fetch_one(&mut conn)

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -152,7 +152,6 @@ async fn test_can_trigger_and_index_blocks_and_transactions_postgres() {
     let fuel_node_handle = tokio::spawn(setup_example_test_fuel_node());
 
     let pool = postgres_connection_pool().await;
-
     let mut srvc = indexer_service_postgres().await;
     let mut manifest: Manifest =
         serde_yaml::from_str(assets::FUEL_INDEXER_TEST_MANIFEST).expect("Bad yaml file.");


### PR DESCRIPTION
## Changelog
- Adjust CI so that tests and analyses are properly run
-- `cargo fmt --all --check` and `cargo clippy --all-targets` are run across the entire workspace
-- `cargo test --locked --workspace --all-targets --exclude fuel-indexer-tests`: this runs tests through the entire workspace excluding `fuel-indexer-tests`; this is because this command also tests doc-tests, and the path resolution in the use of the `abigen!` macro in `fuel-indexer-tests` causes the tests to fail. Workarounds described in the `cargo test` documentation did not work; this may be due to the structure of the package.
-- Because of the above issue, `cargo test --locked --all-targets --features e2e,postgres -p fuel-indexer-tests` is run in order to test E2E and integration functionality while avoiding triggering the doc-tests 
- Remove QEMU setup step as it's currently unused (and unlikely to be used at the moment due to its slowness in the build process)
- Small clippy and format fixes done to satisfy the new CI run
- Adjust a few tests to be more robust against faulty data

## Motivation
In our current CI workflow, we have a step in which we run some [tests and analyses](https://github.com/FuelLabs/fuel-indexer/blob/master/.github/workflows/ci.yml#L165) of the individual packages. However, if you look at any of the actions, it seems that we're only actually running one command (`test --locked --all-targets --features postgres --workspace`); also, it's being run as many times as we have packages. You can look at the [workflow run from the SDK upgrade PR](https://github.com/FuelLabs/fuel-indexer/actions/runs/4212175047/jobs/7311025204) as an example; click each package and you'll see that the same command is being run for each package. I ran some tests over on the ci-dummy-test repo, and [early results were promising](https://github.com/FuelLabs/ci-dummy-test/actions/runs/4217849061). Thus, I modeled our new process after both `fuel-core` and `fuels-rs`.

## Notes
- We should eventually have a different section for just the examples and run `cargo build --target wasm32-unknown-unknown` on each.
- The new workflow seems to take around the same time as our current one. We have other places that we can optimize the testing, but this is a good start.