### PR TITLE
fix: persist embedded db when flag is passed

### DIFF
--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -51,6 +51,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
             password,
             user,
             port,
+            persistent: true,
             config: config.clone(),
             start: true,
             ..Default::default()
@@ -132,7 +133,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
     match cmd.spawn() {
         Ok(child) => {
             info!(
-                "\n✅ Successfully started the indexer service at PID {}.",
+                "\n✅ Successfully started the indexer service at PID {}",
                 child.id()
             );
         }


### PR DESCRIPTION
### Description
- This PR makes a small change to pass the `persistent: true` param to the `CreateDbCommand` command used by `for index start`
- Previously the DB was being created but not persisted, thus resulting in an error

### Testing steps
- [ ] Run `forc index start` and you should not get an error
  - Ensure `fore-index start` points at your local `fuel-indexer` binary 

```bash
./target/release/forc-index start \
  --embedded-database \
  --fuel-node-host beta-3.fuel.network \
  --fuel-node-port 80 \
  --run-migrations \
  --manifest examples/block-explorer/explorer-indexer/explorer_indexer.manifest.yaml
```
- One `master` this command ☝🏽 will fail


### Changelog
- fix: persist embedded db when flag is passed