### PR TITLE
chore: update Docker rustc versions

### DIFF
--- a/ci/Dockerfile.fuel-node
+++ b/ci/Dockerfile.fuel-node
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.67 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.68.1 AS chef
 
 WORKDIR /build/
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.67 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.68.1 AS chef
 
 WORKDIR /build/
 


### PR DESCRIPTION
## Changelog
- Update base Docker images for deployment and fuel node to use `rustc v1.68.1`

## Testing Plan
All tests should pass as this just updates the rustc version for deployments.

## Notes
After merging #696, I noticed that the `publish-docker-image` step failed because it was using a base image with  `rustc` version tied to 1.67. We should make sure to remember to check the Dockerfiles in the future.