### PR TITLE
chore: remove `sqlx-cli` install from certain CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,6 @@ jobs:
           toolchain: nightly
           default: true
       - uses: Swatinem/rust-cache@v1
-      - run: cargo install sqlx-cli
-      - run: bash scripts/run_migrations.bash
       - name: Install cargo-udeps
         uses: actions-rs/cargo@v1
         with:
@@ -177,8 +175,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - run: cargo install sqlx-cli
-      - run: bash scripts/run_migrations.bash
 
       - name: cargo ${{ matrix.command }} -p ${{ matrix.package }} ${{ matrix.args }}
         if: ${{ matrix.package }}


### PR DESCRIPTION
## Changelog
- Remove `cargo install sqlx-cli` from the `cargo-verification` and unused dependency check stages of CI

## Notes
Had a random thought after #600 merged: if we're using `SQLX_OFFLINE=1`, then there would be no compile-time check of the queries; we can probably shave off a couple minutes of CI time by not installing the package for certain steps as it takes an average of 5 minutes on each job.

Update:
- Pre-#600: ~28 mins - https://github.com/FuelLabs/fuel-indexer/actions/runs/4255453841
- Post-#600, pre-#618: ~21 mins - https://github.com/FuelLabs/fuel-indexer/actions/runs/4263521437
- Runtime of #618: ~16 mins - https://github.com/FuelLabs/fuel-indexer/actions/runs/4258854184

Almost a 45% reduction in CI run time when coupled with #600.