### PR TITLE
fix: remove skipped dependent jobs for master/release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,6 @@ jobs:
       - cargo-test-e2e-and-integration-tests
       - cargo-test-unit-tests
       - cargo-verifications
-      - check-forc-index
       - set-env-vars
     if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER == 'true'
     runs-on: buildjet-4vcpu-ubuntu-2204
@@ -388,7 +387,6 @@ jobs:
       - cargo-test-e2e-and-integration-tests
       - cargo-test-unit-tests
       - cargo-verifications
-      - check-forc-index
       - set-env-vars
     if: needs.set-env-vars.outputs.IS_RELEASE == 'true'
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,11 +310,6 @@ jobs:
 
   publish-docker-image:
     needs:
-      - cargo-clippy
-      - cargo-fmt-check
-      - cargo-test-e2e-and-integration-tests
-      - cargo-test-unit-tests
-      - cargo-verifications
       - set-env-vars
     if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER == 'true'
     runs-on: buildjet-4vcpu-ubuntu-2204
@@ -382,11 +377,6 @@ jobs:
   publish-fuel-indexer-binaries:
     runs-on: ${{ matrix.job.os }}
     needs:
-      - cargo-clippy
-      - cargo-fmt-check
-      - cargo-test-e2e-and-integration-tests
-      - cargo-test-unit-tests
-      - cargo-verifications
       - set-env-vars
     if: needs.set-env-vars.outputs.IS_RELEASE == 'true'
     strategy:


### PR DESCRIPTION
- In Github actions a job is skipped if any one of it's dependencies is skipped, even if the `if:` statement of the job evaluates true
- So we need to unskip the docker/publish jobs by removing their skipped dependencies