### PR TITLE
chore: uprgade publish-crates github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,7 +614,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Publish crates
-        uses: katyo/publish-crates@v1
+        uses: katyo/publish-crates@v2
         with:
           publish-delay: 30000
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Changelog
- Upgrade `publish-crates` GitHub action

## Notes
Looks like our very own @xgreenx made a contribution to the `publish-crates` action that will solve our publishing issues.

Contribution: https://github.com/katyo/publish-crates/pull/600
Related `fuels-rs` PR: https://github.com/FuelLabs/fuels-rs/pull/813#issuecomment-1412690390