### PR TITLE
fix: remove tmp ci hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,7 @@ jobs:
         run: kill -9 $(lsof -ti:4000)
 
   check-is-release-branch:
-    # if: github.event_name != 'release' && github.event.action != 'published' && github.ref != 'refs/heads/master'
-    if: false
+    if: github.event_name != 'release' && github.event.action != 'published' && github.ref != 'refs/heads/master'
     needs:
       - cancel-previous-runs
       - cargo-toml-fmt-check

--- a/examples/block-explorer/explorer-index/explorer_index.manifest.yaml
+++ b/examples/block-explorer/explorer-index/explorer_index.manifest.yaml
@@ -4,7 +4,7 @@ abi: ~
 identifier: explorer_index
 graphql_schema: examples/block-explorer/schema/explorer_index.schema.graphql
 module:
-  wasm: target/wasm32-unknown-unknown/debug/explorer_index.wasm
+  wasm: target/wasm32-unknown-unknown/release/explorer_index.wasm
 metrics: ~
 contract_id: ~
 start_block: ~


### PR DESCRIPTION
- This is the hack we used to push v0.3.0 out
- This was a temporary measure, and needs to be reverted