### PR TITLE
Version bump and SDK upgrade to v0.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,9 +2034,9 @@ dependencies = [
  "fuel-indexer-plugin",
  "fuel-indexer-schema",
  "fuel-tx",
- "fuels-core",
- "fuels-macros",
- "fuels-types",
+ "fuels-core 0.37.0",
+ "fuels-macros 0.37.0",
+ "fuels-types 0.37.0",
  "getrandom",
  "serde",
  "serde_json",
@@ -2163,7 +2163,7 @@ dependencies = [
  "forc-util",
  "fuel-indexer-lib",
  "fuel-tx",
- "fuels-types",
+ "fuels-types 0.36.1",
  "hex",
  "hyper-rustls 0.23.2",
  "indicatif",
@@ -2759,10 +2759,10 @@ dependencies = [
  "fuel-indexer-types",
  "fuel-tx",
  "fuels",
- "fuels-code-gen",
- "fuels-core",
- "fuels-macros",
- "fuels-types",
+ "fuels-code-gen 0.36.1",
+ "fuels-core 0.36.1",
+ "fuels-macros 0.36.1",
+ "fuels-types 0.36.1",
  "graphql-parser 0.3.0",
  "lazy_static",
  "proc-macro-error",
@@ -2827,7 +2827,7 @@ dependencies = [
  "fuel-indexer-types",
  "fuel-tx",
  "fuel-types",
- "fuels-core",
+ "fuels-core 0.36.1",
  "graphql-parser 0.3.0",
  "hex",
  "insta",
@@ -2847,9 +2847,9 @@ dependencies = [
  "fuel-indexer-plugin",
  "fuel-indexer-schema",
  "fuel-tx",
- "fuels-core",
- "fuels-macros",
- "fuels-types",
+ "fuels-core 0.36.1",
+ "fuels-macros 0.36.1",
+ "fuels-types 0.36.1",
  "getrandom",
  "serde",
 ]
@@ -2873,8 +2873,8 @@ dependencies = [
  "fuel-tx",
  "fuel-types",
  "fuels",
- "fuels-core",
- "fuels-macros",
+ "fuels-core 0.36.1",
+ "fuels-macros 0.36.1",
  "futures",
  "hex",
  "hyper",
@@ -2900,8 +2900,8 @@ dependencies = [
  "chrono",
  "fuel-tx",
  "fuel-types",
- "fuels-core",
- "fuels-types",
+ "fuels-core 0.36.1",
+ "fuels-types 0.36.1",
  "serde",
  "sha2 0.9.9",
 ]
@@ -2928,7 +2928,7 @@ dependencies = [
  "fuel-indexer-tests",
  "fuel-types",
  "fuels",
- "fuels-macros",
+ "fuels-macros 0.36.1",
  "tokio",
 ]
 
@@ -2996,18 +2996,35 @@ dependencies = [
  "fuel-core",
  "fuel-core-client",
  "fuel-tx",
- "fuels-core",
- "fuels-macros",
+ "fuels-core 0.36.1",
+ "fuels-macros 0.36.1",
  "fuels-programs",
  "fuels-signers",
  "fuels-test-helpers",
- "fuels-types",
+ "fuels-types 0.36.1",
 ]
 
 [[package]]
 name = "fuels-code-gen"
 version = "0.36.1"
 source = "git+https://github.com/FuelLabs/fuels-rs?branch=segfault_magnet/wasm_friendly_abigen#5a59ad3f2105da30ecfa4122a7706f887a79ed84"
+dependencies = [
+ "Inflector",
+ "fuel-abi-types 0.2.1",
+ "itertools",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "fuels-code-gen"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650beefcaa2b7c6aed98f55a64c995b4ac8f099fea6caa8bb3268cb53f6afcc8"
 dependencies = [
  "Inflector",
  "fuel-abi-types 0.2.1",
@@ -3028,7 +3045,22 @@ dependencies = [
  "fuel-tx",
  "fuel-types",
  "fuel-vm",
- "fuels-types",
+ "fuels-types 0.36.1",
+ "hex",
+ "itertools",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "fuels-core"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edf26135f19f23b9c2ec879c7d325f03e29375b2760aac038adf98023327935"
+dependencies = [
+ "fuel-tx",
+ "fuel-types",
+ "fuel-vm",
+ "fuels-types 0.37.0",
  "hex",
  "itertools",
  "sha2 0.9.9",
@@ -3041,7 +3073,26 @@ source = "git+https://github.com/FuelLabs/fuels-rs?branch=segfault_magnet/wasm_f
 dependencies = [
  "Inflector",
  "fuel-abi-types 0.2.1",
- "fuels-code-gen",
+ "fuels-code-gen 0.36.1",
+ "itertools",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "rand",
+ "regex",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "fuels-macros"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c7eadec5720fe7318af459eecf824bf50149324d771e0a70a5e6826784cc24"
+dependencies = [
+ "Inflector",
+ "fuel-abi-types 0.2.1",
+ "fuels-code-gen 0.37.0",
  "itertools",
  "lazy_static",
  "proc-macro2",
@@ -3062,9 +3113,9 @@ dependencies = [
  "fuel-tx",
  "fuel-types",
  "fuel-vm",
- "fuels-core",
+ "fuels-core 0.36.1",
  "fuels-signers",
- "fuels-types",
+ "fuels-types 0.36.1",
  "futures",
  "hex",
  "itertools",
@@ -3095,8 +3146,8 @@ dependencies = [
  "fuel-tx",
  "fuel-types",
  "fuel-vm",
- "fuels-core",
- "fuels-types",
+ "fuels-core 0.36.1",
+ "fuels-types 0.36.1",
  "hex",
  "itertools",
  "rand",
@@ -3119,10 +3170,10 @@ dependencies = [
  "fuel-tx",
  "fuel-types",
  "fuel-vm",
- "fuels-core",
+ "fuels-core 0.36.1",
  "fuels-programs",
  "fuels-signers",
- "fuels-types",
+ "fuels-types 0.36.1",
  "futures",
  "hex",
  "portpicker",
@@ -3147,7 +3198,33 @@ dependencies = [
  "fuel-core-client",
  "fuel-tx",
  "fuel-types",
- "fuels-macros",
+ "fuels-macros 0.36.1",
+ "hex",
+ "itertools",
+ "lazy_static",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.21.0",
+ "strum_macros 0.21.1",
+ "thiserror",
+]
+
+[[package]]
+name = "fuels-types"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6d0112f70cced65b7ddbda5ca2d25abfb19f1a1a27a2c2bfb977884b6f1a29"
+dependencies = [
+ "bech32 0.9.1",
+ "chrono",
+ "fuel-abi-types 0.2.1",
+ "fuel-asm",
+ "fuel-core-chain-config",
+ "fuel-tx",
+ "fuel-types",
+ "fuels-macros 0.37.0",
  "hex",
  "itertools",
  "lazy_static",
@@ -3495,9 +3572,9 @@ dependencies = [
  "fuel-indexer-schema",
  "fuel-tx",
  "fuels",
- "fuels-core",
- "fuels-macros",
- "fuels-types",
+ "fuels-core 0.36.1",
+ "fuels-macros 0.36.1",
+ "fuels-types 0.36.1",
  "getrandom",
  "instant",
  "serde",
@@ -3512,9 +3589,9 @@ dependencies = [
  "fuel-indexer-tests",
  "fuel-tx",
  "fuel-types",
- "fuels",
- "fuels-core",
- "fuels-macros",
+ "fuels-core 0.37.0",
+ "fuels-macros 0.37.0",
+ "fuels-types 0.37.0",
  "rand",
  "thiserror",
  "tokio",
@@ -3537,9 +3614,9 @@ dependencies = [
  "fuel-indexer-plugin",
  "fuel-indexer-schema",
  "fuel-tx",
- "fuels-core",
- "fuels-macros",
- "fuels-types",
+ "fuels-core 0.37.0",
+ "fuels-macros 0.37.0",
+ "fuels-types 0.37.0",
  "getrandom",
  "instant",
  "serde",
@@ -5730,9 +5807,9 @@ dependencies = [
  "fuel-indexer-plugin",
  "fuel-indexer-schema",
  "fuel-tx",
- "fuels-core",
- "fuels-macros",
- "fuels-types",
+ "fuels-core 0.36.1",
+ "fuels-macros 0.36.1",
+ "fuels-types 0.36.1",
  "getrandom",
  "serde",
 ]

--- a/examples/block-explorer/explorer-index/Cargo.toml
+++ b/examples/block-explorer/explorer-index/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.4", path = "../../../packages/fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.4", path = "../../../packages/fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.4", path = "../../../packages/fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.5", path = "../../../packages/fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.5", path = "../../../packages/fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.5", path = "../../../packages/fuel-indexer-schema", default-features = false }
 fuel-tx = "0.26"
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen"}
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
+fuels-core = { version = "0.37", default-features = false }
+fuels-macros = { version = "0.37" }
+fuels-types = { version = "0.37", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/examples/hello-world-native/hello-index-native/Cargo.toml
+++ b/examples/hello-world-native/hello-index-native/Cargo.toml
@@ -6,15 +6,15 @@ publish = false
 
 [dependencies]
 async-trait = { version = "0.1" }
-fuel-indexer = { version = "0.4", path = "../../../packages/fuel-indexer" }
-fuel-indexer-macros = { version = "0.4", path = "../../../packages/fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.4", path = "../../../packages/fuel-indexer-plugin", features = ["native-execution"] }
-fuel-indexer-schema = { version = "0.4", path = "../../../packages/fuel-indexer-schema", default-features = false }
+fuel-indexer = { version = "0.5", path = "../../../packages/fuel-indexer" }
+fuel-indexer-macros = { version = "0.5", path = "../../../packages/fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.5", path = "../../../packages/fuel-indexer-plugin", features = ["native-execution"] }
+fuel-indexer-schema = { version = "0.5", path = "../../../packages/fuel-indexer-schema", default-features = false }
 fuel-tx = "0.26.0"
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" , default-features = false }
+fuels = { version = "0.37" }
+fuels-core = { version = "0.37", default-features = false }
+fuels-macros = { version = "0.37" }
+fuels-types = { version = "0.37", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/examples/hello-world/hello-index/Cargo.toml
+++ b/examples/hello-world/hello-index/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.4", path = "../../../packages/fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.4", path = "../../../packages/fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.4", path = "../../../packages/fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.5", path = "../../../packages/fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.5", path = "../../../packages/fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.5", path = "../../../packages/fuel-indexer-schema", default-features = false }
 fuel-tx = "0.26.0"
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen"}
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" , default-features = false }
+fuels-core = { version = "0.37", default-features = false }
+fuels-macros = { version = "0.37" }
+fuels-types = { version = "0.37", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/examples/hello-world/hello-world-data/Cargo.toml
+++ b/examples/hello-world/hello-world-data/Cargo.toml
@@ -6,13 +6,13 @@ publish = false
 
 [dependencies]
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
-fuel-indexer-lib = { version = "0.4", path = "../../../packages/fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.5", path = "../../../packages/fuel-indexer-lib" }
 fuel-indexer-tests = { version = "0.0.0", path = "./../../../packages/fuel-indexer-tests" }
 fuel-tx = "0.26.0"
 fuel-types = "0.26.0"
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
+fuels-core = { version = "0.37", default-features = false }
+fuels-macros = { version = "0.37" }
+fuels-types = { version = "0.37", default-features = false }
 rand = "0.8"
 thiserror = "1.0"
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }

--- a/packages/fuel-indexer-api-server/Cargo.toml
+++ b/packages/fuel-indexer-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-api-server"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -15,11 +15,11 @@ anyhow = "1.0"
 async-std = "1"
 axum = { version = "0.5", features = ["multipart"] }
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
-fuel-indexer-database = { version = "0.4", path = "../fuel-indexer-database" }
-fuel-indexer-database-types = { version = "0.4", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.4", path = "../fuel-indexer-lib" }
-fuel-indexer-metrics = { version = "0.4", path = "../fuel-indexer-metrics", optional = true }
-fuel-indexer-schema = { version = "0.4", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer-database = { version = "0.5", path = "../fuel-indexer-database" }
+fuel-indexer-database-types = { version = "0.5", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.5", path = "../fuel-indexer-lib" }
+fuel-indexer-metrics = { version = "0.5", path = "../fuel-indexer-metrics", optional = true }
+fuel-indexer-schema = { version = "0.5", path = "../fuel-indexer-schema", features = ["db-models"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http2", "http1", "runtime" ]}
 hyper-rustls = { version = "0.23", features = ["http2"] }

--- a/packages/fuel-indexer-database/Cargo.toml
+++ b/packages/fuel-indexer-database/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fuel-indexer-database"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Database"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.4", path = "./database-types" }
-fuel-indexer-lib = { version = "0.4", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.4", path = "./postgres" }
+fuel-indexer-database-types = { version = "0.5", path = "./database-types" }
+fuel-indexer-lib = { version = "0.5", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.5", path = "./postgres" }
 sqlx = { version = "0.6" }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }

--- a/packages/fuel-indexer-database/database-types/Cargo.toml
+++ b/packages/fuel-indexer-database/database-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-database-types"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/packages/fuel-indexer-database/postgres/Cargo.toml
+++ b/packages/fuel-indexer-database/postgres/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fuel-indexer-postgres"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
 description = "Fuel Indexer Postgres"
 
 [dependencies]
-fuel-indexer-database-types = { version = "0.4", path = "../database-types" }
-fuel-indexer-lib = { version = "0.4", path = "../../fuel-indexer-lib" }
-fuel-indexer-metrics = { version = "0.4", path = "../../fuel-indexer-metrics", optional = true }
+fuel-indexer-database-types = { version = "0.5", path = "../database-types" }
+fuel-indexer-lib = { version = "0.5", path = "../../fuel-indexer-lib" }
+fuel-indexer-metrics = { version = "0.5", path = "../../fuel-indexer-metrics", optional = true }
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "offline"] }
 tracing = "0.1"
 

--- a/packages/fuel-indexer-lib/Cargo.toml
+++ b/packages/fuel-indexer-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-lib"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -9,7 +9,7 @@ description = "Fuel Indexer Library"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
-fuel-indexer-types = { version = "0.4", path = "../fuel-indexer-types" }
+fuel-indexer-types = { version = "0.5", path = "../fuel-indexer-types" }
 http = { version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/packages/fuel-indexer-macros/Cargo.toml
+++ b/packages/fuel-indexer-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-macros"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -14,14 +14,14 @@ proc-macro = true
 
 [dependencies]
 fuel-abi-types = "0.2.1"
-fuel-indexer-database-types = { version = "0.4", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.4", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.4", path = "../fuel-indexer-schema", default-features = false }
-fuel-indexer-types = { version = "0.4", path = "../fuel-indexer-types" }
+fuel-indexer-database-types = { version = "0.5", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.5", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.5", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-types = { version = "0.5", path = "../fuel-indexer-types" }
 fuel-tx = "0.26.0"
-fuels-code-gen = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
+fuels-code-gen = { version = "0.37", default-features = false }
+fuels-core = { version = "0.37", default-features = false }
+fuels-types = { version = "0.37", default-features = false }
 graphql-parser = "0.3"
 lazy_static = "1.4"
 proc-macro-error = "1.0"
@@ -33,10 +33,10 @@ sha2 = "0.9.5"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-fuel-indexer-plugin = { version = "0.4", path = "../fuel-indexer-plugin" }
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen"}
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
+fuel-indexer-plugin = { version = "0.5", path = "../fuel-indexer-plugin" }
+fuels = { version = "0.37" }
+fuels-macros = { version = "0.37", default-features = false }
+fuels-types = { version = "0.37", default-features = false }
 trybuild = "1.0"
 
 [features]

--- a/packages/fuel-indexer-metrics/Cargo.toml
+++ b/packages/fuel-indexer-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-metrics"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"

--- a/packages/fuel-indexer-plugin/Cargo.toml
+++ b/packages/fuel-indexer-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-plugin"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -13,12 +13,12 @@ crate-type = ['rlib']
 anyhow = { version = "1.0", default-features = false, optional = true }
 async-trait = { version = "0.1", optional = true }
 bincode = { version = "1.3.3", optional = true }
-fuel-indexer = { version = "0.4", path = "../fuel-indexer", default-features = false,  optional = true }
-fuel-indexer-api-server = { version = "0.4", path = "../fuel-indexer-api-server", default-features = false, optional = true }
-fuel-indexer-database = { version = "0.4", path = "../fuel-indexer-database", default-features = false, optional = true }
-fuel-indexer-lib = { version = "0.4", path = "../fuel-indexer-lib", default-features = false }
-fuel-indexer-schema = { version = "0.4", path = "../fuel-indexer-schema", default-features = false }
-fuel-indexer-types = { version = "0.4", path = "../fuel-indexer-types" }
+fuel-indexer = { version = "0.5", path = "../fuel-indexer", default-features = false,  optional = true }
+fuel-indexer-api-server = { version = "0.5", path = "../fuel-indexer-api-server", default-features = false, optional = true }
+fuel-indexer-database = { version = "0.5", path = "../fuel-indexer-database", default-features = false, optional = true }
+fuel-indexer-lib = { version = "0.5", path = "../fuel-indexer-lib", default-features = false }
+fuel-indexer-schema = { version = "0.5", path = "../fuel-indexer-schema", default-features = false }
+fuel-indexer-types = { version = "0.5", path = "../fuel-indexer-types" }
 hex = "0.4"
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "sync", "process"], optional = true }
 tracing = { version = "0.1", optional = true }

--- a/packages/fuel-indexer-schema/Cargo.toml
+++ b/packages/fuel-indexer-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-schema"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -9,14 +9,14 @@ description = "Fuel Indexer Schema"
 [dependencies]
 bincode = "1.3.3"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
-fuel-indexer-database = { version = "0.4", path = "../fuel-indexer-database", optional = true }
-fuel-indexer-database-types = { version = "0.4", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.4", path = "../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.4", path = "../fuel-indexer-database/postgres", optional = true }
-fuel-indexer-types = { version = "0.4", path = "../fuel-indexer-types" }
+fuel-indexer-database = { version = "0.5", path = "../fuel-indexer-database", optional = true }
+fuel-indexer-database-types = { version = "0.5", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.5", path = "../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.5", path = "../fuel-indexer-database/postgres", optional = true }
+fuel-indexer-types = { version = "0.5", path = "../fuel-indexer-types" }
 fuel-tx = { version = "0.26.0", features = ["serde", "alloc"] }
 fuel-types = { version = "0.26.0", features = ["serde", "alloc"] }
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
+fuels-core = { version = "0.37", default-features = false }
 graphql-parser = "0.3"
 hex = "0.4"
 itertools = { version = "0.10", optional = true }

--- a/packages/fuel-indexer-tests/Cargo.toml
+++ b/packages/fuel-indexer-tests/Cargo.toml
@@ -28,18 +28,18 @@ actix-web = { version = "4", default-features = false, features = ["macros"] }
 async-std = "1"
 axum = { version = "0.5", features = ["multipart"] }
 chrono = { version = "0.4", features = ["serde"] }
-fuel-indexer = { version = "0.4", path = "./../fuel-indexer" }
-fuel-indexer-api-server = { version = "0.4", path = "./../fuel-indexer-api-server" }
-fuel-indexer-database = { version = "0.4", path = "./../fuel-indexer-database" }
-fuel-indexer-lib = { version = "0.4", path = "./../fuel-indexer-lib" }
-fuel-indexer-postgres = { version = "0.4", path = "./../fuel-indexer-database/postgres" }
-fuel-indexer-schema = { version = "0.4", path = "./../fuel-indexer-schema" }
-fuel-indexer-types = { version = "0.4", path = "./../fuel-indexer-types" }
+fuel-indexer = { version = "0.5", path = "./../fuel-indexer" }
+fuel-indexer-api-server = { version = "0.5", path = "./../fuel-indexer-api-server" }
+fuel-indexer-database = { version = "0.5", path = "./../fuel-indexer-database" }
+fuel-indexer-lib = { version = "0.5", path = "./../fuel-indexer-lib" }
+fuel-indexer-postgres = { version = "0.5", path = "./../fuel-indexer-database/postgres" }
+fuel-indexer-schema = { version = "0.5", path = "./../fuel-indexer-schema" }
+fuel-indexer-types = { version = "0.5", path = "./../fuel-indexer-types" }
 fuel-tx = "0.26.0"
 fuel-types = "0.26.0"
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", features = ["fuel-core-lib"] }
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = true }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
+fuels-core = { version = "0.37", default-features = false }
+fuels-macros = { version = "0.37" }
 futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["client", "http2", "http1", "runtime" ]}

--- a/packages/fuel-indexer-tests/components/fuel-node/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/fuel-node/Cargo.toml
@@ -8,6 +8,5 @@ publish = false
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 fuel-indexer-tests = { version = "0.0.0", path = "./../../../fuel-indexer-tests" }
 fuel-types = "0.26.0"
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", features = ["fuel-core-lib"] }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
+fuels-macros = { version = "0.37" }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
@@ -8,12 +8,12 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.4", path = "../../../../fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.4", path = "../../../../fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.4", path = "../../../../fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.5", path = "../../../../fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.5", path = "../../../../fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.5", path = "../../../../fuel-indexer-schema", default-features = false }
 fuel-tx = "0.26.0"
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
+fuels-core = { version = "0.37", default-features = false }
+fuels-macros = { version = "0.37" }
+fuels-types = { version = "0.37", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
@@ -8,12 +8,12 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { version = "0.4", path = "../../../../../../packages/fuel-indexer-macros", default-features = false }
-fuel-indexer-plugin = { version = "0.4", path = "../../../../../../packages/fuel-indexer-plugin" }
-fuel-indexer-schema = { version = "0.4", path = "../../../../../../packages/fuel-indexer-schema", default-features = false }
+fuel-indexer-macros = { version = "0.5", path = "../../../../../../packages/fuel-indexer-macros", default-features = false }
+fuel-indexer-plugin = { version = "0.5", path = "../../../../../../packages/fuel-indexer-plugin" }
+fuel-indexer-schema = { version = "0.5", path = "../../../../../../packages/fuel-indexer-schema", default-features = false }
 fuel-tx = "0.26.0"
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-macros = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
+fuels-core = { version = "0.37", default-features = false }
+fuels-macros = { version = "0.37" }
+fuels-types = { version = "0.37", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -7,12 +7,12 @@ use fuel_indexer_database::IndexerConnectionPool;
 use fuel_indexer_lib::config::{
     DatabaseConfig, FuelNodeConfig, GraphQLConfig, IndexerConfig,
 };
-use fuels::core::parameters::StorageConfiguration;
 use fuels::{
     macros::abigen,
     prelude::{
         setup_single_asset_coins, setup_test_client, AssetId, Bech32ContractId, Config,
-        Contract, Provider, TxParameters, WalletUnlocked, DEFAULT_COIN_AMOUNT,
+        Contract, Provider, StorageConfiguration, TxParameters, WalletUnlocked,
+        DEFAULT_COIN_AMOUNT,
     },
     signers::Signer,
 };
@@ -284,7 +284,7 @@ pub async fn connect_to_deployed_contract(
 
     let provider = Provider::connect(defaults::FUEL_NODE_ADDR).await.unwrap();
 
-    wallet.set_provider(provider.clone());
+    wallet.set_provider(provider);
 
     println!(
         "Wallet({}) keystore at: {}",
@@ -298,7 +298,7 @@ pub async fn connect_to_deployed_contract(
 
     let contract = FuelIndexerTest::new(contract_id.clone(), wallet);
 
-    println!("Using contract at {}", contract_id.to_string());
+    println!("Using contract at {}", contract_id);
 
     Ok(contract)
 }

--- a/packages/fuel-indexer-types/Cargo.toml
+++ b/packages/fuel-indexer-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer-types"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -10,7 +10,7 @@ description = "Fuel Indexer Types"
 chrono = { version = "0.4", features = ["serde"] }
 fuel-tx = { version = "0.26.0", features = ["serde"] }
 fuel-types = "0.26.0"
-fuels-core = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }
+fuels-core = { version = "0.37", default-features = false }
+fuels-types = { version = "0.37", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 sha2 = "0.9"

--- a/packages/fuel-indexer/Cargo.toml
+++ b/packages/fuel-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-indexer"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-indexer"
@@ -21,14 +21,14 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 fuel-core = { version = "0.17.0", optional = true }
 fuel-core-client = "0.17.2"
-fuel-indexer-api-server = { version = "0.4", path = "../fuel-indexer-api-server", optional = true }
-fuel-indexer-database = { version = "0.4", path = "../fuel-indexer-database" }
-fuel-indexer-database-types = { version = "0.4", path = "../fuel-indexer-database/database-types" }
-fuel-indexer-lib = { version = "0.4", path = "../fuel-indexer-lib" }
-fuel-indexer-metrics = { version = "0.4", path = "../fuel-indexer-metrics", optional = true }
-fuel-indexer-postgres = { version = "0.4", path = "../fuel-indexer-database/postgres" }
-fuel-indexer-schema = { version = "0.4", path = "../fuel-indexer-schema", features = ["db-models"] }
-fuel-indexer-types = { version = "0.4", path = "../fuel-indexer-types" }
+fuel-indexer-api-server = { version = "0.5", path = "../fuel-indexer-api-server", optional = true }
+fuel-indexer-database = { version = "0.5", path = "../fuel-indexer-database" }
+fuel-indexer-database-types = { version = "0.5", path = "../fuel-indexer-database/database-types" }
+fuel-indexer-lib = { version = "0.5", path = "../fuel-indexer-lib" }
+fuel-indexer-metrics = { version = "0.5", path = "../fuel-indexer-metrics", optional = true }
+fuel-indexer-postgres = { version = "0.5", path = "../fuel-indexer-database/postgres" }
+fuel-indexer-schema = { version = "0.5", path = "../fuel-indexer-schema", features = ["db-models"] }
+fuel-indexer-types = { version = "0.5", path = "../fuel-indexer-types" }
 fuel-tx = "0.26.0"
 fuel-types = "0.26.0"
 futures = "0.3"

--- a/plugins/forc-index/Cargo.toml
+++ b/plugins/forc-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-index"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
@@ -11,12 +11,12 @@ description = "Fuel Indexer forc plugin"
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }
-forc-postgres = { version = "0.4", path = "../forc-postgres" }
+forc-postgres = { version = "0.5", path = "../forc-postgres" }
 forc-tracing = { version = "0.31", default-features = false }
 forc-util = { version = "0.35.0" }
-fuel-indexer-lib = { version = "0.4", path = "../../packages/fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.5", path = "../../packages/fuel-indexer-lib" }
 fuel-tx = { version = "0.26.0", features = ["builder"] }
-fuels-types = { git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" , default-features = false }
+fuels-types = { version = "0.37", default-features = false }
 hex = "0.4.3"
 hyper-rustls = { version = "0.23", features = ["http2"] }
 indicatif = "0.17"

--- a/plugins/forc-index/src/utils/defaults.rs
+++ b/plugins/forc-index/src/utils/defaults.rs
@@ -21,13 +21,13 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = {{ version = "0.4", default-features = false }}
-fuel-indexer-plugin = {{ version = "0.4", features = ["native-execution"] }}
-fuel-indexer-schema = {{ version = "0.4", default-features = false }}
+fuel-indexer-macros = {{ version = "0.5", default-features = false }}
+fuel-indexer-plugin = {{ version = "0.5", features = ["native-execution"] }}
+fuel-indexer-schema = {{ version = "0.5", default-features = false }}
 fuel-tx = "0.26"
-fuels = {{ git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }}
-fuels-core = {{ git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }}
-fuels-types = {{ git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }}
+fuels = {{ version = "0.37" }}
+fuels-core = {{ version = "0.37" }}
+fuels-types = {{ version = "0.37", default-features = false }}
 getrandom = {{ version = "0.2", features = ["js"] }}
 serde = {{ version = "1.0", default-features = false, features = ["derive"] }}
 "#
@@ -46,13 +46,13 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = {{ version = "0.4", default-features = false }}
-fuel-indexer-plugin = {{ version = "0.4" }}
-fuel-indexer-schema = {{ version = "0.4", default-features = false }}
+fuel-indexer-macros = {{ version = "0.5", default-features = false }}
+fuel-indexer-plugin = {{ version = "0.5" }}
+fuel-indexer-schema = {{ version = "0.5", default-features = false }}
 fuel-tx = "0.26"
-fuels-core = {{ git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }}
-fuels-macros = {{ git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen" }}
-fuels-types ={{ git = "https://github.com/FuelLabs/fuels-rs", branch = "segfault_magnet/wasm_friendly_abigen", default-features = false }}
+fuels-core = {{ version = "0.37", default-features = false }}
+fuels-macros = {{ version = "0.37" }}
+fuels-types ={{ version = "0.37", default-features = false }}
 getrandom = {{ version = "0.2", features = ["js"] }}
 serde = {{ version = "1.0", default-features = false, features = ["derive"] }}
 "#

--- a/plugins/forc-postgres/Cargo.toml
+++ b/plugins/forc-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-postgres"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BUSL-1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }
 forc-tracing = { version = "0.31", default-features = false }
-fuel-indexer-lib = { version = "0.4", path = "../../packages/fuel-indexer-lib" }
+fuel-indexer-lib = { version = "0.5", path = "../../packages/fuel-indexer-lib" }
 home = "0.5"
 indicatif = "0.17"
 pg-embed = { version = "0.7" }


### PR DESCRIPTION
Closes #605.

## Changelog
- Upgrade to the newest SDK release which contains the WASM fix
- Bump versions to 0.5

## Notes
For some reason, `fuels-programs 0.37.0` is unable to be found in the crates.io index, even though it's [actually present on crates.io itself](https://crates.io/crates/fuels-programs).
```
~/dev/fuel/indexer deekerno/v0.5.0*
❯ cargo update             
    Updating crates.io index
error: failed to select a version for the requirement `fuels-programs = "^0.37.0"`
candidate versions found which didn't match: 0.36.1, 0.36.0, 0.35.1, ...
location searched: crates.io index
required by package `fuels v0.37.0`
    ... which satisfies dependency `fuels = "^0.37"` of package `fuel-indexer-macros v0.5.0 (/Users/deekerno/dev/fuel/indexer/packages/fuel-indexer-macros)`
    ... which satisfies path dependency `fuel-indexer-macros` of package `explorer_index v0.0.0 (/Users/deekerno/dev/fuel/indexer/examples/block-explorer/explorer-index)`
```

We can't completely remove the monolithic `fuels` dependency as our tests need things from `fuels-programs`, which is the problem crate anyways. I've notified @digorithm, and we'll continue to monitor/re-attempt.