### PR TITLE
enhancement: compute message ID by using `MessageOut` receipt fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ dependencies = [
  "getrandom",
  "serde",
  "serde_json",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3068,6 +3069,7 @@ dependencies = [
  "fuels-types",
  "getrandom",
  "serde",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3799,6 +3801,7 @@ dependencies = [
  "getrandom",
  "instant",
  "serde",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3818,6 +3821,7 @@ dependencies = [
  "getrandom",
  "instant",
  "serde",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -6113,6 +6117,7 @@ dependencies = [
  "fuels-types",
  "getrandom",
  "serde",
+ "sha2 0.10.6",
 ]
 
 [[package]]

--- a/examples/block-explorer/explorer-indexer/Cargo.toml
+++ b/examples/block-explorer/explorer-indexer/Cargo.toml
@@ -18,3 +18,4 @@ fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.10" }

--- a/examples/hello-world-native/hello-indexer-native/Cargo.toml
+++ b/examples/hello-world-native/hello-indexer-native/Cargo.toml
@@ -18,3 +18,4 @@ fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+sha2 = { version = "0.10" }

--- a/examples/hello-world/hello-indexer/Cargo.toml
+++ b/examples/hello-world/hello-indexer/Cargo.toml
@@ -18,3 +18,4 @@ fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+sha2 = { version = "0.10" }

--- a/packages/fuel-indexer-macros/src/indexer.rs
+++ b/packages/fuel-indexer-macros/src/indexer.rs
@@ -96,12 +96,12 @@ fn process_fn_items(
         .iter()
         .flatten()
         .map(|typ| {
-            let message_id = typ.message_id;
+            let message_type_id = typ.message_id;
             let ty_id = typ.application.type_id;
 
             quote! {
-                #message_id => {
-                    self.decode_type(#ty_id, data.data.clone());
+                #message_type_id => {
+                    self.decode_type(#ty_id, data);
                 }
             }
         })
@@ -377,6 +377,21 @@ fn process_fn_items(
                 }
             }
 
+            fn compute_message_id(&self, sender: &Address, recipient: &Address, nonce: Bytes32, amount: Word, data: &[u8]) -> MessageId {
+
+                let raw_message_id = Sha256::new()
+                    .chain_update(sender)
+                    .chain_update(recipient)
+                    .chain_update(nonce)
+                    .chain_update(amount.to_be_bytes())
+                    .chain_update(data)
+                    .finalize();
+
+                let message_id = <[u8; 32]>::try_from(&raw_message_id[..]).expect("Could not calculate message ID from receipt fields");
+
+                message_id.into()
+            }
+
             fn decode_type(&mut self, ty_id: usize, data: Vec<u8>) {
                 match ty_id {
                     #(#decoders),*
@@ -402,7 +417,7 @@ fn process_fn_items(
                 }
             }
 
-            pub fn decode_messageout(&mut self, type_id: u64, data: abi::MessageOut) {
+            pub fn decode_messagedata(&mut self, type_id: u64, data: Vec<u8>) {
                 match type_id {
                     #(#message_types_decoders),*
                     _ => Logger::warn("Unknown message type ID; check ABI to make sure that message types are correct.")
@@ -470,7 +485,9 @@ fn process_fn_items(
                                     decoder.decode_return_type(selector, data);
                                 }
                             }
-                            Receipt::MessageOut { message_id, sender, recipient, amount, nonce, len, digest, data } => {
+                            Receipt::MessageOut { sender, recipient, amount, nonce, len, digest, data, .. } => {
+                                let message_id = decoder.compute_message_id(&sender, &recipient, nonce, amount, &data[..]);
+
                                 // It's possible that the data field was generated from an empty Sway `Bytes` array
                                 // in the send_message() instruction in which case the data field in the receipt will
                                 // have no type information or data to decode, so we decode an empty vector to a unit struct
@@ -489,8 +506,11 @@ fn process_fn_items(
                                     .map(|buffer| buffer.to_vec())
                                     .unwrap_or(Vec::<u8>::new());
 
-                                let receipt = abi::MessageOut{ message_id, sender, recipient, amount, nonce, len, digest, data };
-                                decoder.decode_messageout(type_id, receipt);
+                                decoder.decode_messagedata(type_id, data.clone());
+
+                                let ty_id = abi::MessageOut::type_id();
+                                let data = bincode::serialize(&abi::MessageOut{ message_id, sender, recipient, amount, nonce, len, digest, data }).expect("Bad encoding");
+                                decoder.decode_type(ty_id, data);
                             }
                             Receipt::ScriptResult { result, gas_used } => {
                                 let ty_id = abi::ScriptResult::type_id();

--- a/packages/fuel-indexer-macros/src/native.rs
+++ b/packages/fuel-indexer-macros/src/native.rs
@@ -33,6 +33,7 @@ fn native_prelude() -> proc_macro2::TokenStream {
         use fuels_types::traits::{Parameterize, Tokenizable};
         use fuels_macros::{Parameterize, Tokenizable};
         use fuel_indexer_plugin::native::bincode;
+        use sha2::{Sha256, Digest};
 
         type B256 = [u8; 32];
 

--- a/packages/fuel-indexer-macros/src/wasm.rs
+++ b/packages/fuel-indexer-macros/src/wasm.rs
@@ -39,6 +39,7 @@ fn wasm_prelude() -> proc_macro2::TokenStream {
         use fuels_types::StringToken;
         use fuels_types::traits::{Parameterize, Tokenizable};
         use fuels_macros::{Parameterize, Tokenizable};
+        use sha2::{Sha256, Digest};
         use std::str::FromStr;
         use fuel_indexer_plugin::wasm::bincode;
 

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
@@ -17,3 +17,4 @@ fuels-macros = { version = "0.38.1" }
 fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+sha2 = { version = "0.10" }

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/schema/fuel_indexer_test.graphql
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/schema/fuel_indexer_test.graphql
@@ -112,6 +112,7 @@ type ScriptResult {
 
 type MessageOut {
     id: ID!
+    message_id: MessageId!
     sender: Address!
     recipient: Address!
     amount: UInt8!

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
@@ -171,6 +171,7 @@ mod fuel_indexer_test {
 
         let entity = MessageOut {
             id: first8_bytes_to_u64(message_id),
+            message_id,
             sender,
             recipient,
             amount,

--- a/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
@@ -17,3 +17,4 @@ fuels-macros = { version = "0.38.1" }
 fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+sha2 = { version = "0.10" }

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -140,7 +140,7 @@ async fn test_can_trigger_and_index_callreturn_postgres() {
 
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
-async fn w() {
+async fn test_can_trigger_and_index_blocks_and_transactions_postgres() {
     let (node_handle, test_db, mut srvc) = setup_test_components().await;
 
     let mut manifest = Manifest::try_from(assets::FUEL_INDEXER_TEST_MANIFEST).unwrap();
@@ -415,6 +415,19 @@ async fn test_can_trigger_and_index_messageout_event_postgres() {
     node_handle.abort();
 
     let mut conn = test_db.pool.acquire().await.unwrap();
+    let row = sqlx::query("SELECT * FROM fuel_indexer_test_index1.messageout LIMIT 1")
+        .fetch_one(&mut conn)
+        .await
+        .unwrap();
+
+    let recipient = row.get::<&str, usize>(3);
+    let amount = row.get::<BigDecimal, usize>(4).to_u64().unwrap();
+    assert_eq!(
+        recipient,
+        "532ee5fb2cabec472409eb5f9b42b59644edb7bf9943eda9c2e3947305ed5e96"
+    );
+    assert_eq!(amount, 100);
+
     let row = sqlx::query("SELECT * FROM fuel_indexer_test_index1.messageentity LIMIT 1")
         .fetch_one(&mut conn)
         .await


### PR DESCRIPTION
Closes #722.

## Changelog
- Compute `message_id` from `MessageOut` receipt fields
- Fix a bug in which the message data from the receipt was being indexed but not the receipt itself
- Fix errant re-name of one of our E2E tests

## Testing Plan
CI should pass. Since the message ID is different on every pass, I couldn't add an assertion to the E2E test. But if you want to be sure that the calculated message ID is exactly the same as the one in the receipt, feel free to replace the first two lines of the `Receipt::MessageOut` match arm with the following:
```
Receipt::MessageOut { sender, recipient, amount, nonce, len, digest, data, message_id } => {
    let computed_message_id = decoder.compute_message_id(&sender, &recipient, nonce, amount, &data[..]);
    Logger::warn!(&format!("These two message IDs should match:\nmessage id from receipt: {}\ncalculated message id: {}\n", message_id, calculated_message_id));
```

Then run `cargo run --bin fuel-node` along and `cargo run --bin web-api` to start up the testing components. After that, run `cargo run --bin fuel-indexer -- run --manifest packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml --verbose` to make sure logs are printed. Finally, run `curl -X POST http://127.0.0.1:8000/messageout` and inspect the logs to ensure that the IDs are the same.