### PR TITLE
ci: remove Postgres service from cargo-verifications build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       matrix:
         command: [build]
         args: [--locked --all-features --all-targets]
-        package: [fuel-indexer-api-server, fuel-indexer-database, fuel-indexer-database-types, fuel-indexer-postgres, fuel-indexer-lib, fuel-indexer-macros, fuel-indexer-metrics, fuel-indexer-plugin, fuel-indexer-schema, fuel-indexer-types, forc-index, forc-postgres]
+        package: [fuel-indexer, fuel-indexer-api-server, fuel-indexer-database, fuel-indexer-database-types, fuel-indexer-postgres, fuel-indexer-lib, fuel-indexer-macros, fuel-indexer-metrics, fuel-indexer-plugin, fuel-indexer-schema, fuel-indexer-types, forc-index, forc-postgres]
 
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,16 +128,6 @@ jobs:
 
   cargo-verifications:
     runs-on: buildjet-4vcpu-ubuntu-2204
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_PASSWORD: my-secret
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     needs:
       - cargo-toml-fmt-check
       - set-env-vars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,12 @@ jobs:
       - deploy
       - publish
       - cargo-verifications
+      - cargo-test-unit-tests
+      - cargo-test-e2e-and-integration-tests
+      - cargo-clippy
+      - cargo-fmt-check
+      - check-forc-index
+
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - run: true


### PR DESCRIPTION
## Changelog
- Remove Postgres from the `services` for `cargo-verifications`
- Re-add `fuel-indexer` to package strategy matrix for `cargo-verifications`
- Add additional requirements to `validation-complete` step

## Notes
@Voxelot mentioned that we're pulling Postgres in on the build step for each package. However, we're not leveraging the database at all during the build step as we've disabled SQLx's compile-time query checking. So in order to reduce the frequency of rate limit errors, I'm removing Postgres from the build step.