### PR TITLE
docs: fix block explorer embed in book

### DIFF
--- a/docs/src/examples/block-explorer.md
+++ b/docs/src/examples/block-explorer.md
@@ -3,7 +3,7 @@
 Below is an example of a rudimentary block explorer backend implementation that demonstrates how to leverage basic Fuel indexer abstractions in order to build a cool dApp backend.
 
 ```rust,ignore
-{{#include ../../../examples/block-explorer/explorer-index/src/lib.rs}}
+{{#include ../../../examples/block-explorer/explorer-indexer/src/lib.rs}}
 ```
 
 Once blocks have been added to the database by the indexer, you can query for them by using a query similar to the following:


### PR DESCRIPTION
## Changelog
- Fix improper include in block explorer example section of book

## Testing Plan
Pull down the branch, change into the `docs` directory, and run `mdbook serve`. Check the block explorer section to verify that the code is properly included now.