### PR TITLE
chore: enable sparse protocol in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
   SQLX_OFFLINE: true
-  RUSTC_VERSION: 1.67
+  RUSTC_VERSION: 1.68
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   IS_MASTER: github.ref == 'refs/heads/master'
   IS_RELEASE: github.event_name == 'release' && github.event.action == 'published'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-indexer"
-rust-version = "1.67.0"
+rust-version = "1.68.0"
 version = "0.4.0"
 
 [workspace.dependencies]


### PR DESCRIPTION
closes #654 

According to [this](https://github.com/FuelLabs/fuels-rs/pull/888#issuecomment-1469491450), all we need to do is bump the version to enable sparse protocol in the CI. See the linked issue about this new rust feature. 

