### PR TITLE
fix: use namespace and identifier to generate and retrieve type IDs

### DIFF
--- a/packages/fuel-indexer-database/postgres/sqlx-data.json
+++ b/packages/fuel-indexer-database/postgres/sqlx-data.json
@@ -38,51 +38,6 @@
     },
     "query": "SELECT\n               id AS \"id: i64\", root_id AS \"root_id: i64\", column_name, graphql_type\n           FROM graph_registry_root_columns\n           WHERE root_id = $1"
   },
-  "2a7d1741198b91d9175b00373f51d793be5415583317ed1d42cd2a75cca51007": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "schema_version",
-          "ordinal": 1,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "schema_name",
-          "ordinal": 2,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "graphql_name",
-          "ordinal": 3,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "table_name",
-          "ordinal": 4,
-          "type_info": "Varchar"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "SELECT id, schema_version, schema_name, graphql_name, table_name FROM graph_registry_type_ids WHERE schema_name = $1 AND schema_version = $2"
-  },
   "4c73704cce4724de27f4aa91f6105aeac0fded522a6c6d111197e2f1288027ea": {
     "describe": {
       "columns": [
@@ -146,115 +101,6 @@
     },
     "query": "SELECT * FROM index_registry"
   },
-  "6daf0d3b6d1ec9412ba138cae993af3736a64100a1fca6ee15520513e0cc580e": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "version",
-          "ordinal": 1,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "schema_name",
-          "ordinal": 2,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "query",
-          "ordinal": 3,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "schema",
-          "ordinal": 4,
-          "type_info": "Varchar"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "SELECT * FROM graph_registry_graph_root WHERE schema_name = $1 ORDER BY id DESC LIMIT 1"
-  },
-  "6dec97ff504142a7e8f65a5716737670b9393444436b742cbd93cd6cec44d767": {
-    "describe": {
-      "columns": [
-        {
-          "name": "type_id",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "table_name",
-          "ordinal": 1,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "column_position",
-          "ordinal": 2,
-          "type_info": "Int4"
-        },
-        {
-          "name": "column_name",
-          "ordinal": 3,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "column_type: String",
-          "ordinal": 4,
-          "type_info": "Varchar"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "SELECT\n               c.type_id as type_id,\n               t.table_name as table_name,\n               c.column_position as column_position,\n               c.column_name as column_name,\n               c.column_type as \"column_type: String\"\n           FROM graph_registry_type_ids as t\n           INNER JOIN graph_registry_columns as c\n           ON t.id = c.type_id\n           WHERE t.schema_name = $1\n           AND t.schema_version = $2\n           ORDER BY c.type_id, c.column_position"
-  },
-  "a3eaf437c002e776fbf79f2d1461f797cec299713648da4df5ba4e262dda4e6e": {
-    "describe": {
-      "columns": [
-        {
-          "name": "schema_version",
-          "ordinal": 0,
-          "type_info": "Varchar"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "SELECT schema_version FROM graph_registry_type_ids WHERE schema_name = $1 ORDER BY id"
-  },
   "c52e7d2cc0bff0b8ca87d8ecd6d094b05cb80792b804e1373c80d0ff2abedeea": {
     "describe": {
       "columns": [
@@ -311,17 +157,17 @@
     },
     "query": "SELECT id AS \"id: i64\", type_id, column_position, column_name, column_type AS \"column_type: String\", nullable, graphql_type FROM graph_registry_columns WHERE type_id = $1"
   },
-  "ee7e6f84bb6541909ddfec641a828287d6e414337988b0bc346b765f8766479e": {
+  "cc8316279c93363e0ad4d86d7b6c3d93f73f0f2ebb75174116aeeeef9e431449": {
     "describe": {
       "columns": [
         {
-          "name": "num",
+          "name": "schema_version",
           "ordinal": 0,
-          "type_info": "Int8"
+          "type_info": "Varchar"
         }
       ],
       "nullable": [
-        null
+        false
       ],
       "parameters": {
         "Left": [
@@ -330,6 +176,52 @@
         ]
       }
     },
-    "query": "SELECT count(*) as num FROM graph_registry_type_ids WHERE schema_name = $1 AND schema_version = $2"
+    "query": "SELECT schema_version FROM graph_registry_type_ids WHERE schema_name = $1 AND schema_identifier = $2 ORDER BY id"
+  },
+  "cf3fb574c3ebcb286d20709f1387fc92eca73a9f7f5b99abf7c2b2c608031188": {
+    "describe": {
+      "columns": [
+        {
+          "name": "type_id",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "table_name",
+          "ordinal": 1,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "column_position",
+          "ordinal": 2,
+          "type_info": "Int4"
+        },
+        {
+          "name": "column_name",
+          "ordinal": 3,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "column_type: String",
+          "ordinal": 4,
+          "type_info": "Varchar"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "SELECT\n               c.type_id as type_id,\n               t.table_name as table_name,\n               c.column_position as column_position,\n               c.column_name as column_name,\n               c.column_type as \"column_type: String\"\n           FROM graph_registry_type_ids as t\n           INNER JOIN graph_registry_columns as c\n           ON t.id = c.type_id\n           WHERE t.schema_name = $1\n           AND t.schema_identifier = $2\n           AND t.schema_version = $3\n           ORDER BY c.type_id, c.column_position"
   }
 }

--- a/packages/fuel-indexer-database/src/queries.rs
+++ b/packages/fuel-indexer-database/src/queries.rs
@@ -39,10 +39,11 @@ pub async fn type_id_list_by_name(
 pub async fn type_id_latest(
     conn: &mut IndexerConnection,
     schema_name: &str,
+    identifier: &str,
 ) -> sqlx::Result<String> {
     match conn {
         IndexerConnection::Postgres(ref mut c) => {
-            postgres::type_id_latest(c, schema_name).await
+            postgres::type_id_latest(c, schema_name, identifier).await
         }
     }
 }
@@ -96,11 +97,12 @@ pub async fn list_column_by_id(
 pub async fn columns_get_schema(
     conn: &mut IndexerConnection,
     name: &str,
+    identifier: &str,
     version: &str,
 ) -> sqlx::Result<Vec<ColumnInfo>> {
     match conn {
         IndexerConnection::Postgres(ref mut c) => {
-            postgres::columns_get_schema(c, name, version).await
+            postgres::columns_get_schema(c, name, identifier, version).await
         }
     }
 }

--- a/packages/fuel-indexer-macros/src/schema.rs
+++ b/packages/fuel-indexer-macros/src/schema.rs
@@ -141,6 +141,7 @@ fn process_fk_field<'a>(
 fn process_type_def(
     query_root: &str,
     namespace: &str,
+    identifier: &str,
     types: &HashSet<String>,
     typ: &TypeDefinition<String>,
     processed: &mut HashSet<String>,
@@ -155,7 +156,7 @@ fn process_type_def(
             }
 
             let name = &obj.name;
-            let type_id = type_id(namespace, name);
+            let type_id = type_id(&format!("{namespace}_{identifier}"), name);
             let mut block = quote! {};
             let mut row_extractors = quote! {};
             let mut construction = quote! {};
@@ -304,6 +305,7 @@ fn process_type_def(
 fn process_definition(
     query_root: &str,
     namespace: &str,
+    identifier: &str,
     types: &HashSet<String>,
     definition: &Definition<String>,
     processed: &mut HashSet<String>,
@@ -313,8 +315,8 @@ fn process_definition(
 ) -> Option<proc_macro2::TokenStream> {
     match definition {
         Definition::TypeDefinition(def) => process_type_def(
-            query_root, namespace, types, def, processed, primitives, types_map,
-            is_native,
+            query_root, namespace, identifier, types, def, processed, primitives,
+            types_map, is_native,
         ),
         Definition::SchemaDefinition(_def) => None,
         def => {
@@ -430,6 +432,7 @@ pub(crate) fn process_graphql_schema(
         if let Some(def) = process_definition(
             &query_root,
             &namespace,
+            &identifier,
             &types,
             definition,
             &mut processed,

--- a/packages/fuel-indexer-schema/src/db/tables.rs
+++ b/packages/fuel-indexer-schema/src/db/tables.rs
@@ -318,7 +318,7 @@ impl SchemaBuilder {
                 }
 
                 let table_name = o.name.to_lowercase();
-                let type_id = type_id(&self.namespace, &o.name);
+                let type_id = type_id(&self.namespace(), &o.name);
                 let columns =
                     self.generate_columns(o, type_id, &o.fields, &table_name, types_map);
 

--- a/packages/fuel-indexer-tests/tests/integration/database.rs
+++ b/packages/fuel-indexer-tests/tests/integration/database.rs
@@ -20,7 +20,7 @@ const SIMPLE_WASM_GRAPHQL_SCHEMA: &str =
     include_str!("./../../components/indices/simple-wasm/schema/simple_wasm.graphql");
 const SIMPLE_WASM_WASM: &[u8] =
     include_bytes!("./../../components/indices/simple-wasm/simple_wasm.wasm");
-const THING1_TYPE: i64 = -6766053528336050638;
+const THING1_TYPE: i64 = -4145438814509139062;
 const TEST_COLUMNS: [(&str, i32, &str); 10] = [
     ("thing2", 0, "id"),
     ("thing2", 1, "account"),
@@ -33,6 +33,8 @@ const TEST_COLUMNS: [(&str, i32, &str); 10] = [
     ("indexmetadataentity", 1, "time"),
     ("indexmetadataentity", 2, "object"),
 ];
+const TEST_NAMESPACE: &str = "test_namespace";
+const TEST_INDENTIFIER: &str = "simple_wasm_executor";
 
 async fn load_wasm_module(database_url: &str) -> IndexerResult<Instance> {
     let compiler = compiler();
@@ -87,9 +89,14 @@ async fn generate_schema_then_load_schema_from_wasm_module(database_url: &str) {
     assert!(result.is_ok());
 
     let version = schema_version(&schema);
-    let results = queries::columns_get_schema(&mut conn, "test_namespace", &version)
-        .await
-        .expect("Metadata query failed");
+    let results = queries::columns_get_schema(
+        &mut conn,
+        "test_namespace",
+        "simple_wasm_executor",
+        &version,
+    )
+    .await
+    .expect("Metadata query failed");
 
     for (index, result) in results.into_iter().enumerate() {
         assert_eq!(result.table_name, TEST_COLUMNS[index].0);
@@ -113,7 +120,8 @@ async fn generate_schema_then_load_schema_from_wasm_module(database_url: &str) {
     assert_eq!(db.version, version);
 
     for column in TEST_COLUMNS.iter() {
-        assert!(db.schema.contains_key(column.0));
+        let key = format!("{}_{}.{}", TEST_NAMESPACE, TEST_INDENTIFIER, column.0);
+        assert!(db.schema.contains_key(&key));
     }
 
     let object_id = 4;


### PR DESCRIPTION
Closes #604.

## Changelog
- Generate  and retrieve type IDs with both namespace and identifier instead of only namespace

## Notes
This bug is ultimately caused by type ID collisions in `graph_registry_type_ids`. Currently, type IDs are generated by using only the namespace of an index and then stored in `graph_registry_type_ids`. If the same type is present in two indices, then there will be a collision and the service will not start the second index. 

## Reproduction (on master)
0. Ensure database is clear and build `forc-index` and `explorer-index` WASM: `cargo build -p forc-index`, then `bash scripts/utils/build_test_wasm_module.bash`.
1. Start the service using the beta2 testnet node and ensure that the example has successfully started and indexed data: 
```
cargo run --bin fuel-indexer -- run --fuel-node-host node-beta-2.fuel.network --fuel-node-port 80 --manifest examples/block-explorer/explorer-index/explorer_index.manifest.yaml
```
2. Change`identifier` field in explorer example indexer manifest to something unique; "explorer_index2" will suffice.
3. Deploy explorer indexer again:
```
../../target/release/forc-index deploy --release \
   --path explorer-index \
   --output-dir-root ~/dev/fuel/indexer \
   --url http://0.0.0.0:29987 \
   --target wasm32-unknown-unknown
```
4. A non-200 status code saying that the deployment failed should be returned as a result.

Alternatively, you should be able to reproduce the error using the steps detailed [here](https://github.com/FuelLabs/fuel-indexer/issues/604#issuecomment-1462755739).

## Testing Steps (on this branch)
1. Repeat the same steps as above. You should see that the second indexer is successfully deployed under the same namespace. Upon checking the logs, you should see `INSERT` queries from both indexers.
2. If desired, you can run the following queries to ensure that both indexers have stored data and are able to return it:
```
curl -X POST http://127.0.0.1:29987/api/graph/fuel_examples/explorer_index \
   -H 'content-type: application/json' \
   -d '{"query": "query { block { id height timestamp }}", "params": "b"}' \
| json_pp

```
```
curl -X POST http://127.0.0.1:29987/api/graph/fuel_examples/explorer_index2 \
   -H 'content-type: application/json' \
   -d '{"query": "query { block { id height timestamp }}", "params": "b"}' \
| json_pp

```