### PR TITLE
 fix: decode auth signature before recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,6 +2917,7 @@ dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-metrics",
  "fuel-indexer-schema",
+ "hex",
  "http",
  "hyper",
  "hyper-rustls 0.23.2",

--- a/packages/fuel-indexer-api-server/Cargo.toml
+++ b/packages/fuel-indexer-api-server/Cargo.toml
@@ -25,6 +25,7 @@ fuel-indexer-database = { workspace = true }
 fuel-indexer-lib = { workspace = true }
 fuel-indexer-metrics = { workspace = true, optional = true }
 fuel-indexer-schema = { workspace = true, features = ["db-models"] }
+hex = "0.4"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http2", "http1", "runtime" ] }
 hyper-rustls = { version = "0.23", features = ["http2"] }

--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -78,6 +78,8 @@ pub enum ApiError {
     FuelCrypto(#[from] FuelCryptoError),
     #[error("JsonWebTokenError: {0:?}")]
     JsonWebTokenError(#[from] JsonWebTokenError),
+    #[error("HexError: {0:?}")]
+    HexError(#[from] hex::FromHexError),
 }
 
 impl Default for ApiError {

--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -32,6 +32,7 @@ use tower_http::{
     LatencyUnit,
 };
 use tracing::{error, Level};
+
 pub type ApiResult<T> = core::result::Result<T, ApiError>;
 
 #[derive(Debug, Error)]

--- a/packages/fuel-indexer-api-server/src/uses.rs
+++ b/packages/fuel-indexer-api-server/src/uses.rs
@@ -310,8 +310,9 @@ pub(crate) async fn verify_signature(
                     return Err(ApiError::Http(HttpError::Unauthorized));
                 }
 
-                let mut buff: [u8; 64] = [0u8; 64];
-                buff.copy_from_slice(&payload.signature.as_bytes()[..64]);
+                let buff: [u8; 64] = hex::decode(&payload.signature)?
+                    .try_into()
+                    .unwrap_or([0u8; 64]);
                 let sig = Signature::from_bytes(buff);
                 let msg = Message::new(payload.message);
                 let pk = sig.recover(&msg)?;

--- a/plugins/forc-index/src/ops/forc_index_auth.rs
+++ b/plugins/forc-index/src/ops/forc_index_auth.rs
@@ -55,8 +55,6 @@ pub fn init(command: AuthCommand) -> anyhow::Result<()> {
 
     let response: NonceResponse = res.json().unwrap();
 
-    // NOTE: Until latest forc-wallet is available via fuelup, manually insert
-    // the path to the latest compiled forc-wallet binary
     let signature = match Command::new("forc-wallet")
         .arg("sign")
         .arg("--account")


### PR DESCRIPTION
### Description
- PR fixes an authentication bug by decoding the message signatures before trying to derive a signature

### Testing steps
- [ ] Start a node `cargo run --bin fuel-node`
- [ ] Start the service with auth enabled `cargo  run --bin fuel-indexer -- run --run-migrations --auth-enabled --auth-strategy jwt --jwt-secret 12345677890`
- [ ] Try to authenticate `forc index auth`
- Everything should work the first time (and every subsequent time)

### Changelog
- fix: decode auth signature before recovery 