### PR TITLE
enhancement: allow network config from manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
   pull_request:
   release:
     types: [published]
-
-
+    
 env:
   DATABASE_URL: postgres://postgres:my-secret@localhost:5432
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64

--- a/config.yaml
+++ b/config.yaml
@@ -14,12 +14,15 @@
 
 # # Run database migrations before starting service.
 # run_migrations: true
-#
+
 # # Enable verbose logging.
 # verbose: false
 
 # # Start a local Fuel node.
 # local_fuel_node: false
+
+# # Allow network configuration via indexer manifests.
+# indexer_net_config: false
 
 # # ***********************
 # # Fuel Node configuration

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -238,3 +238,4 @@ http://127.0.0.1:29987/api/graph/my_project/hello_indexer
 ### Finished! 🥳
 
 Congrats, you just created, built, and deployed your first indexer on the world's fastest execution layer. For more detailed info on how the Fuel indexer service works, make sure you [**read the book**](https://fuellabs.github.io/fuel-indexer/master/).
+

--- a/docs/src/getting-started/starting-the-fuel-indexer.md
+++ b/docs/src/getting-started/starting-the-fuel-indexer.md
@@ -39,6 +39,9 @@ OPTIONS:
     -h, --help
             Print help information
 
+        --indexer-net-config
+            Allow network configuration via indexer manifests.
+
         --jwt-expiry <JWT_EXPIRY>
             Amount of time (seconds) before expiring token (if JWT scheme is specified).
 

--- a/docs/src/reference-guide/components/assets/manifest.md
+++ b/docs/src/reference-guide/components/assets/manifest.md
@@ -5,6 +5,7 @@ A manifest serves as the YAML configuration file for a given indexer. A proper m
 ```yaml
 namespace: fuel
 identifier: index1
+fuel_client: beta-3.fuel.network:80
 abi: path/to/my/contract-abi.json
 contract_id: "0x39150017c9e38e5e280432d546fae345d6ce6d8fe4710162c2e3a95a6faff051"
 graphql_schema: path/to/my/schema.graphql
@@ -16,17 +17,31 @@ report_metrics: true
 
 ## `namespace`
 
+_Required._
+
 The `namespace` is the topmost organizational level of an indexer. You can think of different namespaces as separate and distinct collections comprised of indexers. A namespace is unique to a given indexer operator -- i.e., indexer operators will not be able to support more than one namespace of the same name.
 
 ## `identifier`
 
+_Required._
+
 The `identifier` field is used to (quite literally) identify the given indexer. If a namespace describes a collection of indexers, then an identifier describes a unique indexer inside that collection. As an example, if a provided `namespace` is `"fuel"` and a provided `identifier` is `"index1"`, then the full identifier for the given indexer will be `fuel.index1`.
 
+## `fuel_client`
+
+_Optional._
+
+The `fuel_client` denotes the address (host, port combination) of the running Fuel client that you would like your indexer to index events from. In order to use this per-indexer `fuel_client` option, the indexer service at which your indexer is deployed will have to run with the `--indexer_net_config` option.
+
 ## `abi`
+
+_Optional._
 
 The `abi` option is used to provide a link to the Sway JSON application binary interface (ABI) that is generated when you build your Sway project. This generated ABI contains all types, type IDs, logged types, and message types used in your Sway contract.
 
 ## `contract_id`
+
+_Optional._
 
 The `contract_id` specifies the particular contract to which you would like an indexer to subscribe. Setting this field to an empty string will index events from any contract that is currently executing on the network.
 
@@ -34,15 +49,21 @@ The `contract_id` specifies the particular contract to which you would like an i
 
 ## `graphql_schema`
 
+_Required._
+
 The `graphql_schema` field contains the file path pointing to the corresponding GraphQL schema for a given indexer. This schema file holds the structures of the data that will eventually reside in your database. You can read more about the format of the schema file [here](./schema.md).
 
 > Important: The objects defined in your GraphQL schema are called 'entities'. These entities are what will be eventually be stored in the database.
 
 ## `start_block`
 
+_Optional._
+
 The `start_block` field indicates the block height after which you'd like your indexer to start indexing events.
 
 ## `module`
+
+_Required._
 
 The `module` field contains a file path that points to code that will be run as an _executor_ inside of the indexer. There are two available options for modules/execution: `wasm` and `native`. Note that when specifying a `wasm` module, the provided path must lead to a compiled WASM binary.
 
@@ -50,8 +71,12 @@ The `module` field contains a file path that points to code that will be run as 
 
 ## `report_metrics`
 
+_Optional._
+
 The `report_metrics` field indicates whether to report Prometheus metrics to the Fuel backend.
 
 ## `resumable`
+
+_Optional._
 
 The `resumable` field contains a boolean value and specifies whether the indexer should synchronise with the latest block if it has fallen out of sync.

--- a/examples/block-explorer/explorer-indexer/explorer_indexer.manifest.yaml
+++ b/examples/block-explorer/explorer-indexer/explorer_indexer.manifest.yaml
@@ -1,6 +1,7 @@
 ---
 namespace: fuel_examples
 abi: ~
+fuel_client: ~
 identifier: explorer_indexer
 graphql_schema: examples/block-explorer/explorer-indexer/schema/explorer_indexer.schema.graphql
 module:

--- a/examples/hello-world-native/hello-indexer-native/hello_indexer_native.manifest.yaml
+++ b/examples/hello-world-native/hello-indexer-native/hello_indexer_native.manifest.yaml
@@ -1,6 +1,7 @@
 namespace: fuel_examples
 identifier: hello_indexer_native
 contract_id: ~
+fuel_client: ~
 report_metrics: true
 abi: examples/hello-world/contracts/greeting/out/debug/greeting-abi.json
 start_block: 1

--- a/examples/hello-world/hello-indexer/hello_indexer.manifest.yaml
+++ b/examples/hello-world/hello-indexer/hello_indexer.manifest.yaml
@@ -2,6 +2,7 @@
 namespace: fuel_examples
 abi: examples/hello-world/contracts/greeting/out/debug/greeting-abi.json
 identifier: hello_indexer
+fuel_client: ~
 graphql_schema: examples/hello-world/hello-indexer/schema/hello_indexer.schema.graphql
 module:
   wasm: target/wasm32-unknown-unknown/release/hello_indexer.wasm

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -195,6 +195,10 @@ pub struct IndexerArgs {
     /// Start a local Fuel node.
     #[clap(long, help = "Start a local Fuel node.")]
     pub local_fuel_node: bool,
+
+    /// Allow network configuration via indexer manifests.
+    #[clap(long, help = "Allow network configuration via indexer manifests.")]
+    pub indexer_net_config: bool,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -311,6 +315,8 @@ pub struct IndexerConfig {
     #[serde(default)]
     pub local_fuel_node: bool,
     #[serde(default)]
+    pub indexer_net_config: bool,
+    #[serde(default)]
     pub fuel_node: FuelNodeConfig,
     #[serde(default)]
     pub graphql_api: GraphQLConfig,
@@ -366,6 +372,7 @@ impl From<IndexerArgs> for IndexerConfig {
         let mut config = IndexerConfig {
             verbose: args.verbose,
             local_fuel_node: args.local_fuel_node,
+            indexer_net_config: args.indexer_net_config,
             database,
             fuel_node: FuelNodeConfig {
                 host: args.fuel_node_host,
@@ -442,6 +449,7 @@ impl From<ApiServerArgs> for IndexerConfig {
         let mut config = IndexerConfig {
             verbose: args.verbose,
             local_fuel_node: defaults::LOCAL_FUEL_NODE,
+            indexer_net_config: defaults::INDEXER_NET_CONFIG,
             database,
             fuel_node: FuelNodeConfig {
                 host: args.fuel_node_host,
@@ -491,6 +499,8 @@ impl IndexerConfig {
         let run_migrations_key = serde_yaml::Value::String("run_migrations".into());
         let verbose_key = serde_yaml::Value::String("verbose".into());
         let local_fuel_node_key = serde_yaml::Value::String("local_fuel_node".into());
+        let indexer_net_config_key =
+            serde_yaml::Value::String("indexer_net_config".into());
 
         if let Some(metrics) = content.get(metrics_key) {
             config.metrics = metrics.as_bool().unwrap();
@@ -510,6 +520,10 @@ impl IndexerConfig {
 
         if let Some(local_fuel_node) = content.get(local_fuel_node_key) {
             config.local_fuel_node = local_fuel_node.as_bool().unwrap();
+        }
+
+        if let Some(indexer_net_config) = content.get(indexer_net_config_key) {
+            config.indexer_net_config = indexer_net_config.as_bool().unwrap();
         }
 
         let fuel_config_key = serde_yaml::Value::String("fuel_node".into());

--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -51,3 +51,5 @@ pub const VERBOSE_DB_LOGGING: &str = "false";
 pub const NODE_GRAPHQL_PAGE_SIZE: usize = 10;
 
 pub const LOCAL_FUEL_NODE: bool = false;
+
+pub const INDEXER_NET_CONFIG: bool = false;

--- a/packages/fuel-indexer-lib/src/manifest.rs
+++ b/packages/fuel-indexer-lib/src/manifest.rs
@@ -76,13 +76,6 @@ impl Manifest {
         Self::from_str(&content)
     }
 
-    pub fn fuel_client(&self) -> String {
-        self
-            .fuel_client
-            .clone()
-            .expect("`fuel_client` is required in indexer manifest when `indexer_net_config` is specified in indexer config.")
-    }
-
     pub fn from_slice(s: &[u8]) -> ManifestResult<Self> {
         Ok(serde_yaml::from_slice(s)?)
     }

--- a/packages/fuel-indexer-lib/src/manifest.rs
+++ b/packages/fuel-indexer-lib/src/manifest.rs
@@ -73,15 +73,7 @@ impl Manifest {
         let mut file = File::open(path)?;
         let mut content = String::new();
         file.read_to_string(&mut content)?;
-        Self::from_str(&content)
-    }
-
-    pub fn from_slice(s: &[u8]) -> ManifestResult<Self> {
-        Ok(serde_yaml::from_slice(s)?)
-    }
-
-    pub fn to_bytes(&self) -> ManifestResult<Vec<u8>> {
-        Ok(serde_yaml::to_string(&self)?.as_bytes().to_vec())
+        Self::try_from(content.as_str())
     }
 
     /// Return the raw GraphQL schema string for an indexer manifest.

--- a/packages/fuel-indexer-lib/src/manifest.rs
+++ b/packages/fuel-indexer-lib/src/manifest.rs
@@ -57,6 +57,7 @@ pub struct Manifest {
     pub namespace: String,
     pub abi: Option<String>,
     pub identifier: String,
+    pub fuel_client: Option<String>,
     pub graphql_schema: String,
     pub module: Module,
     pub metrics: Option<bool>,
@@ -72,7 +73,22 @@ impl Manifest {
         let mut file = File::open(path)?;
         let mut content = String::new();
         file.read_to_string(&mut content)?;
-        Manifest::try_from(content.as_str())
+        Self::from_str(&content)
+    }
+
+    pub fn fuel_client(&self) -> String {
+        self
+            .fuel_client
+            .clone()
+            .expect("`fuel_client` is required in indexer manifest when `indexer_net_config` is specified in indexer config.")
+    }
+
+    pub fn from_slice(s: &[u8]) -> ManifestResult<Self> {
+        Ok(serde_yaml::from_slice(s)?)
+    }
+
+    pub fn to_bytes(&self) -> ManifestResult<Vec<u8>> {
+        Ok(serde_yaml::to_string(&self)?.as_bytes().to_vec())
     }
 
     /// Return the raw GraphQL schema string for an indexer manifest.

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml
@@ -8,3 +8,4 @@ identifier: index1
 module:
   wasm: target/wasm32-unknown-unknown/release/fuel_indexer_test.wasm
 report_metrics: true
+

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml
@@ -1,4 +1,5 @@
 namespace: fuel_indexer_test
+fuel_client: ~
 graphql_schema: packages/fuel-indexer-tests/components/indices/fuel-indexer-test/schema/fuel_indexer_test.graphql
 abi: packages/fuel-indexer-tests/contracts/fuel-indexer-test/out/debug/fuel-indexer-test-abi.json
 start_block: 1

--- a/packages/fuel-indexer-tests/src/fixtures.rs
+++ b/packages/fuel-indexer-tests/src/fixtures.rs
@@ -282,6 +282,7 @@ pub async fn api_server_app_postgres(database_url: Option<&str>) -> Router {
     let config = IndexerConfig {
         verbose: true,
         local_fuel_node: false,
+        indexer_net_config: false,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),
@@ -307,6 +308,7 @@ pub async fn authenticated_api_server_app_postgres(database_url: Option<&str>) -
     let config = IndexerConfig {
         verbose: true,
         local_fuel_node: false,
+        indexer_net_config: false,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),
@@ -338,6 +340,7 @@ pub async fn indexer_service_postgres(database_url: Option<&str>) -> IndexerServ
     let config = IndexerConfig {
         verbose: true,
         local_fuel_node: false,
+        indexer_net_config: false,
         fuel_node: FuelNodeConfig::default(),
         database,
         graphql_api: GraphQLConfig::default(),

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -75,7 +75,10 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
     let stop_idle_indexers = config.stop_idle_indexers;
 
     let fuel_node_addr = if config.indexer_net_config {
-        manifest.fuel_client()
+        manifest
+            .fuel_client
+            .clone()
+            .unwrap_or(config.fuel_node.to_string())
     } else {
         config.fuel_node.to_string()
     };

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -71,9 +71,14 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
     mut executor: T,
     kill_switch: Arc<AtomicBool>,
 ) -> impl Future<Output = ()> {
-    let fuel_node_addr = config.fuel_node.to_string();
     let start_block = manifest.start_block.expect("Failed to detect start_block.");
     let stop_idle_indexers = config.stop_idle_indexers;
+
+    let fuel_node_addr = if config.indexer_net_config {
+        manifest.fuel_client()
+    } else {
+        config.fuel_node.to_string()
+    };
 
     let mut next_cursor = if start_block > 1 {
         let decremented = start_block - 1;

--- a/packages/fuel-indexer/src/lib.rs
+++ b/packages/fuel-indexer/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(unused_crate_dependencies)]
-
 pub mod cli;
 pub(crate) mod commands;
 mod database;


### PR DESCRIPTION
### Description
- PR adds `fuel_node` param to indexer manifest and `--indexer-net-config` config opt to the indexer service
- `--indexer-net-config` is set by the indexer operator, and allows indexers uploaded with a `fuel_client` manifest param to connect to that particular indexer's Fuel client address (as opposed to the indexer operator's Fuel client address)
- I think the `--indexer-net-config` is necessary because flag because an indexer operator should decide whether they want to support this functionality.
  - If the indexer operator _does not_ use the `--indexer-net-config` flag, then whatever is specified in the `fuel_client` param of an indexer manifest will be ignored

### Testing steps
- [ ] Change the `fuel_client` param in `fuel_indexer_test.yaml` to `beta-3.fuel.network:80`
- [ ] Start service

```bash
cargo run --bin fuel-indexer -- run \
  --indexer-net-config \
  --manifest packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml \
  --run-migrations
```
- [ ] The indexer should be connected to beta-3 and should be indexing events

### Changelog 
- enhancement: allow network config from manifest