### PR TITLE
remove --fuel-core-lib from Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,6 @@ jobs:
             build \
             --profile=release \
             --target ${{ matrix.job.target }} \
-            --features fuel-core-lib \
             -p fuel-indexer \
             -p fuel-indexer-api-server \
             -p forc-index

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -30,10 +30,10 @@ COPY --from=planner /build/recipe.json recipe.json
 
 ENV SQLX_OFFLINE=true
 
-RUN cargo chef cook --release --features fuel-core-lib -p fuel-indexer --recipe-path recipe.json
-RUN cargo chef cook --release --features fuel-core-lib -p fuel-indexer-api-server --recipe-path recipe.json
+RUN cargo chef cook --release -p fuel-indexer --recipe-path recipe.json
+RUN cargo chef cook --release -p fuel-indexer-api-server --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --features fuel-core-lib -p fuel-indexer -p fuel-indexer-api-server $BUILD_TARGET
+RUN cargo build --release -p fuel-indexer -p fuel-indexer-api-server $BUILD_TARGET
 
 # Stage 3: Run
 FROM ubuntu:22.04 AS run


### PR DESCRIPTION
### Description
- `--fuel-core-lib` is a feature that only applies to `fuel-indexer`, not `fuel-indexer-api-server`
- For now, just remove the feature from the Docker build, we can add it back later when we decide if we want to also add the feature to `fuel-indexer-api-server`

### Testing steps
- [ ] Local build should pass `docker build -t fuel-indexer/local:latest -f deployment/Dockerfile .`