### PR TITLE
docs: swap link for copy/paste of m1 text in book

### DIFF
--- a/docs/src/getting-started/dependencies/wasm.md
+++ b/docs/src/getting-started/dependencies/wasm.md
@@ -20,4 +20,7 @@ To install the `wasm32-unknown-unknown` target via `rustup`:
 rustup target add wasm32-unknown-unknown
 ```
 
-> Note for Apple Silicon macOS users: Due to the default architecture-specific libraries that are shipped with macOS, you may have trouble building WASM binaries. Please refer to [this section](../../reference-guide/components/assets/module.md#notes-on-wasm) of the _Module_ page for more information.
+> IMPORTANT: Users on Apple Silicon macOS systems may experience trouble when trying to build WASM modules due to its `clang` binary not supporting WASM targets. If encountered, you can install a binary with better support from Homebrew (`brew install llvm`) and instruct `rustc` to leverage it by setting the following environment variables:
+>
+> - `AR=/opt/homebrew/opt/llvm/bin/llvm-ar`
+> - `CC=/opt/homebrew/opt/llvm/bin/clang`


### PR DESCRIPTION
### Description
- Had an experience today where a user missed the link in the docs and just forgot to follow the additional WASM dependency steps. 
- PR makes the WASM dependency notes more visible

### Testing steps
- [ ] N/A

### Changelog
- docs: swap link for copy/paste of m1 text in book