### PR TITLE
chore: fix CI commands for plugin tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,38 +272,6 @@ jobs:
       - name: cargo test --locked --all-targets -p plugin-tests -- --test-threads=1
         run: cargo test --locked --all-targets -p plugin-tests -- --test-threads=1
 
-  check-forc-index:
-    if: needs.check-is-semver-branch.outputs.is_semver_branch != 'true'
-    needs:
-      - check-is-semver-branch
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Install wasm-snip
-        run: cargo install wasm-snip
-
-      - name: Build forc index
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p forc-index
-
-      - name: Create new index
-        run: |
-          mkdir ../forc_index_test && cd ../forc_index_test && ../fuel-indexer/target/debug/forc-index init --namespace fuel
-
-      - name: Build new index
-        working-directory: ../forc_index_test
-        run: ../fuel-indexer/target/debug/forc-index build
-
   publish-docker-image:
     needs:
       - set-env-vars
@@ -641,7 +609,7 @@ jobs:
       - cargo-test-e2e-and-integration-tests
       - cargo-clippy
       - cargo-fmt-check
-      - check-forc-index
+      - cargo-test-forc-index-plugins
 
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,8 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - name: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests forc-index-tests
-        run: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests forc-index-tests
+      - name: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests plugin-tests
+        run: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests plugin-tests
 
   cargo-test-e2e-and-integration-tests:
     if: needs.set-env-vars.outputs.IS_RELEASE != 'true'
@@ -248,7 +248,7 @@ jobs:
           cp simple_wasm.wasm target/wasm32-unknown-unknown/release/
 
       - name: Run E2E and integration tests
-        run: cargo test --locked --all-targets --features e2e,postgres -p fuel-indexer-tests --workspace --exclude forc-index-tests -- --test-threads=1
+        run: cargo test --locked --all-targets --features e2e,postgres -p fuel-indexer-tests -- --test-threads=1
 
   cargo-test-forc-index-plugins:
     if: needs.check-is-semver-branch.outputs.is_semver_branch != 'true'
@@ -269,8 +269,8 @@ jobs:
       - name: wasm-snip
         run: cargo install wasm-snip
 
-      - name: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests -- --test-threads=1
-        run: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests -- --test-threads=1
+      - name: cargo test --locked --all-targets -p plugin-tests -- --test-threads=1
+        run: cargo test --locked --all-targets -p plugin-tests -- --test-threads=1
 
   check-forc-index:
     if: needs.check-is-semver-branch.outputs.is_semver_branch != 'true'


### PR DESCRIPTION
## Changelog
- Ensure that `cargo-test-forc-index-plugins` CI step only tests the plugins
- Remove unnecessary exclusions
- Remove `check-forc-index` as it's superseded by `cargo-test-forc-index-plugins`

## Testing Plan
CI should pass.

## Notes
`cargo-test-forc-index-plugins` was testing the entire workspace _and_ running each test sequentially. This changes that step so that it only runs the plugin tests.