### PR TITLE
chore: update docs with new fuelup url

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ To Install fuelup with the default features/options, use the following command, 
 ```bash
 curl \
   --proto '=https' \
-  --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
+  --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh 
 ```
 
 > If you require a non-default `fuelup` installation, please [read the `fuelup` installation docs.](https://github.com/FuelLabs/fuelup)

--- a/docs/src/getting-started/dependencies.md
+++ b/docs/src/getting-started/dependencies.md
@@ -16,7 +16,7 @@ Also, it's assumed that you have the Rust programming language installed on your
 We strongly recommend that you use the Fuel indexer through [`forc`, the Fuel orchestrator](https://fuellabs.github.io/sway/master/forc/index.html). You can get `forc` (and other Fuel components) by way of [`fuelup`, the Fuel toolchain manager](https://fuellabs.github.io/fuelup/latest). Install `fuelup` by running the following command, which downloads and runs the installation script.
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
+curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh 
 ```
 
 After `fuelup` has been installed, the `forc index` command and `fuel-indexer` binaries will be available on your system.

--- a/docs/src/getting-started/dependencies/fuelup.md
+++ b/docs/src/getting-started/dependencies/fuelup.md
@@ -6,7 +6,7 @@ We strongly recommend that you use the Fuel indexer through [`forc`, the Fuel or
 curl \
     --proto '=https' \
     --tlsv1.2 -sSf \
-    curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh
+    https://install.fuel.network/fuelup-init.sh | sh
 ```
 
 After `fuelup` has been installed, the `forc index` command and `fuel-indexer` binaries will be available on your system.

--- a/docs/src/getting-started/dependencies/fuelup.md
+++ b/docs/src/getting-started/dependencies/fuelup.md
@@ -6,7 +6,7 @@ We strongly recommend that you use the Fuel indexer through [`forc`, the Fuel or
 curl \
     --proto '=https' \
     --tlsv1.2 -sSf \
-    https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
+    curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh
 ```
 
 After `fuelup` has been installed, the `forc index` command and `fuel-indexer` binaries will be available on your system.


### PR DESCRIPTION
the fuelup resource url has changed. Our docs need to be updated with the new url. 

## testing
remove your current fuelup directory. Try the command in the current docs, this should fail.
```
curl \
    --proto '=https' \
    --tlsv1.2 -sSf \
    https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
```
Try the new command 
```
curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh
```
