### PR TITLE
enhancement: make verbose logging configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,6 +66,9 @@
 #     # Postgres port.
 #     port: 5432
 
+#     # Enable verbose database logging.
+#     verbose_logging: false
+
 # # ******************************
 # # Indexer service authentication
 # # ******************************

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,9 @@
 
 # # Run database migrations before starting service.
 # run_migrations: true
+#
+# # Enable verbose logging.
+# verbose_logging: false
 
 # # ***********************
 # # Fuel Node configuration

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@
 # run_migrations: true
 #
 # # Enable verbose logging.
-# verbose_logging: false
+# verbose: false
 
 # # ***********************
 # # Fuel Node configuration
@@ -65,9 +65,6 @@
 
 #     # Postgres port.
 #     port: 5432
-
-#     # Enable verbose database logging.
-#     verbose_logging: false
 
 # # ******************************
 # # Indexer service authentication

--- a/deployment/charts/templates/fuel-indexer-deployment.yaml
+++ b/deployment/charts/templates/fuel-indexer-deployment.yaml
@@ -44,6 +44,7 @@ spec:
             - "--graphql-api-host"
             - "0.0.0.0"
             - "--run-migrations"
+            - "--verbose"
           env:
           - name: POSTGRES_PASSWORD
             valueFrom:

--- a/docs/src/getting-started/starting-the-fuel-indexer.md
+++ b/docs/src/getting-started/starting-the-fuel-indexer.md
@@ -9,8 +9,8 @@ USAGE:
     fuel-indexer run [OPTIONS]
 
 OPTIONS:
-        --auth-enabled <auth-enabled>
-            Require users to authenticate for some operations. [default: false]
+        --auth-enabled
+            Require users to authenticate for some operations.
 
         --auth-strategy <AUTH_STRATEGY>
             Authentication scheme used.
@@ -20,6 +20,9 @@ OPTIONS:
 
         --database <DATABASE>
             Database type. [default: postgres] [possible values: postgres]
+
+        --embedded-database
+            Automatically create and start database using provided options or defaults.
 
         --fuel-node-host <FUEL_NODE_HOST>
             Host of the running Fuel node. [default: localhost]
@@ -50,13 +53,13 @@ OPTIONS:
             debug, error, warn]
 
     -m, --manifest <FILE>
-            Indexer config file.
+            Index config file.
 
         --max-body-size <MAX_BODY_SIZE>
             Max body size for GraphQL API requests. [default: 5242880]
 
-        --metrics <metrics>
-            Use Prometheus metrics reporting. [default: true]
+        --metrics
+            Use Prometheus metrics reporting.
 
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.
@@ -73,8 +76,8 @@ OPTIONS:
         --postgres-user <POSTGRES_USER>
             Postgres username.
 
-        --run-migrations <run-migrations>
-            Run database migrations before starting service. [default: true]
+        --run-migrations
+            Run database migrations before starting service.
 
         --stop-idle-indexers
             Prevent indexers from running without handling any blocks.
@@ -82,6 +85,11 @@ OPTIONS:
     -V, --version
             Print version information
 
+        --verbose-db-logging
+            Enable verbose database logging.
+
+        --verbose-logging
+            Enable verbose logging.
 ```
 
 ## Using a configuration file

--- a/docs/src/getting-started/starting-the-fuel-indexer.md
+++ b/docs/src/getting-started/starting-the-fuel-indexer.md
@@ -53,7 +53,7 @@ OPTIONS:
             debug, error, warn]
 
     -m, --manifest <FILE>
-            Index config file.
+            Indexer config file.
 
         --max-body-size <MAX_BODY_SIZE>
             Max body size for GraphQL API requests. [default: 5242880]
@@ -85,11 +85,9 @@ OPTIONS:
     -V, --version
             Print version information
 
-        --verbose-db-logging
-            Enable verbose database logging.
-
-        --verbose-logging
+    -v, --verbose
             Enable verbose logging.
+
 ```
 
 ## Using a configuration file

--- a/docs/src/reference-guide/components/graphql/api-server.md
+++ b/docs/src/reference-guide/components/graphql/api-server.md
@@ -22,11 +22,23 @@ USAGE:
     fuel-indexer-api-server run [OPTIONS]
 
 OPTIONS:
+        --auth-enabled
+            Require users to authenticate for some operations.
+
+        --auth-strategy <AUTH_STRATEGY>
+            Authentication scheme used.
+
     -c, --config <CONFIG>
             API server config file.
 
         --database <DATABASE>
             Database type. [default: postgres] [possible values: postgres]
+
+        --fuel-node-host <FUEL_NODE_HOST>
+            Host of the running Fuel node. [default: localhost]
+
+        --fuel-node-port <FUEL_NODE_PORT>
+            Listening port of the running Fuel node. [default: 4000]
 
         --graphql-api-host <GRAPHQL_API_HOST>
             GraphQL API host. [default: localhost]
@@ -37,12 +49,20 @@ OPTIONS:
     -h, --help
             Print help information
 
-        --log-level <LOG_LEVEL>
-            Log level passed to the Fuel Indexer service. [default: info] [possible values: info,
-            debug, error, warn]
+        --jwt-expiry <JWT_EXPIRY>
+            Amount of time (seconds) before expiring token (if JWT scheme is specified).
 
-        --metrics <metrics>
-            Use Prometheus metrics reporting. [default: true]
+        --jwt-issuer <JWT_ISSUER>
+            Issuer of JWT claims (if JWT scheme is specified).
+
+        --jwt-secret <JWT_SECRET>
+            Secret used for JWT scheme (if JWT scheme is specified).
+
+        --max-body-size <MAX_BODY_SIZE>
+            Max body size for GraphQL API requests. [default: 5242880]
+
+        --metrics
+            Use Prometheus metrics reporting.
 
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.
@@ -59,9 +79,13 @@ OPTIONS:
         --postgres-user <POSTGRES_USER>
             Postgres username.
 
-        --run-migrations <run-migrations>
-            Run database migrations before starting service. [default: true]
+        --run-migrations
+            Run database migrations before starting service.
 
     -V, --version
             Print version information
+
+    -v, --verbose
+            Enable verbose logging.
+
 ```

--- a/packages/fuel-indexer-api-server/src/cli.rs
+++ b/packages/fuel-indexer-api-server/src/cli.rs
@@ -1,7 +1,6 @@
 pub(crate) use crate::commands::run;
 use clap::{Parser, Subcommand};
 use fuel_indexer_lib::config::ApiServerArgs;
-use fuel_indexer_lib::utils::bin_utils::init_logging;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -23,8 +22,6 @@ pub enum ApiServer {
 }
 
 pub async fn run_cli() -> anyhow::Result<()> {
-    init_logging().await?;
-
     let opt = Opt::try_parse();
 
     match opt {

--- a/packages/fuel-indexer-api-server/src/commands/run.rs
+++ b/packages/fuel-indexer-api-server/src/commands/run.rs
@@ -1,6 +1,9 @@
 use crate::api::GraphQlApi;
 use fuel_indexer_database::{queries, IndexerConnectionPool};
-use fuel_indexer_lib::config::{ApiServerArgs, IndexerConfig};
+use fuel_indexer_lib::{
+    config::{ApiServerArgs, IndexerConfig},
+    utils::init_logging,
+};
 use tracing::info;
 
 pub async fn exec(args: ApiServerArgs) -> anyhow::Result<()> {
@@ -17,6 +20,8 @@ pub async fn exec(args: ApiServerArgs) -> anyhow::Result<()> {
         let mut c = pool.acquire().await?;
         queries::run_migration(&mut c).await?;
     }
+
+    init_logging(&config).await?;
 
     let _ = GraphQlApi::build_and_run(config.clone(), pool, None).await;
 

--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -561,7 +561,7 @@ pub async fn register_index_asset(
         asset_already_exists(conn, &asset_type, &bytes, &index.id).await?
     {
         info!(
-            "Asset({asset_type:?}) for Index({}) already registered.",
+            "Asset({asset_type:?}) for Indexer({}) already registered.",
             index.uid()
         );
         return Ok(asset);
@@ -585,7 +585,7 @@ pub async fn register_index_asset(
         .await?;
 
     info!(
-        "Registered Asset({:?}) to Index({}).",
+        "Registered Asset({:?}) to Indexer({}).",
         asset_type,
         index.uid()
     );

--- a/packages/fuel-indexer-database/src/lib.rs
+++ b/packages/fuel-indexer-database/src/lib.rs
@@ -1,5 +1,10 @@
 #![deny(unused_crate_dependencies)]
 
+pub mod queries;
+pub mod types {
+    pub use fuel_indexer_database_types::*;
+}
+
 pub use fuel_indexer_database_types::DbType;
 use fuel_indexer_lib::utils::{attempt_database_connection, ServiceStatus};
 use fuel_indexer_postgres as postgres;
@@ -8,11 +13,6 @@ use sqlx::{
 };
 use std::{cmp::Ordering, collections::HashMap, str::FromStr};
 use thiserror::Error;
-
-pub mod queries;
-pub mod types {
-    pub use fuel_indexer_database_types::*;
-}
 
 #[derive(Debug, Error)]
 pub enum IndexerDatabaseError {

--- a/packages/fuel-indexer-database/src/lib.rs
+++ b/packages/fuel-indexer-database/src/lib.rs
@@ -57,7 +57,7 @@ impl IndexerConnectionPool {
         let url = url.expect("Database URL should be correctly formed");
         let params: HashMap<_, _> = url.query_pairs().into_owned().collect();
         let verbose = params
-            .get("verbose_logging")
+            .get("verbose")
             .map(|x| x.to_string())
             .unwrap_or("false".to_string());
 

--- a/packages/fuel-indexer-database/src/lib.rs
+++ b/packages/fuel-indexer-database/src/lib.rs
@@ -57,7 +57,7 @@ impl IndexerConnectionPool {
         let url = url.expect("Database URL should be correctly formed");
         let params: HashMap<_, _> = url.query_pairs().into_owned().collect();
         let verbose = params
-            .get("verbose")
+            .get("verbose_logging")
             .map(|x| x.to_string())
             .unwrap_or("false".to_string());
 

--- a/packages/fuel-indexer-lib/src/config/database.rs
+++ b/packages/fuel-indexer-lib/src/config/database.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::{
     config::{Env, IndexerConfigResult},
     defaults,
@@ -8,6 +6,7 @@ use crate::{
 pub use clap::Parser;
 use http::Uri;
 use serde::Deserialize;
+use std::{collections::HashMap, str::FromStr};
 use url::{ParseError, Url};
 
 #[derive(Clone, Deserialize)]
@@ -131,6 +130,11 @@ impl FromStr for DatabaseConfig {
 
     fn from_str(db_url: &str) -> Result<Self, Self::Err> {
         let url = Url::parse(db_url)?;
+        let params: HashMap<_, _> = url.query_pairs().into_owned().collect();
+        let value = params
+            .get("verbose_logging")
+            .unwrap_or(&"false".into())
+            .to_owned();
 
         match url.scheme() {
             "postgres" => {
@@ -150,6 +154,7 @@ impl FromStr for DatabaseConfig {
                     host: host.to_string(),
                     port: port.to_string(),
                     database: database.to_string(),
+                    verbose_logging: value,
                 })
             }
             _ => {

--- a/packages/fuel-indexer-lib/src/config/database.rs
+++ b/packages/fuel-indexer-lib/src/config/database.rs
@@ -18,7 +18,7 @@ pub enum DatabaseConfig {
         host: String,
         port: String,
         database: String,
-        verbose_logging: String,
+        verbose: String,
     },
 }
 
@@ -66,9 +66,9 @@ impl std::string::ToString for DatabaseConfig {
                 host,
                 port,
                 database,
-                verbose_logging,
+                verbose,
             } => {
-                let params = [("verbose_logging", verbose_logging)]
+                let params = [("verbose", verbose)]
                     .iter()
                     .map(|(k, v)| format!("{k}={v}"))
                     .collect::<Vec<String>>()
@@ -87,7 +87,7 @@ impl std::fmt::Debug for DatabaseConfig {
                 host,
                 port,
                 database,
-                verbose_logging,
+                verbose,
                 ..
             } => {
                 let _ = f
@@ -97,7 +97,7 @@ impl std::fmt::Debug for DatabaseConfig {
                     .field("host", &host)
                     .field("port", &port)
                     .field("database", &database)
-                    .field("verbose_logging", &verbose_logging)
+                    .field("verbose", &verbose)
                     .finish();
             }
         }
@@ -114,7 +114,7 @@ impl Default for DatabaseConfig {
             host: defaults::POSTGRES_HOST.into(),
             port: defaults::POSTGRES_PORT.into(),
             database: defaults::POSTGRES_DATABASE.into(),
-            verbose_logging: defaults::VERBOSE_DB_LOGGING.into(),
+            verbose: defaults::VERBOSE_DB_LOGGING.into(),
         }
     }
 }
@@ -131,10 +131,7 @@ impl FromStr for DatabaseConfig {
     fn from_str(db_url: &str) -> Result<Self, Self::Err> {
         let url = Url::parse(db_url)?;
         let params: HashMap<_, _> = url.query_pairs().into_owned().collect();
-        let value = params
-            .get("verbose_logging")
-            .unwrap_or(&"false".into())
-            .to_owned();
+        let value = params.get("verbose").unwrap_or(&"false".into()).to_owned();
 
         match url.scheme() {
             "postgres" => {
@@ -154,7 +151,7 @@ impl FromStr for DatabaseConfig {
                     host: host.to_string(),
                     port: port.to_string(),
                     database: database.to_string(),
-                    verbose_logging: value,
+                    verbose: value,
                 })
             }
             _ => {

--- a/packages/fuel-indexer-lib/src/config/database.rs
+++ b/packages/fuel-indexer-lib/src/config/database.rs
@@ -19,6 +19,7 @@ pub enum DatabaseConfig {
         host: String,
         port: String,
         database: String,
+        verbose_logging: String,
     },
 }
 
@@ -31,6 +32,7 @@ impl Env for DatabaseConfig {
                 host,
                 port,
                 database,
+                ..
             } => {
                 if is_opt_env_var(user) {
                     *user = std::env::var(trim_opt_env_key(user))?;
@@ -65,8 +67,14 @@ impl std::string::ToString for DatabaseConfig {
                 host,
                 port,
                 database,
+                verbose_logging,
             } => {
-                format!("postgres://{user}:{password}@{host}:{port}/{database}")
+                let params = [("verbose_logging", verbose_logging)]
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<String>>()
+                    .join("&");
+                format!("postgres://{user}:{password}@{host}:{port}/{database}?{params}")
             }
         }
     }
@@ -80,6 +88,7 @@ impl std::fmt::Debug for DatabaseConfig {
                 host,
                 port,
                 database,
+                verbose_logging,
                 ..
             } => {
                 let _ = f
@@ -89,6 +98,7 @@ impl std::fmt::Debug for DatabaseConfig {
                     .field("host", &host)
                     .field("port", &port)
                     .field("database", &database)
+                    .field("verbose_logging", &verbose_logging)
                     .finish();
             }
         }
@@ -105,6 +115,7 @@ impl Default for DatabaseConfig {
             host: defaults::POSTGRES_HOST.into(),
             port: defaults::POSTGRES_PORT.into(),
             database: defaults::POSTGRES_DATABASE.into(),
+            verbose_logging: defaults::VERBOSE_DB_LOGGING.into(),
         }
     }
 }

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -11,7 +11,6 @@ pub use crate::{
         graphql::GraphQLConfig,
     },
     defaults,
-    utils::bool_to_str,
 };
 pub use clap::{Args, Parser, ValueEnum};
 use serde::Deserialize;
@@ -359,7 +358,7 @@ impl From<IndexerArgs> for IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
-                verbose: bool_to_str(args.verbose),
+                verbose: args.verbose.to_string(),
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -434,7 +433,7 @@ impl From<ApiServerArgs> for IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
-                verbose: bool_to_str(args.verbose),
+                verbose: args.verbose.to_string(),
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -511,7 +510,7 @@ impl IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
-                verbose: bool_to_str(args.verbose),
+                verbose: args.verbose.to_string(),
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -667,7 +666,7 @@ impl IndexerConfig {
                     host: pg_host,
                     port: pg_port,
                     database: pg_db,
-                    verbose: bool_to_str(config.verbose),
+                    verbose: config.verbose.to_string(),
                 };
             }
         }

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -740,8 +740,8 @@ mod tests {
         let config = IndexerConfig::from_file(FILE).unwrap();
 
         assert!(config.stop_idle_indexers);
-        assert_eq!(config.run_migrations, false);
-        assert_eq!(config.verbose, false);
+        assert!(!config.run_migrations);
+        assert!(!config.verbose);
 
         let DatabaseConfig::Postgres { verbose, .. } = config.database;
         assert_eq!(verbose.as_str(), "false");

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -184,7 +184,7 @@ pub struct IndexerArgs {
 
     /// Enable verbose logging.
     #[clap(long, help = "Enable verbose logging.")]
-    pub verbose: bool,
+    pub verbose_logging: bool,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -283,6 +283,10 @@ pub struct ApiServerArgs {
         help = "Amount of time (seconds) before expiring token (if JWT scheme is specified)."
     )]
     pub jwt_expiry: Option<usize>,
+
+    /// Enable verbose logging.
+    #[clap(long, help = "Enable verbose logging.")]
+    pub verbose_logging: bool,
 }
 
 fn derive_http_url(host: &String, port: &String) -> String {
@@ -306,6 +310,8 @@ impl std::string::ToString for FuelNodeConfig {
 
 #[derive(Clone, Deserialize, Default, Debug)]
 pub struct IndexerConfig {
+    #[serde(default)]
+    pub verbose_logging: bool,
     #[serde(default)]
     pub fuel_node: FuelNodeConfig,
     #[serde(default)]
@@ -359,6 +365,7 @@ impl From<IndexerArgs> for IndexerConfig {
         };
 
         let mut config = IndexerConfig {
+            verbose_logging: args.verbose_logging,
             database,
             fuel_node: FuelNodeConfig {
                 host: args.fuel_node_host,
@@ -430,6 +437,7 @@ impl From<ApiServerArgs> for IndexerConfig {
         };
 
         let mut config = IndexerConfig {
+            verbose_logging: args.verbose_logging,
             database,
             fuel_node: FuelNodeConfig {
                 host: args.fuel_node_host,
@@ -503,6 +511,7 @@ impl IndexerConfig {
         };
 
         let mut config = IndexerConfig {
+            verbose_logging: args.verbose_logging,
             database,
             fuel_node: FuelNodeConfig {
                 host: args.fuel_node_host,

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -185,6 +185,10 @@ pub struct IndexerArgs {
     /// Enable verbose logging.
     #[clap(long, help = "Enable verbose logging.")]
     pub verbose_logging: bool,
+
+    /// Enable verbose database logging.
+    #[clap(long, default_value = defaults::VERBOSE_DB_LOGGING, help = "Enable verbose database logging.")]
+    pub verbose_db_logging: String,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -287,6 +291,10 @@ pub struct ApiServerArgs {
     /// Enable verbose logging.
     #[clap(long, help = "Enable verbose logging.")]
     pub verbose_logging: bool,
+
+    /// Enable verbose database logging.
+    #[clap(long, default_value = defaults::VERBOSE_DB_LOGGING, help = "Enable verbose database logging.")]
+    pub verbose_db_logging: String,
 }
 
 fn derive_http_url(host: &String, port: &String) -> String {
@@ -358,6 +366,7 @@ impl From<IndexerArgs> for IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
+                verbose_logging: args.verbose_db_logging,
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -430,6 +439,7 @@ impl From<ApiServerArgs> for IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
+                verbose_logging: args.verbose_db_logging,
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -504,6 +514,7 @@ impl IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
+                verbose_logging: args.verbose_db_logging,
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -598,6 +609,7 @@ impl IndexerConfig {
                 let mut pg_host = defaults::POSTGRES_HOST.to_string();
                 let mut pg_port = defaults::POSTGRES_PORT.to_string();
                 let mut pg_db = defaults::POSTGRES_DATABASE.to_string();
+                let mut verbose = defaults::VERBOSE_DB_LOGGING.to_string();
 
                 let pg_host_value =
                     pg_section.get(&serde_yaml::Value::String("host".into()));
@@ -629,12 +641,19 @@ impl IndexerConfig {
                     pg_db = pg_database_value.as_str().unwrap().to_string();
                 }
 
+                let verbose_db_logging =
+                    pg_section.get(&serde_yaml::Value::String("verbose_logging".into()));
+                if let Some(verbose_db_logging) = verbose_db_logging {
+                    verbose = verbose_db_logging.as_str().unwrap().to_string();
+                }
+
                 config.database = DatabaseConfig::Postgres {
                     user: pg_user,
                     password: pg_password,
                     host: pg_host,
                     port: pg_port,
                     database: pg_db,
+                    verbose_logging: verbose,
                 };
             }
         }

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -11,6 +11,7 @@ pub use crate::{
         graphql::GraphQLConfig,
     },
     defaults,
+    utils::bool_to_str,
 };
 pub use clap::{Args, Parser, ValueEnum};
 use serde::Deserialize;
@@ -187,8 +188,8 @@ pub struct IndexerArgs {
     pub verbose_logging: bool,
 
     /// Enable verbose database logging.
-    #[clap(long, default_value = defaults::VERBOSE_DB_LOGGING, help = "Enable verbose database logging.")]
-    pub verbose_db_logging: String,
+    #[clap(long, help = "Enable verbose database logging.")]
+    pub verbose_db_logging: bool,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -293,8 +294,8 @@ pub struct ApiServerArgs {
     pub verbose_logging: bool,
 
     /// Enable verbose database logging.
-    #[clap(long, default_value = defaults::VERBOSE_DB_LOGGING, help = "Enable verbose database logging.")]
-    pub verbose_db_logging: String,
+    #[clap(long, help = "Enable verbose database logging.")]
+    pub verbose_db_logging: bool,
 }
 
 fn derive_http_url(host: &String, port: &String) -> String {
@@ -366,7 +367,7 @@ impl From<IndexerArgs> for IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
-                verbose_logging: args.verbose_db_logging,
+                verbose_logging: bool_to_str(args.verbose_db_logging),
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -439,7 +440,7 @@ impl From<ApiServerArgs> for IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
-                verbose_logging: args.verbose_db_logging,
+                verbose_logging: bool_to_str(args.verbose_db_logging),
             },
             _ => {
                 panic!("Unrecognized database type in options.");
@@ -514,7 +515,7 @@ impl IndexerConfig {
                         defaults::POSTGRES_DATABASE.to_string(),
                     )
                 }),
-                verbose_logging: args.verbose_db_logging,
+                verbose_logging: bool_to_str(args.verbose_db_logging),
             },
             _ => {
                 panic!("Unrecognized database type in options.");

--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -44,3 +44,7 @@ pub const AUTH_ENABLED: bool = false;
 pub const JWT_EXPIRY_SECS: usize = 2592000; // 30 days
 
 pub const ACCOUNT_INDEX: &str = "0";
+
+pub const VERBOSE_LOGGING: bool = false;
+
+pub const VERBOSE_DB_LOGGING: &str = "false";

--- a/packages/fuel-indexer-lib/src/utils.rs
+++ b/packages/fuel-indexer-lib/src/utils.rs
@@ -328,11 +328,3 @@ pub fn host_triple() -> String {
         .expect("Failed to determine host triple via rustc.")[6..]
         .to_owned()
 }
-
-pub fn bool_to_str(b: bool) -> String {
-    if b {
-        "true".to_string()
-    } else {
-        "false".to_string()
-    }
-}

--- a/packages/fuel-indexer-lib/src/utils.rs
+++ b/packages/fuel-indexer-lib/src/utils.rs
@@ -1,18 +1,23 @@
-use crate::defaults;
+use crate::{config::IndexerConfig, defaults};
 use anyhow::Result;
 use fuel_indexer_types::Bytes32;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::str::FromStr;
 use std::{
+    env,
     fs::canonicalize,
     future::Future,
     net::{SocketAddr, ToSocketAddrs},
     path::Path,
     process::Command,
+    str::FromStr,
 };
 use tokio::time::{sleep, Duration};
 use tracing::{info, warn};
+use tracing_subscriber::filter::EnvFilter;
+
+const RUST_LOG: &str = "RUST_LOG";
+const HUMAN_LOGGING: &str = "HUMAN_LOGGING";
 
 // Testing assets use relative paths, while production assets will use absolute paths
 //
@@ -171,51 +176,49 @@ pub struct FuelNodeHealthResponse {
     up: bool,
 }
 
-pub mod bin_utils {
-    use std::env;
-    use std::str::FromStr;
-    use tracing_subscriber::filter::EnvFilter;
+pub async fn init_logging(config: &IndexerConfig) -> anyhow::Result<()> {
+    let level = env::var_os(RUST_LOG)
+        .map(|x| x.into_string().unwrap())
+        .unwrap_or("info".to_string());
 
-    const LOG_FILTER: &str = "RUST_LOG";
-    const HUMAN_LOGGING: &str = "HUMAN_LOGGING";
-
-    pub async fn init_logging() -> anyhow::Result<()> {
-        let filter = match env::var_os(LOG_FILTER) {
-            Some(_) => {
-                EnvFilter::try_from_default_env().expect("Invalid `RUST_LOG` provided")
-            }
-            None => EnvFilter::new("info"),
-        };
-
-        let human_logging = env::var_os(HUMAN_LOGGING)
-            .map(|s| {
-                bool::from_str(s.to_str().unwrap()).expect(
-                    "Expected `true` or `false` to be provided for `HUMAN_LOGGING`",
-                )
-            })
-            .unwrap_or(true);
-
-        let sub = tracing_subscriber::fmt::Subscriber::builder()
-            .with_writer(std::io::stderr)
-            .with_env_filter(filter);
-
-        if human_logging {
-            sub.with_ansi(true)
-                .with_level(true)
-                .with_line_number(true)
-                .init();
-        } else {
-            sub.with_ansi(false)
-                .with_level(true)
-                .with_line_number(true)
-                .json()
-                .init();
-        }
-        Ok(())
+    if !config.verbose_logging {
+        std::env::set_var(RUST_LOG, &format!("{level},wasmer_compiler_cranelift=warn"));
     }
+
+    let filter = match env::var_os(RUST_LOG) {
+        Some(_) => {
+            EnvFilter::try_from_default_env().expect("Invalid `RUST_LOG` provided")
+        }
+        None => EnvFilter::new("info"),
+    };
+
+    let human_logging = env::var_os(HUMAN_LOGGING)
+        .map(|s| {
+            bool::from_str(s.to_str().unwrap())
+                .expect("Expected `true` or `false` to be provided for `HUMAN_LOGGING`")
+        })
+        .unwrap_or(true);
+
+    let sub = tracing_subscriber::fmt::Subscriber::builder()
+        .with_writer(std::io::stderr)
+        .with_env_filter(filter);
+
+    if human_logging {
+        sub.with_ansi(true)
+            .with_level(true)
+            .with_line_number(true)
+            .init();
+    } else {
+        sub.with_ansi(false)
+            .with_level(true)
+            .with_line_number(true)
+            .json()
+            .init();
+    }
+    Ok(())
 }
 
-pub mod index_utils {
+pub mod indexer_utils {
     use fuel_indexer_types::SizedAsciiString;
 
     use super::{sha256_digest, Bytes32};
@@ -324,4 +327,12 @@ pub fn host_triple() -> String {
         .first()
         .expect("Failed to determine host triple via rustc.")[6..]
         .to_owned()
+}
+
+pub fn bool_to_str(b: bool) -> String {
+    if b {
+        "true".to_string()
+    } else {
+        "false".to_string()
+    }
 }

--- a/packages/fuel-indexer-lib/src/utils.rs
+++ b/packages/fuel-indexer-lib/src/utils.rs
@@ -181,7 +181,7 @@ pub async fn init_logging(config: &IndexerConfig) -> anyhow::Result<()> {
         .map(|x| x.into_string().unwrap())
         .unwrap_or("info".to_string());
 
-    if !config.verbose_logging {
+    if !config.verbose {
         std::env::set_var(RUST_LOG, format!("{level},wasmer_compiler_cranelift=warn"));
     }
 

--- a/packages/fuel-indexer-lib/src/utils.rs
+++ b/packages/fuel-indexer-lib/src/utils.rs
@@ -182,7 +182,7 @@ pub async fn init_logging(config: &IndexerConfig) -> anyhow::Result<()> {
         .unwrap_or("info".to_string());
 
     if !config.verbose_logging {
-        std::env::set_var(RUST_LOG, &format!("{level},wasmer_compiler_cranelift=warn"));
+        std::env::set_var(RUST_LOG, format!("{level},wasmer_compiler_cranelift=warn"));
     }
 
     let filter = match env::var_os(RUST_LOG) {

--- a/packages/fuel-indexer-plugin/src/lib.rs
+++ b/packages/fuel-indexer-plugin/src/lib.rs
@@ -13,7 +13,7 @@ pub mod types {
 
 pub mod utils {
     pub use fuel_indexer_lib::utils::{
-        index_utils::{
+        indexer_utils::{
             bytes32_from_inputs, first32_bytes_to_bytes32, first8_bytes_to_u64,
             trim_sized_ascii_string, u64_id, u64_id_from_inputs,
         },

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -71,7 +71,7 @@ impl TestPostgresDb {
             host,
             port,
             database: db_name.clone(),
-            verbose_logging: "true".to_string(),
+            verbose: "true".to_string(),
         };
 
         // Connect directly to the Postgres server and create a database with the unique string
@@ -280,7 +280,7 @@ pub async fn api_server_app_postgres(database_url: Option<&str>) -> Router {
         });
 
     let config = IndexerConfig {
-        verbose_logging: true,
+        verbose: true,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),
@@ -304,7 +304,7 @@ pub async fn authenticated_api_server_app_postgres(database_url: Option<&str>) -
         });
 
     let config = IndexerConfig {
-        verbose_logging: true,
+        verbose: true,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),
@@ -334,7 +334,7 @@ pub async fn indexer_service_postgres(database_url: Option<&str>) -> IndexerServ
         });
 
     let config = IndexerConfig {
-        verbose_logging: true,
+        verbose: true,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -71,6 +71,7 @@ impl TestPostgresDb {
             host,
             port,
             database: db_name.clone(),
+            verbose_logging: "true".to_string(),
         };
 
         // Connect directly to the Postgres server and create a database with the unique string

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -279,6 +279,7 @@ pub async fn api_server_app_postgres(database_url: Option<&str>) -> Router {
         });
 
     let config = IndexerConfig {
+        verbose_logging: true,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),
@@ -302,6 +303,7 @@ pub async fn authenticated_api_server_app_postgres(database_url: Option<&str>) -
         });
 
     let config = IndexerConfig {
+        verbose_logging: true,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),
@@ -331,6 +333,7 @@ pub async fn indexer_service_postgres(database_url: Option<&str>) -> IndexerServ
         });
 
     let config = IndexerConfig {
+        verbose_logging: true,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),

--- a/packages/fuel-indexer/src/cli.rs
+++ b/packages/fuel-indexer/src/cli.rs
@@ -1,7 +1,6 @@
 pub(crate) use crate::commands::run;
 use clap::{Parser, Subcommand};
 use fuel_indexer_lib::config::IndexerArgs;
-use fuel_indexer_lib::utils::bin_utils::init_logging;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -23,8 +22,6 @@ pub enum Indexer {
 }
 
 pub async fn run_cli() -> anyhow::Result<()> {
-    init_logging().await?;
-
     let opt = Opt::try_parse();
 
     match opt {

--- a/packages/fuel-indexer/src/commands/run.rs
+++ b/packages/fuel-indexer/src/commands/run.rs
@@ -3,7 +3,7 @@ use fuel_indexer_database::{queries, IndexerConnectionPool};
 use fuel_indexer_lib::{
     config::{IndexerArgs, IndexerConfig},
     manifest::Manifest,
-    utils::ServiceRequest,
+    utils::{init_logging, ServiceRequest},
 };
 use tracing::info;
 
@@ -39,6 +39,8 @@ pub async fn exec(args: IndexerArgs) -> anyhow::Result<()> {
         Some(path) => IndexerConfig::from_file(path)?,
         None => IndexerConfig::from(args.clone()),
     };
+
+    init_logging(&config).await?;
 
     info!("Configuration: {:?}", config);
 

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -100,7 +100,7 @@ impl IndexerService {
 
         while let Some((asset_type, bytes)) = items.pop() {
             info!(
-                "Registering Asset({:?}) for Index({})",
+                "Registering Asset({:?}) for Indexer({})",
                 asset_type,
                 index.uid()
             );
@@ -118,7 +118,7 @@ impl IndexerService {
             }
         }
 
-        info!("Registered Index({})", &manifest.uid());
+        info!("Registered Indexer({})", &manifest.uid());
         self.handles.insert(manifest.uid(), handle);
         self.killers.insert(manifest.uid(), killer);
 
@@ -143,7 +143,7 @@ impl IndexerService {
             )
             .await?;
 
-            info!("Registered Index({})", manifest.uid());
+            info!("Registered Indexer({})", manifest.uid());
             self.handles.insert(manifest.uid(), handle);
             self.killers.insert(manifest.uid(), killer);
         }
@@ -306,7 +306,9 @@ async fn create_service_task(
                         if let Some(killer) = killers.remove(&uid) {
                             killer.store(true, Ordering::SeqCst);
                         } else {
-                            warn!("Stop Indexer: No indexer with the name Index({uid})");
+                            warn!(
+                                "Stop Indexer: No indexer with the name Indexer({uid})"
+                            );
                         }
                     }
                     ServiceRequest::IndexRevert(request) => {

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -59,7 +59,9 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         forc_postgres::commands::create::exec(Box::new(create_db_cmd)).await?;
     }
 
-    let mut cmd = Command::new("fuel-indexer");
+    let mut cmd = Command::new(
+        "/Users/rashad/development/repos/fuel-indexer/target/release/fuel-indexer",
+    );
     cmd.arg("run");
 
     if let Some(m) = &manifest {
@@ -119,7 +121,9 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
                     }
                 }
             }
-            _ => unreachable!(),
+            _ => unreachable!(
+                "'postgres' is currently the only supported database option."
+            ),
         }
     }
 
@@ -133,7 +137,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
             child.id()
         );
     } else {
-        anyhow::bail!("❌ Failed to spawn fuel-indexer child process.");
+        panic!("❌ Failed to spawn fuel-indexer child process.");
     }
 
     Ok(())

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -59,9 +59,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         forc_postgres::commands::create::exec(Box::new(create_db_cmd)).await?;
     }
 
-    let mut cmd = Command::new(
-        "/Users/rashad/development/repos/fuel-indexer/target/release/fuel-indexer",
-    );
+    let mut cmd = Command::new("fuel-indexer");
     cmd.arg("run");
 
     if let Some(m) = &manifest {
@@ -131,13 +129,16 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         info!("{cmd:?}");
     }
 
-    if let Ok(child) = cmd.spawn() {
-        info!(
-            "\n✅ Successfully started the indexer service at PID {}.",
-            child.id()
-        );
-    } else {
-        panic!("❌ Failed to spawn fuel-indexer child process.");
+    match cmd.spawn() {
+        Ok(child) => {
+            info!(
+                "\n✅ Successfully started the indexer service at PID {}.",
+                child.id()
+            );
+        }
+        Err(e) => {
+            panic!("❌ Failed to spawn fuel-indexer child process: {e:?}.");
+        }
     }
 
     Ok(())

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -27,8 +27,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         jwt_secret,
         jwt_issuer,
         jwt_expiry,
-        verbose_logging,
-        verbose_db_logging,
+        verbose,
         ..
     } = command;
 
@@ -82,8 +81,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
             ("--run-migrations", run_migrations),
             ("--metrics", metrics),
             ("--auth-enabled", auth_enabled),
-            ("--verbose-logging", verbose_logging),
-            ("--verbose-db-logging", verbose_db_logging),
+            ("--verbose", verbose),
         ];
         for (opt, value) in options.iter() {
             if *value {
@@ -125,7 +123,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         }
     }
 
-    if verbose_logging {
+    if verbose {
         info!("{cmd:?}");
     }
 

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -27,7 +27,8 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         jwt_secret,
         jwt_issuer,
         jwt_expiry,
-        verbose,
+        verbose_logging,
+        verbose_db_logging,
         ..
     } = command;
 
@@ -75,12 +76,14 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         cmd.arg("--graphql-api-host").arg(&graphql_api_host);
         cmd.arg("--graphql-api-port").arg(&graphql_api_port);
         cmd.arg("--log-level").arg(&log_level);
+        cmd.arg("--verbose-db-logging").arg(&verbose_db_logging);
 
         // Bool options
         let options = vec![
             ("--run-migrations", run_migrations),
             ("--metrics", metrics),
             ("--auth-enabled", auth_enabled),
+            ("--verbose-logging", verbose_logging),
         ];
         for (opt, value) in options.iter() {
             if *value {
@@ -122,7 +125,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         }
     }
 
-    if verbose {
+    if verbose_logging {
         info!("{cmd:?}");
     }
 

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -76,7 +76,6 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         cmd.arg("--graphql-api-host").arg(&graphql_api_host);
         cmd.arg("--graphql-api-port").arg(&graphql_api_port);
         cmd.arg("--log-level").arg(&log_level);
-        cmd.arg("--verbose-db-logging").arg(&verbose_db_logging);
 
         // Bool options
         let options = vec![
@@ -84,6 +83,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
             ("--metrics", metrics),
             ("--auth-enabled", auth_enabled),
             ("--verbose-logging", verbose_logging),
+            ("--verbose-db-logging", verbose_db_logging),
         ];
         for (opt, value) in options.iter() {
             if *value {

--- a/plugins/forc-postgres/src/ops/forc_postgres_createdb.rs
+++ b/plugins/forc-postgres/src/ops/forc_postgres_createdb.rs
@@ -92,7 +92,7 @@ pub async fn init(command: CreateDbCommand) -> anyhow::Result<()> {
     } = command.clone();
 
     let pg_config: PgEmbedConfig = if config.is_some() {
-        IndexerConfig::from_file(&config.clone().unwrap())?.into()
+        IndexerConfig::from_file(config.clone().unwrap())?.into()
     } else {
         command.into()
     };


### PR DESCRIPTION
### Description
- PR adds `-v --verbose` flag to `fuel-indexer` and `fuel-indexer-api-server`
- Updates docs accordingly

### Testing steps
- Ensure `forc-index start` points to a latest `fuel-indexer` binary
- Run with verbose logging
  - [ ] Try running the block explorer with and without the `-v --verbose` flag

 
```bash
cargo run --bin fuel-indexer -- run \
  --fuel-node-host beta-3.fuel.network \
  --fuel-node-port 80 \
  --manifest examples/block-explorer/explorer-indexer/explorer_indexer.manifest.yaml \
  --verbose
```
   - [ ] And the plugin as well (with and without verbosity)

```
cargo run --bin forc-index -- start -v
```

### Changelog
- enhancement: make verbose logging configurable