### PR TITLE
chore: upgrade `wasmer` to v2.3.0

### DIFF
--- a/packages/fuel-indexer-tests/Cargo.toml
+++ b/packages/fuel-indexer-tests/Cargo.toml
@@ -54,9 +54,9 @@ tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["env-filter"] }
 url = "2.3"
-wasmer = "2.0"
-wasmer-compiler-cranelift = { version = "2.0" }
-wasmer-engine-universal = "2.0"
+wasmer = "2.3"
+wasmer-compiler-cranelift = { version = "2.3" }
+wasmer-engine-universal = "2.3"
 
 [features]
 e2e = []

--- a/packages/fuel-indexer/Cargo.toml
+++ b/packages/fuel-indexer/Cargo.toml
@@ -33,9 +33,9 @@ sqlx = { version = "0.6", features = ["bigdecimal"] }
 thiserror = "1.0"
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "sync", "process"] }
 tracing = "0.1"
-wasmer = "2.0"
-wasmer-compiler-cranelift = { version = "2.0" }
-wasmer-engine-universal = "2.0"
+wasmer = "2.3"
+wasmer-compiler-cranelift = { version = "2.3" }
+wasmer-engine-universal = "2.3"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Changelog
- Upgrade `wasmer` from `v2.0` to `v2.3`

## Testing Plan
Tests should pass. Each example should pass as well.

## Notes
_No changes in functionality_; this is just an upgrade to bring in some fixes for memory leaks and the like that have been added after `wasmer`'s `v2.0` release. We should still investigate refactoring to use `v3.0` or above, just at a later time.