### PR TITLE
enhancement: add `PageInfo` object to paginated GraphQL responses

### DIFF
--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -112,6 +112,9 @@ impl IntoResponse for ApiError {
             ApiError::FuelCrypto(e) => {
                 (StatusCode::BAD_REQUEST, format!("Crypto error: {e}."))
             }
+            ApiError::Graphql(e) => {
+                (StatusCode::BAD_REQUEST, format!("GraphQL error: {e}."))
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, generic_details),
         };
 

--- a/packages/fuel-indexer-api-server/src/uses.rs
+++ b/packages/fuel-indexer-api-server/src/uses.rs
@@ -34,6 +34,7 @@ use fuel_indexer_schema::db::{
 use hyper::Client;
 use hyper_rustls::HttpsConnectorBuilder;
 use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
 use serde_json::{json, Value};
 use std::{
     convert::From,
@@ -42,6 +43,11 @@ use std::{
 };
 use tokio::sync::mpsc::Sender;
 use tracing::error;
+
+#[derive(Serialize)]
+pub(crate) struct QueryResponse {
+    data: Value,
+}
 
 #[cfg(feature = "metrics")]
 use fuel_indexer_metrics::{encode_metrics_response, METRICS};
@@ -372,14 +378,22 @@ pub async fn run_query(
     let builder = GraphqlQueryBuilder::new(&schema, &query)?;
     let query = builder.build()?;
 
-    let queries = query.as_sql(&schema, pool.database_type()).join(";\n");
+    let queries = query.as_sql(&schema, pool.database_type())?.join(";\n");
 
     let mut conn = pool.acquire().await?;
 
     match queries::run_query(&mut conn, queries).await {
         Ok(ans) => {
             let ans_json: Value = serde_json::from_value(ans)?;
-            Ok(serde_json::json!({ "data": ans_json }))
+
+            // If the response is paginated, remove the array wrapping.
+            if ans_json[0].get("pageInfo").is_some() {
+                Ok(serde_json::json!(QueryResponse {
+                    data: ans_json[0].clone()
+                }))
+            } else {
+                Ok(serde_json::json!(QueryResponse { data: ans_json }))
+            }
         }
         Err(e) => {
             error!("Error querying database: {e}.");

--- a/packages/fuel-indexer-api-server/src/uses.rs
+++ b/packages/fuel-indexer-api-server/src/uses.rs
@@ -387,7 +387,7 @@ pub async fn run_query(
             let ans_json: Value = serde_json::from_value(ans)?;
 
             // If the response is paginated, remove the array wrapping.
-            if ans_json[0].get("pageInfo").is_some() {
+            if ans_json[0].get("page_info").is_some() {
                 Ok(serde_json::json!(QueryResponse {
                     data: ans_json[0].clone()
                 }))

--- a/packages/fuel-indexer-schema/src/db/queries.rs
+++ b/packages/fuel-indexer-schema/src/db/queries.rs
@@ -177,12 +177,12 @@ impl UserQuery {
 
                 let selection_query = format!(
                     r#"SELECT json_build_object(
-                        'pageInfo', json_build_object(
-                            'hasNextPage', (({limit} + {offset}) < (SELECT count from total_count_cte)),
+                        'page_info', json_build_object(
+                            'has_next_page', (({limit} + {offset}) < (SELECT count from total_count_cte)),
                             'limit', {limit},
                             'offset', {offset},
                             'pages', ceil((SELECT count from total_count_cte)::float / {limit}::float),
-                            'totalCount', (SELECT count from total_count_cte)
+                            'total_count', (SELECT count from total_count_cte)
                         ),
                         '{alias}', (
                             SELECT json_agg(item)

--- a/packages/fuel-indexer-schema/src/db/queries.rs
+++ b/packages/fuel-indexer-schema/src/db/queries.rs
@@ -464,6 +464,6 @@ mod tests {
 
         let expected = "SELECT json_build_object('hash', name_ident.block.hash, 'tx', json_build_object('hash', name_ident.tx.hash), 'height', name_ident.block.height) FROM name_ident.entity_name INNER JOIN name_ident.block ON name_ident.tx.block = name_ident.block.id WHERE name_ident.entity_name.id = 1"
             .to_string();
-        assert_eq!(expected, uq.to_sql(&DbType::Postgres));
+        assert_eq!(expected, uq.to_sql(&DbType::Postgres).unwrap());
     }
 }

--- a/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
@@ -849,7 +849,7 @@ async fn test_can_return_query_response_with_alias_and_ascending_offset_and_limi
         .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
         .header(CONTENT_TYPE, "application/graphql".to_owned())
         .body(
-            r#"{"query": "query { aliasedEntities: filterentity(order: { asc: foola }, first: 1, offset: 1) { id foola } }" }"#,
+            r#"{"query": "query { aliased_entities: filterentity(order: { asc: foola }, first: 1, offset: 1) { id foola } }" }"#,
         )
         .send()
         .await
@@ -862,7 +862,7 @@ async fn test_can_return_query_response_with_alias_and_ascending_offset_and_limi
     let v: Value = serde_json::from_str(&body).unwrap();
     let data = v["data"].as_object().expect("data is not an object");
 
-    assert_eq!(data["aliasedEntities"][0]["id"].as_i64(), Some(3));
-    assert_eq!(data["aliasedEntities"][0]["foola"].as_str(), Some("blorp"));
-    assert_eq!(data["pageInfo"]["pages"].as_i64(), Some(3));
+    assert_eq!(data["aliased_entities"][0]["id"].as_i64(), Some(3));
+    assert_eq!(data["aliased_entities"][0]["foola"].as_str(), Some("blorp"));
+    assert_eq!(data["page_info"]["pages"].as_i64(), Some(3));
 }

--- a/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
+++ b/packages/fuel-indexer-tests/tests/e2e/graphql_api_postgres.rs
@@ -819,7 +819,8 @@ async fn test_can_return_query_response_with_sorted_results_postgres() {
 
 #[actix_web::test]
 #[cfg(all(feature = "e2e", feature = "postgres"))]
-async fn test_can_return_query_response_with_ascending_limited_results_postgres() {
+async fn test_can_return_query_response_with_alias_and_ascending_offset_and_limited_results_postgres(
+) {
     let (fuel_node_handle, _test_db, mut srvc, api_app) = setup_test_components().await;
 
     let server = axum::Server::bind(&GraphQLConfig::default().into())
@@ -848,7 +849,7 @@ async fn test_can_return_query_response_with_ascending_limited_results_postgres(
         .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
         .header(CONTENT_TYPE, "application/graphql".to_owned())
         .body(
-            r#"{"query": "query { filterentity(order: { asc: foola }, first: 1) { id foola } }" }"#,
+            r#"{"query": "query { aliasedEntities: filterentity(order: { asc: foola }, first: 1, offset: 1) { id foola } }" }"#,
         )
         .send()
         .await
@@ -857,58 +858,11 @@ async fn test_can_return_query_response_with_ascending_limited_results_postgres(
     server_handle.abort();
 
     let body = resp.text().await.unwrap();
+    println!("{body}");
     let v: Value = serde_json::from_str(&body).unwrap();
-    let data = v["data"].as_array().expect("data is not an array");
+    let data = v["data"].as_object().expect("data is not an object");
 
-    assert_eq!(data[0]["id"].as_i64(), Some(1));
-    assert_eq!(data[0]["foola"].as_str(), Some("beep"));
-}
-
-#[actix_web::test]
-#[cfg(all(feature = "e2e", feature = "postgres"))]
-async fn test_can_return_query_response_with_offset_results_postgres() {
-    let (fuel_node_handle, _test_db, mut srvc, api_app) = setup_test_components().await;
-
-    let server = axum::Server::bind(&GraphQLConfig::default().into())
-        .serve(api_app.into_make_service());
-
-    let server_handle = tokio::spawn(server);
-    let mut manifest: Manifest =
-        serde_yaml::from_str(assets::FUEL_INDEXER_TEST_MANIFEST).expect("Bad yaml file.");
-
-    update_test_manifest_asset_paths(&mut manifest);
-
-    srvc.register_index_from_manifest(manifest)
-        .await
-        .expect("Failed to initialize indexer.");
-
-    let contract = connect_to_deployed_contract().await.unwrap();
-    let app = test::init_service(app(contract)).await;
-    let req = test::TestRequest::post().uri("/ping").to_request();
-    let _ = app.call(req).await;
-
-    sleep(Duration::from_secs(defaults::INDEXED_EVENT_WAIT)).await;
-    fuel_node_handle.abort();
-
-    let client = http_client();
-    let resp = client
-        .post("http://127.0.0.1:29987/api/graph/fuel_indexer_test/index1")
-        .header(CONTENT_TYPE, "application/graphql".to_owned())
-        .body(
-            r#"{"query": "query { filterentity(order: { asc: foola }, offset: 1) { id foola } }" }"#,
-        )
-        .send()
-        .await
-        .unwrap();
-
-    server_handle.abort();
-
-    let body = resp.text().await.unwrap();
-    let v: Value = serde_json::from_str(&body).unwrap();
-    let data = v["data"].as_array().expect("data is not an array");
-
-    assert_eq!(data[0]["id"].as_i64(), Some(3));
-    assert_eq!(data[0]["foola"].as_str(), Some("blorp"));
-    assert_eq!(data[1]["id"].as_i64(), Some(2));
-    assert_eq!(data[1]["foola"].as_str(), Some("boop"));
+    assert_eq!(data["aliasedEntities"][0]["id"].as_i64(), Some(3));
+    assert_eq!(data["aliasedEntities"][0]["foola"].as_str(), Some("blorp"));
+    assert_eq!(data["pageInfo"]["pages"].as_i64(), Some(3));
 }

--- a/packages/fuel-indexer-tests/tests/integration/graphql_schema.rs
+++ b/packages/fuel-indexer-tests/tests/integration/graphql_schema.rs
@@ -113,6 +113,7 @@ fn test_query_builder_parses_correctly() {
                 offset: None,
                 limit: None,
             },
+            alias: None,
         },
         UserQuery {
             elements: vec![
@@ -142,6 +143,7 @@ fn test_query_builder_parses_correctly() {
                 offset: None,
                 limit: None,
             },
+            alias: None,
         },
         UserQuery {
             elements: vec![QueryElement::Field {
@@ -173,6 +175,7 @@ fn test_query_builder_parses_correctly() {
                 offset: None,
                 limit: None,
             },
+            alias: None,
         },
     ];
 


### PR DESCRIPTION
## Changelog
- Adds `PageInfo` object to paginated GraphQL responses
- Adjusts SQL query for paginated GraphQL requests
- Adds support for aliased fields
- Adjust tests
- Adjust doc comments
- Adds match arm in `ApiError` for `GraphQlError`

## Testing Plan
CI should pass.

### Manual Testing
0. Compile fresh WASM modules and clear database.
1. `cargo run --bin fuel-indexer -- run --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --manifest examples/block-explorer/explorer-indexer/explorer_indexer.manifest.yaml`
2. Open the corresponding playground: `http://localhost:29987/api/playground/fuel_examples/explorer_indexer`
3. Run the following query.
```
query {
  blocks: block(order: { desc: height}, first: 5, offset: 5) {
    id
    hash
    height
    timestamp
  }
}
```
 You should see that the last 5 blocks are shown in reverse order of block height under a `blocks` key as well as a `PageInfo` object that contains pagination metadata. It will be similar in structure to the following example:
```
{
  "data": {
    "blocks": ...,
    "page_info": {
      "has_next_page": true,
      "limit": 5,
      "offset": 5,
      "pages": 282,
      "total_count": 1409
    }
  }
}
```
