### PR TITLE
chore: bump docker image version

### DIFF
--- a/ci/Dockerfile.fuel-node
+++ b/ci/Dockerfile.fuel-node
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.67 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.68.1 AS chef
 
 WORKDIR /build/
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.67 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.68.1 AS chef
 
 WORKDIR /build/
 


### PR DESCRIPTION
The docker image being pulled in `Dockerfile.fuel-node` was using rust `1.67` `lukemathwalker/cargo-chef` has the latest available `1.68.1`. This bumps it and should resolve the X on master CI. 

I am unable to test this locally due to M1 build problem. 