### PR TITLE
fix: await fuel-core service when using --local-fuel-node

### DIFF
--- a/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
@@ -12,13 +12,11 @@ use fuel_indexer_tests::{
         TestPostgresDb,
     },
     utils::update_test_manifest_asset_paths,
-    WORKSPACE_ROOT,
 };
-use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
-use lazy_static::lazy_static;
+use hyper::header::CONTENT_TYPE;
 use serde_json::{Number, Value};
 use std::collections::HashMap;
-use tokio::task::{spawn, JoinHandle};
+use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
 
 async fn setup_test_components() -> (
@@ -38,7 +36,7 @@ async fn setup_test_components() -> (
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
 async fn test_can_return_query_response_with_all_fields_required_postgres() {
-    let (fuel_node_handle, test_db, mut srvc, api_app) = setup_test_components().await;
+    let (fuel_node_handle, _test_db, mut srvc, api_app) = setup_test_components().await;
 
     let server = axum::Server::bind(&GraphQLConfig::default().into())
         .serve(api_app.into_make_service());
@@ -82,7 +80,7 @@ async fn test_can_return_query_response_with_all_fields_required_postgres() {
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
 async fn test_can_return_query_response_with_nullable_fields_postgres() {
-    let (fuel_node_handle, test_db, mut srvc, api_app) = setup_test_components().await;
+    let (fuel_node_handle, _test_db, mut srvc, api_app) = setup_test_components().await;
 
     let server = axum::Server::bind(&GraphQLConfig::default().into())
         .serve(api_app.into_make_service());
@@ -127,7 +125,7 @@ async fn test_can_return_query_response_with_nullable_fields_postgres() {
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
 async fn test_can_return_nested_query_response_with_implicit_foreign_keys_postgres() {
-    let (fuel_node_handle, test_db, mut srvc, api_app) = setup_test_components().await;
+    let (fuel_node_handle, _test_db, mut srvc, api_app) = setup_test_components().await;
 
     let server = axum::Server::bind(&GraphQLConfig::default().into())
         .serve(api_app.into_make_service());
@@ -179,7 +177,7 @@ async fn test_can_return_nested_query_response_with_implicit_foreign_keys_postgr
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
 async fn test_can_return_query_response_with_deeply_nested_query_postgres() {
-    let (fuel_node_handle, test_db, mut srvc, api_app) = setup_test_components().await;
+    let (fuel_node_handle, _test_db, mut srvc, api_app) = setup_test_components().await;
 
     let server = axum::Server::bind(&GraphQLConfig::default().into())
         .serve(api_app.into_make_service());
@@ -331,7 +329,7 @@ async fn test_can_return_query_response_with_deeply_nested_query_postgres() {
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
 async fn test_can_return_nested_query_response_with_explicit_foreign_keys_postgres() {
-    let (fuel_node_handle, test_db, mut srvc, api_app) = setup_test_components().await;
+    let (fuel_node_handle, _test_db, mut srvc, api_app) = setup_test_components().await;
 
     let server = axum::Server::bind(&GraphQLConfig::default().into())
         .serve(api_app.into_make_service());

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -1,8 +1,6 @@
 use actix_service::Service;
 use actix_web::test;
 use fuel_indexer::IndexerService;
-use fuel_indexer_database::{queries, IndexerConnection};
-
 use fuel_indexer_lib::manifest::Manifest;
 use fuel_indexer_tests::{
     assets, defaults,
@@ -11,16 +9,9 @@ use fuel_indexer_tests::{
         setup_example_test_fuel_node, test_web::app, TestPostgresDb,
     },
     utils::update_test_manifest_asset_paths,
-    WORKSPACE_ROOT,
 };
 use fuel_indexer_types::{Address, ContractId, Identity};
-use hex::FromHex;
-use lazy_static::lazy_static;
-use sqlx::{
-    pool::{Pool, PoolConnection},
-    types::BigDecimal,
-    Postgres, Row,
-};
+use sqlx::{types::BigDecimal, Row};
 use std::str::FromStr;
 use tokio::{
     task::JoinHandle,
@@ -254,7 +245,7 @@ async fn test_can_trigger_and_index_ping_event_postgres() {
             .await
             .unwrap();
 
-    let id: i64 = row.get(0);
+    let _id: i64 = row.get(0);
     let value1: BigDecimal = row.get(1);
     let value2: BigDecimal = row.get(2);
 
@@ -497,7 +488,7 @@ async fn test_can_trigger_and_index_messageout_event_postgres() {
     let message_id: i64 = row.get(0);
     let recipient: &str = row.get(2);
     let amount: i64 = row.get(3);
-    let len: i64 = row.get(5);
+    let _len: i64 = row.get(5);
 
     let row = sqlx::query("SELECT * FROM fuel_indexer_test_index1.messageentity LIMIT 1")
         .fetch_one(&mut conn)
@@ -667,7 +658,7 @@ async fn test_index_respects_start_block_postgres() {
 
     let row = final_check.unwrap();
 
-    let id: i64 = row.get(0);
+    let _id: i64 = row.get(0);
     let height: i64 = row.get(1);
     let timestamp: i64 = row.get(2);
 
@@ -776,7 +767,7 @@ async fn test_can_trigger_and_index_revert_function_postgres() {
     let req = test::TestRequest::post().uri("/revert").to_request();
     let res = app.call(req).await;
 
-    let status = res.unwrap().status();
+    let _status = res.unwrap().status();
 
     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
     fuel_node_handle.abort();
@@ -814,7 +805,7 @@ async fn test_can_trigger_and_index_panic_function_postgres() {
     let contract = connect_to_deployed_contract().await.unwrap();
     let app = test::init_service(app(contract)).await;
     let req = test::TestRequest::post().uri("/panic").to_request();
-    let res = app.call(req).await;
+    let _res = app.call(req).await;
 
     sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
     fuel_node_handle.abort();

--- a/packages/fuel-indexer-tests/tests/integration/service.rs
+++ b/packages/fuel-indexer-tests/tests/integration/service.rs
@@ -1,12 +1,9 @@
 extern crate alloc;
 use fuel_indexer_lib::manifest::Manifest;
-use fuel_indexer_tests::{
-    defaults,
-    fixtures::{indexer_service_postgres, tx_params},
-};
+use fuel_indexer_tests::{defaults, fixtures::indexer_service_postgres};
 use fuels::prelude::{
     setup_single_asset_coins, setup_test_client, AssetId, Contract, DeployConfiguration,
-    Provider, StorageConfiguration, WalletUnlocked, DEFAULT_COIN_AMOUNT,
+    Provider, WalletUnlocked, DEFAULT_COIN_AMOUNT,
 };
 use fuels::signers::Signer;
 use fuels_macros::abigen;

--- a/packages/fuel-indexer-tests/tests/integration/web_api_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/integration/web_api_postgres.rs
@@ -1,6 +1,4 @@
-use fuel_indexer_api_server::api::GraphQlApi;
-use fuel_indexer_database::queries;
-use fuel_indexer_lib::{config::GraphQLConfig, defaults};
+use fuel_indexer_lib::config::GraphQLConfig;
 use fuel_indexer_postgres as postgres;
 use fuel_indexer_tests::assets::{
     SIMPLE_WASM_MANIFEST, SIMPLE_WASM_SCHEMA, SIMPLE_WASM_WASM,
@@ -10,10 +8,9 @@ use fuel_indexer_tests::fixtures::{
     indexer_service_postgres, TestPostgresDb,
 };
 use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
-use reqwest::{multipart, Body};
+use reqwest::multipart;
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task::spawn;
 
 const SIGNATURE: &str = "cb19384361af5dd7fec2a0052ca49d289f997238ea90590baf47f16ff0a33fb20170a43bd20208ce16daf443bad06dd66c1d1bf73f48b5ae53de682a5731d7d9";
 const NONCE: &str = "ea35be0c98764e7ca06d02067982e3b4";
@@ -61,7 +58,7 @@ async fn test_database_postgres_metrics_properly_increments_counts_when_queries_
     let server = axum::Server::bind(&GraphQLConfig::default().into())
         .serve(app.into_make_service());
 
-    let server_handle = tokio::spawn(server);
+    let _srv = tokio::spawn(server);
 
     let mut conn = test_db.pool.acquire().await.unwrap();
     let _ = postgres::execute_query(&mut conn, "SELECT 1;".into()).await;
@@ -196,7 +193,7 @@ async fn test_signature_route_validates_signature_expires_nonce_and_creates_jwt(
     let server = axum::Server::bind(&GraphQLConfig::default().into())
         .serve(app.into_make_service());
 
-    let server_handle = tokio::spawn(server);
+    let _srv = tokio::spawn(server);
 
     let resp = http_client()
         .post("http://localhost:29987/api/auth/signature")

--- a/packages/fuel-indexer-tests/tests/lib.rs
+++ b/packages/fuel-indexer-tests/tests/lib.rs
@@ -1,6 +1,4 @@
 #![allow(dead_code)]
-#![allow(unused_imports)]
-#![allow(unused_variables)]
 
 mod e2e;
 mod integration;

--- a/packages/fuel-indexer/src/commands/run.rs
+++ b/packages/fuel-indexer/src/commands/run.rs
@@ -24,6 +24,7 @@ use tokio::sync::mpsc::channel;
 
 #[cfg(feature = "fuel-core-lib")]
 async fn run_fuel_core_node() -> anyhow::Result<FuelService> {
+    // TODO: This should accept what ever is in FuelNodeConfig
     let config = Config {
         addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 4000),
         ..Config::local_node()

--- a/plugins/forc-index/src/ops/forc_index_auth.rs
+++ b/plugins/forc-index/src/ops/forc_index_auth.rs
@@ -92,11 +92,15 @@ pub fn init(command: AuthCommand) -> anyhow::Result<()> {
         .expect("Failed post signature.");
 
     if res.status() != StatusCode::OK {
-        error!(
-            "\n❌ {} returned a non-200 response code: {:?}",
-            &target,
-            res.status()
-        );
+        if verbose {
+            error!(
+                "\n❌ {} returned a non-200 response code: {:?}",
+                &target,
+                res.status()
+            );
+        } else {
+            error!("\n❌ Authentication failed.");
+        }
         return Ok(());
     }
 

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -61,7 +61,8 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         forc_postgres::commands::create::exec(Box::new(create_db_cmd)).await?;
     }
 
-    let mut cmd = Command::new("fuel-indexer");
+    let mut cmd =
+        Command::new("/Users/rashad/dev/repos/fuel-indexer/target/release/fuel-indexer");
     cmd.arg("run");
 
     if let Some(m) = &manifest {

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -61,8 +61,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         forc_postgres::commands::create::exec(Box::new(create_db_cmd)).await?;
     }
 
-    let mut cmd =
-        Command::new("/Users/rashad/dev/repos/fuel-indexer/target/release/fuel-indexer");
+    let mut cmd = Command::new("fuel-indexer");
     cmd.arg("run");
 
     if let Some(m) = &manifest {


### PR DESCRIPTION
### Description
- PR fixes a bug that was preventing the fuel-node for running (it was starting but the coroutine wasn't being awaited)
- Also adds `clippy` back to the tests

### Testing steps
- [ ] Point `forc-index` to this PR's `fuel-indexer`
- [ ] Build service(s) `cargo build -p forc-index -p fuel-indexer --release --features fuel-core-lib`
- [ ] Run service with fuel-node `./target/release/forc-index start --run-migrations --embedded-database --local-fuel-node --auth-enabled --auth-strategy jwt --jwt-secret abdefg`
- On master running the service should show that the service never actually connects to the fuel node

### Changeling 
- fix: await fuel-core service when using --local-fuel-node