### PR TITLE
chore: add fuel-core to indexer release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   REGISTRY: ghcr.io
   SQLX_OFFLINE: true
   RUSTC_VERSION: 1.67
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   IS_MASTER: github.ref == 'refs/heads/master'
   IS_RELEASE: github.event_name == 'release' && github.event.action == 'published'
   IS_RELEASE_OR_MASTER: github.event_name == 'release' || github.event.action == 'published' || github.ref == 'refs/heads/master'
@@ -37,14 +37,14 @@ jobs:
     steps:
       - name: Check rustc version
         run: |
-          # Check rustc version, log message and exit if it doesnt match env 
+          # Check rustc version, log message and exit if it doesnt match env
           CURRENT_RUSTC_VERSION=$(rustc --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | cut -c -4)
           if [ "$CURRENT_RUSTC_VERSION" != "$RUSTC_VERSION" ]; then
             echo "Rustc version ($CURRENT_RUSTC_VERSION) does not match the required version ($RUSTC_VERSION)"
-            exit 1 
+            exit 1
           fi
           echo "Rustc version ($CURRENT_RUSTC_VERSION) matches the required version ($RUSTC_VERSION)"
-      
+
   cargo-toml-fmt-check:
     needs:
       - check-rustc
@@ -85,7 +85,7 @@ jobs:
     needs:
       - set-env-vars
     runs-on: ubuntu-latest
-    outputs: 
+    outputs:
       is_semver_branch: ${{ steps.semver-branch-check.outputs.is_semver_branch }}
     steps:
       - name: Check for semver branch
@@ -96,7 +96,7 @@ jobs:
           else
             echo "Not a release branch ^(^.^)^"
           fi
-          
+
   mdbook-lint:
     needs:
       - check-rustc
@@ -259,7 +259,7 @@ jobs:
 
       - name: Install wasm-snip
         run: cargo install wasm-snip
-      
+
       - name: Build fuel-indexer-test WASM
         run: |
           cargo build -p fuel-indexer-test --release --target wasm32-unknown-unknown
@@ -359,6 +359,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: BUILD_TARGET=--all-targets
 
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v2
@@ -442,7 +443,14 @@ jobs:
 
       - name: Build fuel-indexer
         run: |
-          cross build --profile=release --target ${{ matrix.job.target }} -p fuel-indexer -p fuel-indexer-api-server -p forc-index
+          cross \
+            build \
+            --profile=release \
+            --target ${{ matrix.job.target }} \
+            --features fuel-core-lib \
+            -p fuel-indexer \
+            -p fuel-indexer-api-server \
+            -p forc-index
 
       - name: Strip release binary linux x86_64
         if: matrix.job.platform == 'linux'
@@ -583,7 +591,7 @@ jobs:
           K8S: 'eks'
           CONFIG: 'fuel-dev1'
           ENV: 'fueldevsway.env'
-          
+
   # TODO: publish these in parallel
   publish:
     needs:
@@ -642,7 +650,6 @@ jobs:
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
-
 
   validation-complete:
     if: always()

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -30,10 +30,10 @@ COPY --from=planner /build/recipe.json recipe.json
 
 ENV SQLX_OFFLINE=true
 
-RUN cargo chef cook --release -p fuel-indexer --recipe-path recipe.json
-RUN cargo chef cook --release -p fuel-indexer-api-server --recipe-path recipe.json
+RUN cargo chef cook --release --features fuel-core-lib -p fuel-indexer --recipe-path recipe.json
+RUN cargo chef cook --release --features fuel-core-lib -p fuel-indexer-api-server --recipe-path recipe.json
 COPY . .
-RUN cargo build --release -p fuel-indexer -p fuel-indexer-api-server --all-targets
+RUN cargo build --release --features fuel-core-lib -p fuel-indexer -p fuel-indexer-api-server $BUILD_TARGET
 
 # Stage 3: Run
 FROM ubuntu:22.04 AS run


### PR DESCRIPTION
### Description
- We should be including `fuel-core-lib` in our release builds

### Testing steps
- This was tested in a previous (now squashed) commit
- If you want to test for yourself, just remove the `if:` condition from the `publish-docker-image` step in this PR

### Changelog
- chore: add fuel-core to indexer release builds