### PR TITLE
chore: iterate blocks in proper ascending order

### DIFF
--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -129,7 +129,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
             debug!("Processing {} results", results.len());
 
             let mut block_info = Vec::new();
-            for block in results.into_iter().rev() {
+            for block in results.into_iter() {
                 let producer = block.block_producer().map(|pk| pk.hash());
 
                 // NOTE: for now assuming we have a single contract instance,


### PR DESCRIPTION
## Changelog
- Iterate blocks in proper ascending order

## Testing Plan
CI should pass. All this does is change the order of incoming blocks into executors from:
```
10, 9, 8, 7, 6, 5, ...
20, 19, 18, 17, 16, 15 ...
```
to:
```
1, 2, 3, 4, 5, ...
11, 12, 13, 14, 15, ...
```

You can notice the change by running the block explorer example pointed to either of the testnet chains. On master, they come in the former order. On this branch, they come in the latter order.

## Notes
We originally had the `.rev()` call on the iterator as the fuel node client originally sent them to the indexer in the reverse order. In all the other work that we've done, we've forgotten to go back and remove it.