### PR TITLE
chore: general plugin cleanup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@
 # fuel_node:
 
 #   # Host of the running Fuel node.
-#   host: 127.0.0.1
+#   host: localhost
 
 #   # Listening port of the running Fuel node.
 #   port: 4000
@@ -33,7 +33,7 @@
 
 # graphql_api:
 #   # GraphQL API host.
-#   host: 127.0.0.1
+#   host: localhost
 
 #   # GraphQL API port.
 #   port: 29987
@@ -58,7 +58,7 @@
 #     password: password
 
 #     # Postgres host.
-#     host: 127.0.0.1
+#     host: localhost
 
 #     # Postgres port.
 #     port: 5432

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,23 +152,25 @@ forc index check
 +--------+------------------------+---------------------------------------------------------+
 | Status |       Component        |                         Details                         |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | fuel-indexer binary    |  /Users/me/.fuelup/bin/fuel-indexer                     |
+|   ⛔️   | fuel-indexer binary    |  Can't locate fuel-indexer.                             |
 +--------+------------------------+---------------------------------------------------------+
-|   ⛔️   | fuel-indexer service   |  Failed to detect service at Port(29987).               |
+|   ✅   | fuel-indexer service   |  Local service found: PID(63967) | Port(29987).         |
 +--------+------------------------+---------------------------------------------------------+
 |   ✅   | psql                   |  /usr/local/bin/psql                                    |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | fuel-core              |  /Users/me/.fuelup/bin/fuel-core                        |
+|   ✅   | fuel-core              |  /Users/rashad/.cargo/bin/fuel-core                     |
 +--------+------------------------+---------------------------------------------------------+
 |   ✅   | docker                 |  /usr/local/bin/docker                                  |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | fuelup                 |  /Users/me/.fuelup/bin/fuelup                           |
+|   ⛔️   | fuelup                 |  Can't locate fuelup.                                   |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | wasm-snip              |  /Users/me/.cargo/bin/wasm-snip                         |
+|   ✅   | wasm-snip              |  /Users/rashad/.cargo/bin/wasm-snip                     |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | forc-postgres          |  /Users/me/.fuelup/bin/fuelup                           |
+|   ⛔️   | forc-postgres          |  Can't locate fuelup.                                   |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | rustc                  |  /Users/me/.cargo/bin/rustc                             |
+|   ✅   | rustc                  |  /Users/rashad/.cargo/bin/rustc                         |
++--------+------------------------+---------------------------------------------------------+
+|   ✅   | forc-wallet            |  /Users/rashad/.cargo/bin/forc-wallet                   |
 +--------+------------------------+---------------------------------------------------------+
 ```
 
@@ -257,6 +259,8 @@ Take a quick tour.
     Deploy your indexer.
 `forc index remove`
     Stop a running indexer.
+`forc index revert`
+    Revert a deployed indexer.
 `forc index auth`
     Authenticate against an indexer service.
 ```
@@ -274,34 +278,8 @@ forc index deploy
 If all goes well, you should see the following:
 
 ```text
-▹▹▸▹▹ ⏰ Building...                                                                                         Finished dev [unoptimized + debuginfo] target(s) in 0.87s
-▪▪▪▪▪ ✅ Build succeeded.
-
-Deploying indexer at hello_index.manifest.yaml to http://localhost:29987/api/index/my_project/hello_index
-▹▸▹▹▹ 🚀 Deploying...
-{
-  "assets": [
-    {
-      "digest": "79e74d6a7b68a35aeb9aa2dd7f6083dae5fdba5b6a2f199529b6c49624d1e27b",
-      "id": 1,
-      "index_id": 1,
-      "version": 1
-    },
-    {
-      "digest": "4415628d9ea79b3c3f1e6f02b1af3416c4d0b261b75abe3cc81b77b7902549c5",
-      "id": 1,
-      "index_id": 1,
-      "version": 1
-    },
-    {
-      "digest": "e901eba95ce8b4d1c159c5d66f24276dc911e87dbff55fb2c10d8b371528eacc",
-      "id": 1,
-      "index_id": 1,
-      "version": 1
-    }
-  ],
-  "success": "true"
-}
+▹▹▹▹▹ ⏰ Building...                         Finished dev [unoptimized + debuginfo] target(s) in 0.96s
+▪▪▪▪▪ ✅ Build succeeded.                    Deploying indexer
 ▪▪▪▪▪ ✅ Successfully deployed indexer.
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -185,7 +185,7 @@ We can quickly create a bootstrapped database and start the Fuel indexer service
 ```bash
 forc index start \
     --embedded-database                         # Setup and start a default database.
-    --fuel-node-host node-beta-3.fuel.network \ # Connect to a Fuel node at this host
+    --fuel-node-host beta-3.fuel.network \ # Connect to a Fuel node at this host
     --fuel-node-port 80                         # and port, and monitor the network.
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -277,7 +277,7 @@ If all goes well, you should see the following:
 ▹▹▸▹▹ ⏰ Building...                                                                                         Finished dev [unoptimized + debuginfo] target(s) in 0.87s
 ▪▪▪▪▪ ✅ Build succeeded.
 
-Deploying indexer at hello_index.manifest.yaml to http://127.0.0.1:29987/api/index/my_project/hello_index
+Deploying indexer at hello_index.manifest.yaml to http://localhost:29987/api/index/my_project/hello_index
 ▹▸▹▹▹ 🚀 Deploying...
 {
   "assets": [
@@ -312,7 +312,7 @@ With our indexer deployed, we should be able to query for newly indexed data aft
 Below, we write a simple GraphQL query that simply returns a few fields from all transactions that we've indexed.
 
 ```bash
-curl -X POST http://127.0.0.1:29987/api/graph/my_project/hello_index \
+curl -X POST http://localhost:29987/api/graph/my_project/hello_index \
    -H 'content-type: application/json' \
    -d '{"query": "query { tx { id hash block }}", "params": "b"}' \
 | json_pp
@@ -477,7 +477,7 @@ On macOS systems, you can install PostgreSQL through Homebrew. If it isn't prese
 
 For Linux-based systems, the installation process is similar. First, you should install PostgreSQL according to your distribution's instructions. Once installed, there should be a new `postgres` user account; you can switch to that account by running `sudo -i -u postgres`. After you have switched accounts, you may need to create a `postgres` database role by running `createuser --interactive`. You will be asked a few questions; the name of the role should be `postgres` and you should elect for the new role to be a superuser. Finally, you can create a database by running `createdb [DATABASE_NAME]`.
 
-In either case, your PostgreSQL database should now be accessible at `postgres://postgres@127.0.0.1:5432/[DATABASE_NAME]`.
+In either case, your PostgreSQL database should now be accessible at `postgres://postgres@localhost:5432/[DATABASE_NAME]`.
 
 ### SQLx
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,19 +158,19 @@ forc index check
 +--------+------------------------+---------------------------------------------------------+
 |   ✅   | psql                   |  /usr/local/bin/psql                                    |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | fuel-core              |  /Users/rashad/.cargo/bin/fuel-core                     |
+|   ✅   | fuel-core              |  /Users/me/.cargo/bin/fuel-core                         |
 +--------+------------------------+---------------------------------------------------------+
 |   ✅   | docker                 |  /usr/local/bin/docker                                  |
 +--------+------------------------+---------------------------------------------------------+
 |   ⛔️   | fuelup                 |  Can't locate fuelup.                                   |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | wasm-snip              |  /Users/rashad/.cargo/bin/wasm-snip                     |
+|   ✅   | wasm-snip              |  /Users/me/.cargo/bin/wasm-snip                         |
 +--------+------------------------+---------------------------------------------------------+
 |   ⛔️   | forc-postgres          |  Can't locate fuelup.                                   |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | rustc                  |  /Users/rashad/.cargo/bin/rustc                         |
+|   ✅   | rustc                  |  /Users/me/.cargo/bin/rustc                             |
 +--------+------------------------+---------------------------------------------------------+
-|   ✅   | forc-wallet            |  /Users/rashad/.cargo/bin/forc-wallet                   |
+|   ✅   | forc-wallet            |  /Users/me/.cargo/bin/forc-wallet                       |
 +--------+------------------------+---------------------------------------------------------+
 ```
 
@@ -184,9 +184,9 @@ We can quickly create a bootstrapped database and start the Fuel indexer service
 
 ```bash
 forc index start \
-    --embedded-database                         # Setup and start a default database.
-    --fuel-node-host beta-3.fuel.network \ # Connect to a Fuel node at this host
-    --fuel-node-port 80                         # and port, and monitor the network.
+    --embedded-database
+    --fuel-node-host beta-3.fuel.network \
+    --fuel-node-port 80
 ```
 
 You should see output indicating the successful creation of a database and start of the indexer service; there may be much more content in your session, but it should generally contain output similar to the following lines:
@@ -290,7 +290,7 @@ With our indexer deployed, we should be able to query for newly indexed data aft
 Below, we write a simple GraphQL query that simply returns a few fields from all transactions that we've indexed.
 
 ```bash
-curl -X POST http://localhost:29987/api/graph/my_project/hello_index \
+curl -X POST http://localhost:29987/api/graph/my_project/hello_indexer \
    -H 'content-type: application/json' \
    -d '{"query": "query { tx { id hash block }}", "params": "b"}' \
 | json_pp

--- a/docs/src/examples/block-explorer.md
+++ b/docs/src/examples/block-explorer.md
@@ -9,7 +9,7 @@ Below is an example of a rudimentary block explorer backend implementation that 
 Once blocks have been added to the database by the indexer, you can query for them by using a query similar to the following:
 
 ```sh
-curl -X POST http://127.0.0.1:29987/api/graph/fuel_examples/explorer_index \
+curl -X POST http://localhost:29987/api/graph/fuel_examples/explorer_index \
    -H 'content-type: application/json' \
    -d '{"query": "query { block { id height timestamp }}", "params": "b"}' \
 | json_pp

--- a/docs/src/examples/block-explorer.md
+++ b/docs/src/examples/block-explorer.md
@@ -9,7 +9,7 @@ Below is an example of a rudimentary block explorer backend implementation that 
 Once blocks have been added to the database by the indexer, you can query for them by using a query similar to the following:
 
 ```sh
-curl -X POST http://localhost:29987/api/graph/fuel_examples/explorer_index \
+curl -X POST http://localhost:29987/api/graph/fuel_examples/explorer_indexer \
    -H 'content-type: application/json' \
    -d '{"query": "query { block { id height timestamp }}", "params": "b"}' \
 | json_pp

--- a/docs/src/for-contributors/index.md
+++ b/docs/src/for-contributors/index.md
@@ -38,7 +38,7 @@ On macOS systems, you can install PostgreSQL through Homebrew. If it isn't prese
 
 For Linux-based systems, the installation process is similar. First, you should install PostgreSQL according to your distribution's instructions. Once installed, there should be a new `postgres` user account; you can switch to that account by running `sudo -i -u postgres`. After you have switched accounts, you may need to create a `postgres` database role by running `createuser --interactive`. You will be asked a few questions; the name of the role should be `postgres` and you should elect for the new role to be a superuser. Finally, you can create a database by running `createdb [DATABASE_NAME]`.
 
-In either case, your PostgreSQL database should now be accessible at `postgres://postgres@127.0.0.1:5432/[DATABASE_NAME]`.
+In either case, your PostgreSQL database should now be accessible at `postgres://postgres@localhost:5432/[DATABASE_NAME]`.
 
 ### SQLx
 

--- a/docs/src/getting-started/dependencies/database.md
+++ b/docs/src/getting-started/dependencies/database.md
@@ -14,4 +14,4 @@ On macOS systems, you can install PostgreSQL through Homebrew. If it isn't prese
 
 For Linux-based systems, the installation process is similar. First, you should install PostgreSQL according to your distribution's instructions. Once installed, there should be a new `postgres` user account; you can switch to that account by running `sudo -i -u postgres`. After you have switched accounts, you may need to create a `postgres` database role by running `createuser --interactive`. You will be asked a few questions; the name of the role should be `postgres` and you should elect for the new role to be a superuser. Finally, you can create a database by running `createdb [DATABASE_NAME]`.
 
-In either case, your PostgreSQL database should now be accessible at `postgres://postgres@127.0.0.1:5432/[DATABASE_NAME]`.
+In either case, your PostgreSQL database should now be accessible at `postgres://postgres@localhost:5432/[DATABASE_NAME]`.

--- a/docs/src/getting-started/starting-the-fuel-indexer.md
+++ b/docs/src/getting-started/starting-the-fuel-indexer.md
@@ -22,13 +22,13 @@ OPTIONS:
             Database type. [default: postgres] [possible values: postgres]
 
         --fuel-node-host <FUEL_NODE_HOST>
-            Host of the running Fuel node. [default: 127.0.0.1]
+            Host of the running Fuel node. [default: localhost]
 
         --fuel-node-port <FUEL_NODE_PORT>
             Listening port of the running Fuel node. [default: 4000]
 
         --graphql-api-host <GRAPHQL_API_HOST>
-            GraphQL API host. [default: 127.0.0.1]
+            GraphQL API host. [default: localhost]
 
         --graphql-api-port <GRAPHQL_API_PORT>
             GraphQL API port. [default: 29987]

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -1,2 +1,2 @@
 <!-- markdownlint-disable MD041 -->
-{{#include ../../README.md:94:340}}
+{{#include ../../README.md:95:321}}

--- a/docs/src/reference-guide/components/fuel-node.md
+++ b/docs/src/reference-guide/components/fuel-node.md
@@ -29,7 +29,7 @@ You can also connect the Fuel indexer to a remote Fuel node. To do so, use the e
 ## Fuel Node configuration
 #
 # fuel_node:
-#   host: https://node-beta-3.fuel.network
+#   host: https://beta-3.fuel.network
 #   port: 4000
 ```
 

--- a/docs/src/reference-guide/components/fuel-node.md
+++ b/docs/src/reference-guide/components/fuel-node.md
@@ -16,10 +16,10 @@ You can run a local Fuel node through the use of `fuel-core`. Once you've instal
 2022-12-21T21:23:46.092853Z  INFO fuel_chain_config::config::chain: 71: PrivateKey(0x7f8a325504e7315eda997db7861c9447f5c3eff26333b20180475d94443a10c6), Address(0xc36be0e14d3eaf5d8d233e0f4a40b3b4e48427d25f84c460d2b03b242a38479e), Balance(10000000)
 2022-12-21T21:23:46.096489Z  WARN fuel_core::cli::run: 158: Fuel Core is using an insecure test key for consensus. Public key: 73dc6cc8cc0041e4924954b35a71a22ccb520664c522198a6d31dc6c945347bb854a39382d296ec64c70d7cea1db75601595e29729f3fbdc7ee9dae66705beb4
 2022-12-21T21:23:46.096673Z  INFO fuel_core::cli::run: 212: Fuel Core version v0.14.1
-2022-12-21T21:23:46.121974Z  INFO new_node: fuel_core::service::graph_api: 111: Binding GraphQL provider to 127.0.0.1:4000
+2022-12-21T21:23:46.121974Z  INFO new_node: fuel_core::service::graph_api: 111: Binding GraphQL provider to localhost:4000
 ```
 
-If you started the node with no additional options (as done in this example), it will be accessible on the default address of `127.0.0.1:4000`. The Fuel indexer will attempt to connect to a Fuel node on this address unless instructed otherwise through a configuration file; you can find an [example configuration file](https://github.com/FuelLabs/fuel-indexer/blob/master/config.yaml) in the Fuel indexer repository. To start the indexer service with a custom configuration, you can run `forc index --config [CONFIG_FILE_PATH]`.
+If you started the node with no additional options (as done in this example), it will be accessible on the default address of `localhost:4000`. The Fuel indexer will attempt to connect to a Fuel node on this address unless instructed otherwise through a configuration file; you can find an [example configuration file](https://github.com/FuelLabs/fuel-indexer/blob/master/config.yaml) in the Fuel indexer repository. To start the indexer service with a custom configuration, you can run `forc index --config [CONFIG_FILE_PATH]`.
 
 ## Remote Node
 

--- a/docs/src/reference-guide/components/graphql/api-server.md
+++ b/docs/src/reference-guide/components/graphql/api-server.md
@@ -29,7 +29,7 @@ OPTIONS:
             Database type. [default: postgres] [possible values: postgres]
 
         --graphql-api-host <GRAPHQL_API_HOST>
-            GraphQL API host. [default: 127.0.0.1]
+            GraphQL API host. [default: localhost]
 
         --graphql-api-port <GRAPHQL_API_PORT>
             GraphQL API port. [default: 29987]

--- a/docs/src/reference-guide/components/graphql/queries.md
+++ b/docs/src/reference-guide/components/graphql/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-Once data has been persisted into your storage backend, you can retrieve it by querying the [GraphQL API server](./api-server.md). By default, the API server can be reached at `http://127.0.0.1:29987/api/graph/<namespace>/<identifier>`, where `<namespace>` and `<identifier>` are the values for the respective fields in your indexer's manifest. If you've changed the `GRAPHQL_API_HOST` or `GRAPHQL_API_PORT` values of your configuration, then you'll need to adjust the URL accordingly.
+Once data has been persisted into your storage backend, you can retrieve it by querying the [GraphQL API server](./api-server.md). By default, the API server can be reached at `http://localhost:29987/api/graph/<namespace>/<identifier>`, where `<namespace>` and `<identifier>` are the values for the respective fields in your indexer's manifest. If you've changed the `GRAPHQL_API_HOST` or `GRAPHQL_API_PORT` values of your configuration, then you'll need to adjust the URL accordingly.
 
 ## Basic Query
 
@@ -22,7 +22,7 @@ The `entity` field corresponds to the name of an entity defined in your [schema]
 Let's refer back to the [block explorer](../../../examples/block-explorer.md) example for an illustration. After the block data has been indexed, we can retrieve information about the blocks by sending a query to the graph endpoint for our indexer.
 
 ```txt
-curl -X POST http://127.0.0.1:29987/api/graph/fuel_examples/explorer_index \
+curl -X POST http://localhost:29987/api/graph/fuel_examples/explorer_index \
    -H 'content-type: application/json' \
    -d '{"query": "query { block { id height timestamp }}", "params": "b"}' \
 | json_pp
@@ -140,7 +140,7 @@ query {
 Let's assume that we've created an indexer for this data and indexed data has been stored in the database. Now we'll send a request to the API server in the same way that we did for the basic query example:
 
 ```txt
-curl -X POST http://127.0.0.1:29987/api/graph/fuel_examples/nested_query_index \
+curl -X POST http://localhost:29987/api/graph/fuel_examples/nested_query_index \
    -H 'content-type: application/json' \
    -d '{"query": "query { character { name book { title library { name city { name } } } } }", "params": "b"}' \
 | json_pp

--- a/docs/src/reference-guide/plugins/forc-index/auth.md
+++ b/docs/src/reference-guide/plugins/forc-index/auth.md
@@ -16,6 +16,6 @@ OPTIONS:
         --account <ACCOUNT>    Index of account to use for signing.
     -h, --help                 Print help information
         --url <URL>            URL at which to deploy indexer assets. [default:
-                               http://127.0.0.1:29987]
+                               http://localhost:29987]
     -v, --verbose              Verbose output.
 ```

--- a/docs/src/reference-guide/plugins/forc-index/check.md
+++ b/docs/src/reference-guide/plugins/forc-index/check.md
@@ -18,7 +18,7 @@ OPTIONS:
             Print help information
 
         --url <URL>
-            URL at which to find indexer service. [default: http://127.0.0.1:29987]
+            URL at which to find indexer service. [default: http://localhost:29987]
 ```
 
 You can expect the command output to look something like this example in which the requisite components are installed but the indexer service is not running:
@@ -26,7 +26,7 @@ You can expect the command output to look something like this example in which t
 ```text
 ➜  forc index check
 
-❌ Could not connect to indexer service: error sending request for url (http://127.0.0.1:29987/api/health): error trying to connect: tcp connect error: Connection refused (os error 61)
+❌ Could not connect to indexer service: error sending request for url (http://localhost:29987/api/health): error trying to connect: tcp connect error: Connection refused (os error 61)
 
 +--------+------------------------+----------------------------------------------------------------------------+
 | Status |       Component        |                                  Details                                   |

--- a/docs/src/reference-guide/plugins/forc-index/deploy.md
+++ b/docs/src/reference-guide/plugins/forc-index/deploy.md
@@ -23,6 +23,6 @@ OPTIONS:
         --target <TARGET>            Target at which to compile. [default: wasm32-unknown-unknown]
         --target-dir <TARGET_DIR>    Directory for all generated artifacts and intermediate files.
         --url <URL>                  URL at which to deploy indexer assets. [default:
-                                     http://127.0.0.1:29987]
+                                     http://localhost:29987]
     -v, --verbose                    Enable verbose logging.
 ```

--- a/docs/src/reference-guide/plugins/forc-index/remove.md
+++ b/docs/src/reference-guide/plugins/forc-index/remove.md
@@ -15,6 +15,6 @@ OPTIONS:
     -h, --help                   Print help information
     -m, --manifest <MANIFEST>    Path to the manifest of the indexer project being removed.
     -p, --path <PATH>            Path to the indexer project.
-        --url <URL>              URL at which indexer is deployed. [default: http://127.0.0.1:29987]
+        --url <URL>              URL at which indexer is deployed. [default: http://localhost:29987]
     -v, --verbose                Enable verbose output.
 ```

--- a/docs/src/reference-guide/plugins/forc-index/revert.md
+++ b/docs/src/reference-guide/plugins/forc-index/revert.md
@@ -15,6 +15,6 @@ OPTIONS:
     -h, --help                   Print help information
     -m, --manifest <MANIFEST>    Path to the manifest of the indexer project being reverted.
     -p, --path <PATH>            Path of indexer project.
-        --url <URL>              URL at which indexer is deployed. [default: http://127.0.0.1:29987]
+        --url <URL>              URL at which indexer is deployed. [default: http://localhost:29987]
     -v, --verbose                Enable verbose output.
 ```

--- a/docs/src/reference-guide/plugins/forc-index/start.md
+++ b/docs/src/reference-guide/plugins/forc-index/start.md
@@ -27,13 +27,13 @@ OPTIONS:
             Automatically create and start database using provided options or defaults.
 
         --fuel-node-host <FUEL_NODE_HOST>
-            Host of the running Fuel node. [default: 127.0.0.1]
+            Host of the running Fuel node. [default: localhost]
 
         --fuel-node-port <FUEL_NODE_PORT>
             Listening port of the running Fuel node. [default: 4000]
 
         --graphql-api-host <GRAPHQL_API_HOST>
-            GraphQL API host. [default: 127.0.0.1]
+            GraphQL API host. [default: localhost]
 
         --graphql-api-port <GRAPHQL_API_PORT>
             GraphQL API port. [default: 29987]

--- a/examples/block-explorer/README.md
+++ b/examples/block-explorer/README.md
@@ -18,10 +18,11 @@ docker compose up
 
 ```bash
 forc-index deploy \
-   --path explorer-index \
+   --path explorer-indexer \
    --target-dir /path/to/repository/fuel-indexer \
    --url http://0.0.0.0:29987 \
    --target wasm32-unknown-unknown
+   --release
 ```
 
 ### Validate
@@ -29,7 +30,7 @@ forc-index deploy \
 Ensure that test data was indexed via a GraphQL query.
 
 ```bash
-curl -X POST http://0.0.0.0:29987/api/graph/fuel_examples \
+curl -X POST http://0.0.0.0:29987/api/graph/fuel_examples/explorer_indexer \
    -H 'content-type: application/json' \
    -d '{"query": "query { tx { id hash status block }}", "params": "b"}' \
 | json_pp

--- a/examples/block-explorer/docker-compose.yaml
+++ b/examples/block-explorer/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       start_period: 80s
   fuel-indexer:
     image: ghcr.io/fuellabs/fuel-indexer:latest
-    command: bash -c "sleep 2 && ./fuel-indexer run --fuel-node-host node-beta-3.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0"
+    command: bash -c "sleep 2 && ./fuel-indexer run --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0"
     ports:
       - "29987:29987"
     volumes:

--- a/examples/block-explorer/docker-compose.yaml
+++ b/examples/block-explorer/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       start_period: 80s
   fuel-indexer:
     image: ghcr.io/fuellabs/fuel-indexer:latest
-    command: bash -c "sleep 2 && ./fuel-indexer --fuel-node-host node-beta-3.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0"
+    command: bash -c "sleep 2 && ./fuel-indexer run --fuel-node-host node-beta-3.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0"
     ports:
       - "29987:29987"
     volumes:

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -40,7 +40,7 @@ cargo run --bin hello-world-data -- --host 0.0.0.0:4000
 Ensure that test data was indexed via a GraphQL query.
 
 ```bash
-curl -X POST http://0.0.0.0:29987/api/graph/fuel_examples/hello_index \
+curl -X POST http://0.0.0.0:29987/api/graph/fuel_examples/hello_indexer \
    -H 'content-type: application/json' \
    -d '{"query": "query { salutation { id message_hash message greeter first_seen last_seen }}", "params": "b"}' \
 | json_pp

--- a/examples/hello-world/hello-indexer/hello_indexer.manifest.yaml
+++ b/examples/hello-world/hello-indexer/hello_indexer.manifest.yaml
@@ -9,4 +9,3 @@ metrics: ~
 contract_id: fuel18hchrf7f4hnpkl84sqf8k0sk8gcauzeemzwgweea8dgr7eachv4s86r9t9
 start_block: 1
 resumable: ~
-

--- a/packages/fuel-indexer-lib/src/config/fuel_node.rs
+++ b/packages/fuel-indexer-lib/src/config/fuel_node.rs
@@ -7,7 +7,6 @@ pub use clap::Parser;
 use http::Uri;
 use serde::Deserialize;
 use std::net::SocketAddr;
-// use url::Url;
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct FuelNodeConfig {
@@ -44,7 +43,7 @@ impl From<FuelNodeConfig> for Uri {
     fn from(config: FuelNodeConfig) -> Self {
         let uri = derive_http_url(&config.host, &config.port);
         uri.parse().unwrap_or_else(|e| {
-            panic!("Failed to parse Uri from FuelNodeConfig {uri:?}: {e}")
+            panic!("Cannot parse HTTP URI from Fuel node config {config:?}: {e}")
         })
     }
 }

--- a/packages/fuel-indexer-lib/src/config/graphql.rs
+++ b/packages/fuel-indexer-lib/src/config/graphql.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{Env, IndexerConfigResult},
     defaults,
-    utils::{is_opt_env_var, trim_opt_env_key},
+    utils::{derive_socket_addr, is_opt_env_var, trim_opt_env_key},
 };
 pub use clap::Parser;
 use http::Uri;
@@ -27,10 +27,10 @@ impl std::string::ToString for GraphQLConfig {
 }
 
 impl From<GraphQLConfig> for Uri {
-    fn from(config: GraphQLConfig) -> Self {
-        let uri = derive_http_url(&config.host, &config.port);
+    fn from(c: GraphQLConfig) -> Self {
+        let uri = derive_http_url(&c.host, &c.port);
         uri.parse().unwrap_or_else(|e| {
-            panic!("Failed to derive Uri from GraphQL config: {config:?}: {e}",)
+            panic!("Cannot parse HTTP URI from GraphQL config: {c:?}: {e}")
         })
     }
 }
@@ -47,9 +47,7 @@ impl Default for GraphQLConfig {
 
 impl From<GraphQLConfig> for SocketAddr {
     fn from(cfg: GraphQLConfig) -> SocketAddr {
-        format!("{}:{}", cfg.host, cfg.port)
-            .parse()
-            .unwrap_or_else(|e| panic!("Failed to parse GraphQL host.: {e}"))
+        derive_socket_addr(&cfg.host, &cfg.port)
     }
 }
 

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -695,7 +695,7 @@ mod tests {
 
         assert_eq!(config.fuel_node.host, "1.1.1.1".to_string());
         assert_eq!(config.fuel_node.port, "9999".to_string());
-        assert_eq!(config.graphql_api.host, "127.0.0.1".to_string());
+        assert_eq!(config.graphql_api.host, "localhost".to_string());
 
         fs::remove_file(tmp_file_path).unwrap();
     }
@@ -718,9 +718,9 @@ mod tests {
         fs::write(tmp_file_path, config_str).expect("Unable to write file");
         let config = IndexerConfig::from_file(Path::new(tmp_file_path)).unwrap();
 
-        assert_eq!(config.fuel_node.host, "127.0.0.1".to_string());
+        assert_eq!(config.fuel_node.host, "localhost".to_string());
         assert_eq!(config.fuel_node.port, "4000".to_string());
-        assert_eq!(config.graphql_api.host, "127.0.0.1".to_string());
+        assert_eq!(config.graphql_api.host, "localhost".to_string());
 
         match config.database {
             DatabaseConfig::Postgres {

--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -1,13 +1,13 @@
-pub const FUEL_NODE_HOST: &str = "127.0.0.1";
+pub const FUEL_NODE_HOST: &str = "localhost";
 pub const FUEL_NODE_PORT: &str = "4000";
 
-pub const GRAPHQL_API_HOST: &str = "127.0.0.1";
+pub const GRAPHQL_API_HOST: &str = "localhost";
 pub const GRAPHQL_API_PORT: &str = "29987";
 
 pub const DATABASE: &str = "postgres";
 pub const POSTGRES_DATABASE: &str = "postgres";
 pub const POSTGRES_USER: &str = "postgres";
-pub const POSTGRES_HOST: &str = "127.0.0.1";
+pub const POSTGRES_HOST: &str = "localhost";
 pub const POSTGRES_PORT: &str = "5432";
 pub const POSTGRES_PASSWORD: &str = "postgres";
 

--- a/packages/fuel-indexer-lib/src/utils.rs
+++ b/packages/fuel-indexer-lib/src/utils.rs
@@ -96,7 +96,7 @@ pub fn is_opt_env_var(key: &str) -> bool {
     key.starts_with('$') || (key.starts_with("${") && key.ends_with('}'))
 }
 
-pub fn derive_socket_addr(host: &String, port: &String) -> SocketAddr {
+pub fn derive_socket_addr(host: &str, port: &str) -> SocketAddr {
     let host = format!("{host}:{port}");
     SocketAddr::from_str(&host).unwrap_or_else(|e| {
             warn!(

--- a/packages/fuel-indexer-tests/src/lib.rs
+++ b/packages/fuel-indexer-tests/src/lib.rs
@@ -36,10 +36,10 @@ pub mod assets {
 pub mod defaults {
     use std::time::Duration;
 
-    pub const FUEL_NODE_ADDR: &str = "127.0.0.1:4000";
-    pub const FUEL_NODE_HOST: &str = "127.0.0.1";
+    pub const FUEL_NODE_ADDR: &str = "localhost:4000";
+    pub const FUEL_NODE_HOST: &str = "localhost";
     pub const FUEL_NODE_PORT: &str = "4000";
-    pub const WEB_API_ADDR: &str = "127.0.0.1:8000";
+    pub const WEB_API_ADDR: &str = "localhost:8000";
     pub const PING_CONTRACT_ID: &str =
         "68518c3ba3768c863e0d945aa18249f9516d3aa1338083ba79467aa393de109c";
     pub const TRANSFER_BASE_ASSET_ID: &str =

--- a/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
@@ -63,7 +63,7 @@ async fn test_can_return_query_response_with_all_fields_required_postgres() {
 
     let client = http_client();
     let resp = client
-        .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
+        .post("http://localhost:29987/api/graph/fuel_indexer_test/index1")
         .header(CONTENT_TYPE, "application/json".to_owned())
         .body(r#"{"query": "query { block { id height timestamp }}", "params": "b"}"#)
         .send()
@@ -107,7 +107,7 @@ async fn test_can_return_query_response_with_nullable_fields_postgres() {
 
     let client = http_client();
     let resp = client
-        .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
+        .post("http://localhost:29987/api/graph/fuel_indexer_test/index1")
         .header(CONTENT_TYPE, "application/json".to_owned())
         .body(r#"{"query": "query { optionentity { int_required int_optional_some addr_optional_none }}", "params": "b"}"#)
         .send()
@@ -152,7 +152,7 @@ async fn test_can_return_nested_query_response_with_implicit_foreign_keys_postgr
 
     let client = http_client();
     let resp = client
-        .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
+        .post("http://localhost:29987/api/graph/fuel_indexer_test/index1")
         .header(CONTENT_TYPE, "application/json".to_owned())
         .body(
             r#"{"query": "query { tx { block { id height } id timestamp }}", "params": "b"}"#,
@@ -268,7 +268,7 @@ async fn test_can_return_query_response_with_deeply_nested_query_postgres() {
 
     let client = http_client();
     let resp = client
-        .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
+        .post("http://localhost:29987/api/graph/fuel_indexer_test/index1")
         .json(&deeply_nested_query)
         .send()
         .await
@@ -356,7 +356,7 @@ async fn test_can_return_nested_query_response_with_explicit_foreign_keys_postgr
 
     let client = http_client();
     let resp = client
-        .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
+        .post("http://localhost:29987/api/graph/fuel_indexer_test/index1")
         .header(CONTENT_TYPE, "application/json".to_owned())
         .body(
             r#"{"query": "query { sportsteam { id name municipality { id name } } }", "params": "b"}"#,

--- a/packages/fuel-indexer-tests/tests/integration/database.rs
+++ b/packages/fuel-indexer-tests/tests/integration/database.rs
@@ -55,7 +55,7 @@ async fn load_wasm_module(database_url: &str) -> IndexerResult<Instance> {
 
 #[tokio::test]
 async fn test_schema_manager_generates_and_loads_schema_postgres() {
-    let database_url = "postgres://postgres:my-secret@127.0.0.1:5432";
+    let database_url = "postgres://postgres:my-secret@localhost:5432";
     generate_schema_then_load_schema_from_wasm_module(database_url).await;
 }
 

--- a/packages/fuel-indexer-tests/tests/integration/web_api_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/integration/web_api_postgres.rs
@@ -32,13 +32,13 @@ async fn test_metrics_endpoint_returns_proper_count_of_metrics_postgres() {
 
     let client = http_client();
     let _ = client
-        .get("http://127.0.0.1:29987/api/health")
+        .get("http://localhost:29987/api/health")
         .send()
         .await
         .unwrap();
 
     let resp = client
-        .get("http://127.0.0.1:29987/api/metrics")
+        .get("http://localhost:29987/api/metrics")
         .send()
         .await
         .unwrap()
@@ -69,13 +69,13 @@ async fn test_database_postgres_metrics_properly_increments_counts_when_queries_
 
     let client = http_client();
     let _ = client
-        .get("http://127.0.0.1:29987/api/health")
+        .get("http://localhost:29987/api/health")
         .send()
         .await
         .unwrap();
 
     let resp = client
-        .get("http://127.0.0.1:29987/api/metrics")
+        .get("http://localhost:29987/api/metrics")
         .send()
         .await
         .unwrap()
@@ -138,7 +138,7 @@ async fn test_asset_upload_endpoint_properly_adds_assets_to_database_postgres() 
 
     let client = http_client();
     let resp = client
-        .post("http://127.0.0.1:29987/api/index/test_namespace/simple_wasm_executor")
+        .post("http://localhost:29987/api/index/test_namespace/simple_wasm_executor")
         .multipart(form)
         .header(CONTENT_TYPE, "multipart/form-data".to_owned())
         .header(AUTHORIZATION, "foo".to_owned())
@@ -199,7 +199,7 @@ async fn test_signature_route_validates_signature_expires_nonce_and_creates_jwt(
     let server_handle = tokio::spawn(server);
 
     let resp = http_client()
-        .post("http://127.0.0.1:29987/api/auth/signature")
+        .post("http://localhost:29987/api/auth/signature")
         .header(CONTENT_TYPE, "application/json".to_owned())
         .json(&SignatureRequest {
             signature: SIGNATURE.to_string(),

--- a/plugins/forc-index/src/ops/forc_index_check.rs
+++ b/plugins/forc-index/src/ops/forc_index_check.rs
@@ -99,7 +99,7 @@ pub fn init(command: CheckCommand) -> anyhow::Result<()> {
     let (service_emoji, service_msg) = find_indexer_service_info(&grpahql_api_port);
     let (docker_emoji, _docker_path, docker_msg) = find_executable_with_msg(docker);
     let (fuelup_emoji, _fuelup_path, fuelup_msg) = find_executable_with_msg(fuelup);
-    let (forc_pg_emoji, _forc_pg_path, forc_pg_msg) = find_executable_with_msg(fuelup);
+    let (forc_pg_emoji, _forc_pg_path, forc_pg_msg) = find_executable_with_msg(forc_pg);
     let (wasm_snip_emoji, _wasm_snip_path, wasm_snip_msg) =
         find_executable_with_msg(wasm_snip);
     let (rustc_emoji, _rustc_path, rustc_msg) = find_executable_with_msg(rustc);

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -125,12 +125,14 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         info!("{cmd:?}");
     }
 
-    let _proc = cmd
-        .spawn()
-        .expect("❌ Failed to spawn fuel-indexer child process.");
-
-    // TODO: check stats code of process before saying ok
-    info!("\n✅ Successfully started the indexer service.");
+    if let Ok(child) = cmd.spawn() {
+        info!(
+            "\n✅ Successfully started the indexer service at PID {}.",
+            child.id()
+        );
+    } else {
+        anyhow::bail!("❌ Failed to spawn fuel-indexer child process.");
+    }
 
     Ok(())
 }

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -41,6 +41,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         let user = postgres_user
             .clone()
             .unwrap_or(defaults::POSTGRES_USER.to_string());
+
         let port = postgres_port
             .clone()
             .unwrap_or(defaults::POSTGRES_PORT.to_string());

--- a/plugins/forc-index/src/utils/defaults.rs
+++ b/plugins/forc-index/src/utils/defaults.rs
@@ -5,7 +5,7 @@ pub const CARGO_MANIFEST_FILE_NAME: &str = "Cargo.toml";
 pub const INDEX_LIB_FILENAME: &str = "lib.rs";
 pub const CARGO_CONFIG_DIR_NAME: &str = ".cargo";
 pub const CARGO_CONFIG_FILENAME: &str = "config";
-pub const INDEXER_SERVICE_HOST: &str = "http://127.0.0.1:29987";
+pub const INDEXER_SERVICE_HOST: &str = "http://localhost:29987";
 pub const GRAPHQL_API_PORT: &str = defaults::GRAPHQL_API_PORT;
 pub const INDEXER_TARGET: &str = "wasm32-unknown-unknown";
 

--- a/scripts/utils/refresh_test_db.bash
+++ b/scripts/utils/refresh_test_db.bash
@@ -13,7 +13,7 @@ db_type=${db_arg:=postgres}
 if [ $db_type == "postgres" ]; then
     dropdb postgres
     createdb postgres
-    DATABASE_URL=postgres://postgres@127.0.0.1 bash scripts/run_migrations.bash
+    DATABASE_URL=postgres://postgres@localhost bash scripts/run_migrations.bash
 else
     echo "Invalid db param. Expected 'postgres'. Found '$db_type'"
     exit 1


### PR DESCRIPTION
### Description
- Updates new beta net references to `beta-3` (not node-beta-3.fuel.network)
- Prints the PID of `forc index start` so a user can kill the proc without having to find it (it runs in the background so Ctrl+C won't work)
- Replaces all 127.0.0.1 references with localhost
- Fixes the examples
  - docker-compose in block explorer was updated with the new `run` command
  - Docs were updated with new example names
- README was updated

### Testing steps
- [ ] Test out the examples
  - With and without docker
- [ ] CI should pass
- [ ] If manually testing commands
  - Ensure `forc index start` is being built with your local `fuel-indexer` at /path/to/fuel-indexer/target/release/fuel-indexer, _not_ the indexer in your `PATH`

### Changelog
- chore: general plugin cleanup and example updates