### PR TITLE
bugfix: fix deserialize bug on contract_id

### DIFF
--- a/packages/fuel-indexer-lib/src/manifest.rs
+++ b/packages/fuel-indexer-lib/src/manifest.rs
@@ -179,7 +179,7 @@ impl ContractIds {
             ContractIds::Multiple(ids) => {
                 serde_json::to_string(ids).map_err(serde::ser::Error::custom)?
             }
-            _ => String::new(),
+            _ => return serializer.serialize_none(),
         };
         serializer.serialize_str(&s)
     }


### PR DESCRIPTION
Closes #827 

## Testing steps 
1. Rebuild wasm binaries and refresh the db. 
2. Rebuild the plugin binary `cargo build -p forc-index -p fuel-indexer --release --features fuel-core-lib`
3. Run the indexer and run the local fuel-node.
3. Run the command (this command before was producing the `""` in the yaml). 
`./target/release/forc-index deploy --path examples/block-explorer/explorer-indexer`
4. In `explorer_indexer.manifest.yaml` check that `contract_id: ~` and *not* `contract_id: ""`