### PR TITLE
Revert "enhancement: compute message ID by using `MessageOut` receipt fields"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,6 @@ dependencies = [
  "getrandom",
  "serde",
  "serde_json",
- "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3069,7 +3068,6 @@ dependencies = [
  "fuels-types",
  "getrandom",
  "serde",
- "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3801,7 +3799,6 @@ dependencies = [
  "getrandom",
  "instant",
  "serde",
- "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3821,7 +3818,6 @@ dependencies = [
  "getrandom",
  "instant",
  "serde",
- "sha2 0.10.6",
 ]
 
 [[package]]
@@ -6117,7 +6113,6 @@ dependencies = [
  "fuels-types",
  "getrandom",
  "serde",
- "sha2 0.10.6",
 ]
 
 [[package]]

--- a/examples/block-explorer/explorer-indexer/Cargo.toml
+++ b/examples/block-explorer/explorer-indexer/Cargo.toml
@@ -18,4 +18,3 @@ fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-sha2 = { version = "0.10" }

--- a/examples/hello-world-native/hello-indexer-native/Cargo.toml
+++ b/examples/hello-world-native/hello-indexer-native/Cargo.toml
@@ -18,4 +18,3 @@ fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-sha2 = { version = "0.10" }

--- a/examples/hello-world/hello-indexer/Cargo.toml
+++ b/examples/hello-world/hello-indexer/Cargo.toml
@@ -18,4 +18,3 @@ fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-sha2 = { version = "0.10" }

--- a/packages/fuel-indexer-macros/src/native.rs
+++ b/packages/fuel-indexer-macros/src/native.rs
@@ -33,7 +33,6 @@ fn native_prelude() -> proc_macro2::TokenStream {
         use fuels_types::traits::{Parameterize, Tokenizable};
         use fuels_macros::{Parameterize, Tokenizable};
         use fuel_indexer_plugin::native::bincode;
-        use sha2::{Sha256, Digest};
 
         type B256 = [u8; 32];
 

--- a/packages/fuel-indexer-macros/src/wasm.rs
+++ b/packages/fuel-indexer-macros/src/wasm.rs
@@ -39,7 +39,6 @@ fn wasm_prelude() -> proc_macro2::TokenStream {
         use fuels_types::StringToken;
         use fuels_types::traits::{Parameterize, Tokenizable};
         use fuels_macros::{Parameterize, Tokenizable};
-        use sha2::{Sha256, Digest};
         use std::str::FromStr;
         use fuel_indexer_plugin::wasm::bincode;
 

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
@@ -17,4 +17,3 @@ fuels-macros = { version = "0.38.1" }
 fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-sha2 = { version = "0.10" }

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/schema/fuel_indexer_test.graphql
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/schema/fuel_indexer_test.graphql
@@ -112,7 +112,6 @@ type ScriptResult {
 
 type MessageOut {
     id: ID!
-    message_id: MessageId!
     sender: Address!
     recipient: Address!
     amount: UInt8!

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
@@ -171,7 +171,6 @@ mod fuel_indexer_test {
 
         let entity = MessageOut {
             id: first8_bytes_to_u64(message_id),
-            message_id,
             sender,
             recipient,
             amount,

--- a/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
@@ -17,4 +17,3 @@ fuels-macros = { version = "0.38.1" }
 fuels-types = { version = "0.38.1", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-sha2 = { version = "0.10" }

--- a/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/indexing_postgres.rs
@@ -140,7 +140,7 @@ async fn test_can_trigger_and_index_callreturn_postgres() {
 
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
-async fn test_can_trigger_and_index_blocks_and_transactions_postgres() {
+async fn w() {
     let (node_handle, test_db, mut srvc) = setup_test_components().await;
 
     let mut manifest = Manifest::try_from(assets::FUEL_INDEXER_TEST_MANIFEST).unwrap();
@@ -415,19 +415,6 @@ async fn test_can_trigger_and_index_messageout_event_postgres() {
     node_handle.abort();
 
     let mut conn = test_db.pool.acquire().await.unwrap();
-    let row = sqlx::query("SELECT * FROM fuel_indexer_test_index1.messageout LIMIT 1")
-        .fetch_one(&mut conn)
-        .await
-        .unwrap();
-
-    let recipient = row.get::<&str, usize>(3);
-    let amount = row.get::<BigDecimal, usize>(4).to_u64().unwrap();
-    assert_eq!(
-        recipient,
-        "532ee5fb2cabec472409eb5f9b42b59644edb7bf9943eda9c2e3947305ed5e96"
-    );
-    assert_eq!(amount, 100);
-
     let row = sqlx::query("SELECT * FROM fuel_indexer_test_index1.messageentity LIMIT 1")
         .fetch_one(&mut conn)
         .await


### PR DESCRIPTION
Reverts FuelLabs/fuel-indexer#744

I had some feedback on this PR but it was merged before I got a chance