### PR TITLE
chore: remove temp CI forc-index workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,7 @@ jobs:
         run: kill -9 $(lsof -ti:4000)
 
   check-is-release-branch:
-    # if: github.event_name != 'release' && github.event.action != 'published' && github.ref != 'refs/heads/master'
-    if: false
+    if: github.event_name != 'release' && github.event.action != 'published' && github.ref != 'refs/heads/master'
     needs:
       - cancel-previous-runs
       - cargo-toml-fmt-check


### PR DESCRIPTION
## Changelog
- Removes CI workaround that was added during the use of the SDK WASM hotfix branch