### PR TITLE
fix: bump deployment tcp timeout

### DIFF
--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use tracing::{error, info};
 
 const STEADY_TICK_INTERVAL: u64 = 120;
-const TCP_TIMEOUT: u64 = 3;
+const TCP_TIMEOUT: u64 = 30;
 
 pub fn init(command: DeployCommand) -> anyhow::Result<()> {
     let DeployCommand {


### PR DESCRIPTION
### Description
- PR fixes a flaky issue where you still get these `HyperError::ChannelClosed` errors when calling `forc index deploy`
- This only seems to happen when using the `forc index deploy` to a `fuel-indexer` binary, not the `cargo run --bin -- fuel-indexer` binary

### Testing steps
- [ ] On master, `forc index new && forc index deploy` should fail with `ChannelClosed` if you're deploying to `forc index start
- [ ] On this branch, `forc index new && forc index deploy` should succeed even when deploying to `forc index start`

### Changelog 
- fix: bump deployment tcp timeout 