### PR TITLE
fix: do not panic when there is an empty data field in `MessageOut` receipt

### DIFF
--- a/packages/fuel-indexer-macros/src/indexer.rs
+++ b/packages/fuel-indexer-macros/src/indexer.rs
@@ -105,7 +105,6 @@ fn process_fn_items(
                 }
             }
         })
-        // Add an arm for a unit struct in case of empty data fields
         .chain(
             vec![quote! {
                 u64::MAX => {
@@ -475,15 +474,20 @@ fn process_fn_items(
                                 // It's possible that the data field was generated from an empty Sway `Bytes` array
                                 // in the send_message() instruction in which case the data field in the receipt will
                                 // have no type information or data to decode, so we decode an empty vector to a unit struct
-                                let type_id = match data.get(..8) {
-                                    Some(buffer) => u64::from_be_bytes(<[u8; 8]>::try_from(&buffer[..]).expect("Could not get type ID for data in MessageOut receipt")),
-                                    None => u64::MAX,
-                                };
+                                let type_id = data
+                                    .get(..8)
+                                    .map(|buffer| {
+                                        u64::from_be_bytes(
+                                            <[u8; 8]>::try_from(&buffer[..])
+                                                .expect("Could not get type ID for data in MessageOut receipt"),
+                                        )
+                                    })
+                                    .unwrap_or(u64::MAX);
 
-                                let data = match data.get(8..) {
-                                    Some(buffer) => buffer.to_vec(),
-                                    None => Vec::<u8>::new(),
-                                };
+                                let data = data
+                                    .get(8..)
+                                    .map(|buffer| buffer.to_vec())
+                                    .unwrap_or(Vec::<u8>::new());
 
                                 let receipt = abi::MessageOut{ message_id, sender, recipient, amount, nonce, len, digest, data };
                                 decoder.decode_messageout(type_id, receipt);

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -751,4 +751,8 @@ async fn test_can_trigger_and_index_pure_function_postgres() {
     );
     assert_eq!(asset_id, defaults::TRANSFER_BASE_ASSET_ID);
     assert_eq!(fn_name, "trigger_pure_function");
+    let data = data
+        .get(8..)
+        .map(|buffer| buffer.to_vec())
+        .unwrap_or(Vec::<u8>::new());
 }


### PR DESCRIPTION
## Changelog
- Safely decode type ID and data from `data` field of `MessageOut` receipt

## Testing Plan
We can't create a test for this just yet as I don't know how someone was able to generate an empty data field. It was suggested that one can use an empty `Bytes` array to trigger it, but I was unable to get it working. In any case, this should solve our issues in which the indexer was crashing on the beta-3 testnet.

### Manual Steps
0. Build WASM modules and ensure DB is cleared.
1. Run examples on beta-2; indexers should work as expected.
2. Run examples on beta-3; indexers should work as expected.

## Notes
This error was caused by a `MessageOut` receipt with an empty hex string for the `data` field:
```
{
  "receiptType": "MESSAGE_OUT",
  "recipient": "0x000000000000000000000000172eda4e99d41a97d7c1849a8d05f46de9eeb8dc",
  "sender": "0xb53d4780ab195abdbd164a4cd5692a4e4ebc61b8d048abb42841ccb6cee150cf",
  "amount": "100000000",
  "data": "0x", <---
  "nonce": "0x632aaa4129d018ac820982dba793c5ec22c12bd19bef57521cf42ba7b7b0aedf"
}
```

We were decoding the type by copying from a slice of the data field, which panics if the slice lengths are not the same; ultimately, this is what was causing the WASM `Trap` error codes.