### PR TITLE
fix: kill old execution module when redeploying under same namespace and identifier

### DIFF
--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -257,11 +257,13 @@ async fn create_service_task(
 
                                 futs.push(handle);
 
-                                if let Some(prior_module_killer) =
+                                if let Some(killer_for_prev_executor) =
                                     killers.insert(manifest.uid(), killer)
                                 {
-                                    info!("Replaced execution module for {}, stopping old execution module.", manifest.uid());
-                                    prior_module_killer.store(true, Ordering::SeqCst);
+                                    let uid = manifest.uid();
+                                    info!("Indexer({uid}) was replaced. Stopping previous version of Indexer({uid}).");
+                                    killer_for_prev_executor
+                                        .store(true, Ordering::SeqCst);
                                 }
                             }
                             Err(e) => {

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -256,7 +256,13 @@ async fn create_service_task(
                                 );
 
                                 futs.push(handle);
-                                killers.insert(manifest.uid(), killer);
+
+                                if let Some(prior_module_killer) =
+                                    killers.insert(manifest.uid(), killer)
+                                {
+                                    info!("Replaced execution module for {}, stopping old execution module.", manifest.uid());
+                                    prior_module_killer.store(true, Ordering::SeqCst);
+                                }
                             }
                             Err(e) => {
                                 error!(


### PR DESCRIPTION
## Changelog
- Kill old execution module if deploying a new execution module under the same namespace and identifier

## Reproduction (on master)
0. Ensure database is clear and build `forc-index`: `cargo build -p forc-index`.
1. Add log message to `examples/block-explorer/explorer-index/src/lib.rs`; something like "FIRST" will suffice.
2. Deploy explorer index:
```
../../target/debug/forc-index deploy \                                                      
   --path explorer-index \
   --output-dir-root [whatever your fuel-indexer repo root is] \
   --url http://0.0.0.0:29987 \
   --target wasm32-unknown-unknown
```
3. Change log message in explorer example to something different, e.g. "SECOND".
4. Re-deploy using same command.
5. Search through service logs; you should see that both messages are being logged.

## Testing Plan (on this branch)
Repeat the above steps, you should see that only the second message is being logged. There should also be a message saying the following:
```
Replaced execution module for fuel_examples.explorer_index, stopping old execution module.
```