### PR TITLE
docs: de-emphasize docker in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ Users of the Fuel indexer project include dApp developers looking to write flexi
 ### `wasm`
 
 Two additonal cargo components will be required to build your indexers: `wasm-snip` and the `wasm32-unknown-unknown` target.
+
 - To install `wasm-snip`:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,6 @@ The Fuel indexer is a standalone service that can be used to index various compo
 - [**For Users**](#for-users)
   - [Dependencies](#dependencies)
     - [`fuelup`](#fuelup)
-    - [`docker`](#docker)
     - [`wasm`](#wasm)
   - [Quickstart](#quickstart)
   - [`forc index` Plugin](#forc-index-plugin)
@@ -55,13 +54,6 @@ Users of the Fuel indexer project include dApp developers looking to write flexi
 
 - We use fuelup in order to get the binaries produced by services in the Fuel ecosystem. Fuelup will install binaries related to the Fuel node, the Fuel indexer, the Fuel orchestrator (forc), and other components.
 - fuelup can be downloaded [here](https://github.com/FuelLabs/fuelup).
-
-### `docker`
-
-> IMPORTANT: Docker is not required to run the Fuel indexer.
-
-- We use Docker to produce reproducible environments for users that may be concerned with installing components with large sets of dependencies (e.g. PostgreSQL).
-- Docker can be downloaded [here](https://docs.docker.com/engine/install/).
 
 ### `wasm`
 
@@ -511,6 +503,13 @@ There are a few points that Fuel indexer users should know when using WASM:
 Contributors of the Fuel indexer project are devs looking to help  backends for their dApps.
 
 ## Dev Dependencies
+
+### `docker`
+
+> IMPORTANT: Docker is not required to run the Fuel indexer.
+
+- We use Docker to produce reproducible environments for users that may be concerned with installing components with large sets of dependencies (e.g. PostgreSQL).
+- Docker can be downloaded [here](https://docs.docker.com/engine/install/).
 
 ### Database
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,7 +9,6 @@
   - [`fuelup`](./getting-started/dependencies/fuelup.md)
   - [Database](./getting-started/dependencies/database.md)
   - [WASM](./getting-started/dependencies/wasm.md)
-  - [Docker](./getting-started/dependencies/docker.md)
 - [Quickstart](./quickstart/index.md)
 - [Starting the Fuel Indexer](./getting-started/starting-the-fuel-indexer.md)
 

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -1,2 +1,2 @@
 <!-- markdownlint-disable MD041 -->
-{{#include ../../README.md:80:413}}
+{{#include ../../README.md:74:407}}


### PR DESCRIPTION
### Description
- As previously mentioned, with https://github.com/FuelLabs/fuel-indexer/issues/544 done, we need to de-emphasize Docker for users in our docs

### Changelog
- docs: de-emphasize docker in docs