### PR TITLE
enhancement: `forc index deploy --stop-previous`

### DIFF
--- a/plugins/forc-index/src/commands/deploy.rs
+++ b/plugins/forc-index/src/commands/deploy.rs
@@ -65,6 +65,10 @@ pub struct Command {
     /// Do not build before deploying.
     #[clap(long, help = "Do not build before deploying.")]
     pub skip_build: bool,
+
+    /// Stop previous running indexer.
+    #[clap(long, help = "Stop previous running indexer.")]
+    pub stop_previous: bool,
 }
 
 impl Default for Command {
@@ -82,6 +86,7 @@ impl Default for Command {
             native: false,
             skip_build: false,
             target_dir: Some(std::path::PathBuf::from(".")),
+            stop_previous: true,
         }
     }
 }

--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -31,6 +31,7 @@ pub fn init(command: DeployCommand) -> anyhow::Result<()> {
         target_dir,
         verbose,
         skip_build,
+        stop_previous,
     } = command;
 
     if !skip_build {
@@ -63,7 +64,8 @@ pub fn init(command: DeployCommand) -> anyhow::Result<()> {
     let form = Form::new()
         .file("manifest", &manifest_path)?
         .file("schema", graphql_schema)?
-        .file("wasm", module.to_string())?;
+        .file("wasm", module.to_string())?
+        .text("stop_previous", stop_previous.to_string());
 
     let target = format!("{url}/api/index/{namespace}/{identifier}");
 


### PR DESCRIPTION
Closes #786 

## Changelog
• Adds flag of bool type to `forc index deploy` subcommand. 
• Updates `register_indexer_assets` to conditionally stop previous running indexers with the same namespace & identifier. 

## Testing 
todo 