### PR TITLE
chore: general `forc index deploy` cleanup

### DIFF
--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -46,6 +46,6 @@ pub const JWT_EXPIRY_SECS: usize = 2592000; // 30 days
 pub const ACCOUNT_INDEX: &str = "0";
 
 pub const VERBOSE_LOGGING: bool = false;
-
 pub const VERBOSE_DB_LOGGING: &str = "false";
+
 pub const NODE_GRAPHQL_PAGE_SIZE: usize = 10;

--- a/plugins/forc-index/src/ops/forc_index_build.rs
+++ b/plugins/forc-index/src/ops/forc_index_build.rs
@@ -68,8 +68,8 @@ pub fn init(command: BuildCommand) -> anyhow::Result<()> {
     file.read_to_string(&mut content)?;
     let config: Config = toml::from_str(&content)?;
 
-    let index_manifest_path = root_dir.join(manifest);
-    let mut manifest = Manifest::from_file(&index_manifest_path)?;
+    let indexer_manifest_path = root_dir.join(manifest);
+    let mut manifest = Manifest::from_file(&indexer_manifest_path)?;
 
     // Construct our build command
     //
@@ -201,7 +201,7 @@ pub fn init(command: BuildCommand) -> anyhow::Result<()> {
             anyhow::bail!("❌ Failed to execute wasm-snip: (Code: {code:?})",)
         }
 
-        manifest.write_to(&index_manifest_path)?;
+        manifest.write_to(&indexer_manifest_path)?;
     }
 
     Ok(())

--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -1,8 +1,9 @@
 use crate::{
     cli::{BuildCommand, DeployCommand},
     commands::build,
-    utils::{extract_manifest_fields, project_dir_info},
+    utils::project_dir_info,
 };
+use fuel_indexer_lib::manifest::Manifest;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::{
     blocking::{multipart::Form, Client},
@@ -10,11 +11,7 @@ use reqwest::{
     StatusCode,
 };
 use serde_json::{to_string_pretty, value::Value, Map};
-use std::{
-    fs,
-    io::{BufReader, Read},
-    time::Duration,
-};
+use std::time::Duration;
 use tracing::{error, info};
 
 pub fn init(command: DeployCommand) -> anyhow::Result<()> {
@@ -43,29 +40,27 @@ pub fn init(command: DeployCommand) -> anyhow::Result<()> {
             verbose,
             locked,
             native,
-            target_dir: target_dir.clone(),
+            target_dir,
         })?;
     }
 
     let (_root_dir, manifest_path, _index_name) =
         project_dir_info(path.as_ref(), manifest.as_ref())?;
 
-    let mut manifest_file = fs::File::open(&manifest_path)?;
-    let mut manifest_contents = String::new();
-    manifest_file.read_to_string(&mut manifest_contents)?;
-    let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_contents)?;
+    let manifest = Manifest::from_file(&manifest_path)?;
 
-    let (namespace, identifier, graphql_schema, module_path) =
-        extract_manifest_fields(manifest, target_dir.as_ref())?;
-
-    let mut manifest_buff = Vec::new();
-    let mut manifest_reader = BufReader::new(manifest_file);
-    manifest_reader.read_to_end(&mut manifest_buff)?;
+    let Manifest {
+        graphql_schema,
+        namespace,
+        identifier,
+        module,
+        ..
+    } = manifest;
 
     let form = Form::new()
         .file("manifest", &manifest_path)?
         .file("schema", graphql_schema)?
-        .file("wasm", module_path)?;
+        .file("wasm", module.path())?;
 
     let target = format!("{url}/api/index/{namespace}/{identifier}");
 

--- a/plugins/forc-index/src/utils/mod.rs
+++ b/plugins/forc-index/src/utils/mod.rs
@@ -6,57 +6,6 @@ pub(crate) fn dasherize_to_underscore(s: &str) -> String {
     str::replace(s, "-", "_")
 }
 
-pub(crate) fn extract_manifest_fields(
-    manifest: serde_yaml::Value,
-    target_dir: Option<&PathBuf>,
-) -> anyhow::Result<(String, String, PathBuf, PathBuf)> {
-    let namespace: String = manifest
-        .get(&serde_yaml::Value::String("namespace".into()))
-        .unwrap()
-        .as_str()
-        .unwrap()
-        .to_string();
-
-    let identifier: String = manifest
-        .get(&serde_yaml::Value::String("identifier".into()))
-        .unwrap()
-        .as_str()
-        .unwrap()
-        .to_string();
-
-    let mut graphql_schema = PathBuf::from(
-        manifest
-            .get(&serde_yaml::Value::String("graphql_schema".into()))
-            .unwrap()
-            .as_str()
-            .unwrap(),
-    );
-
-    let module: serde_yaml::Value = manifest
-        .get(&serde_yaml::Value::String("module".into()))
-        .unwrap()
-        .to_owned();
-
-    let mut module_path = PathBuf::from(
-        module
-            .get(&serde_yaml::Value::String("wasm".into()))
-            .unwrap_or_else(|| {
-                module
-                    .get(&serde_yaml::Value::String("native".into()))
-                    .unwrap()
-            })
-            .as_str()
-            .unwrap(),
-    );
-
-    if let Some(target_dir) = target_dir {
-        graphql_schema = target_dir.join(graphql_schema);
-        module_path = target_dir.join(module_path);
-    }
-
-    Ok((namespace, identifier, graphql_schema, module_path))
-}
-
 pub(crate) fn project_dir_info(
     path: Option<&PathBuf>,
     manifest: Option<&String>,


### PR DESCRIPTION
### Description
- General plugin cleanup

### Testing steps 
- [ ] `forc index deploy` should work as normal
  - Run fuel node `cargo run --bin fuel-node`
  - Run indexer `cargo run --bin fuel-indexer -- run --fuel-node-host localhost --fuel-node-port 4000 --graphql-api-host localhost --graphql-api-port 29987 --log-level info --verbose --run-migrations`
  - Deploy example `./target/release/forc-index deploy --target-dir /Users/rashad/development/repos/fuel-indexer --path examples/block-explorer/explorer-indexer --release --verbose`
    - Should have latest `forc-index` at `./target/release`


### Changelog 
- chore: general `forc index deploy` cleanup