### PR TITLE
chore: make plugin output consistent

### DIFF
--- a/plugins/forc-index/src/ops/forc_index_remove.rs
+++ b/plugins/forc-index/src/ops/forc_index_remove.rs
@@ -48,17 +48,22 @@ pub fn init(command: RemoveCommand) -> anyhow::Result<()> {
         .send()
         .expect("Failed to remove indexer.");
 
-    if res.status() != StatusCode::OK {
-        error!(
-            "\n❌ {target} returned a non-200 response code: {:?}",
-            res.status()
-        );
-        return Ok(());
-    }
-
+    let status = res.status();
     let res_json = res
         .json::<Map<String, Value>>()
         .expect("Failed to read JSON response.");
+
+    if status != StatusCode::OK {
+        if verbose {
+            error!("\n❌ {target} returned a non-200 response code: {status:?}",);
+
+            info!("\n{}", to_string_pretty(&res_json)?);
+        } else {
+            info!("\n{}", to_string_pretty(&res_json)?);
+        }
+
+        return Ok(());
+    }
 
     if verbose {
         info!(

--- a/plugins/forc-index/src/ops/forc_index_revert.rs
+++ b/plugins/forc-index/src/ops/forc_index_revert.rs
@@ -48,18 +48,22 @@ pub async fn init(command: RevertCommand) -> anyhow::Result<()> {
         .send()
         .expect("Failed to deploy indexer.");
 
-    if res.status() != StatusCode::OK {
-        error!(
-            "\n❌ {} returned a non-200 response code: {:?}",
-            &target,
-            res.status()
-        );
-        return Ok(());
-    }
-
+    let status = res.status();
     let res_json = res
         .json::<Map<String, Value>>()
         .expect("Failed to read JSON response.");
+
+    if status != StatusCode::OK {
+        if verbose {
+            error!("\n❌ {target} returned a non-200 response code: {status:?}",);
+
+            info!("\n{}", to_string_pretty(&res_json)?);
+        } else {
+            info!("\n{}", to_string_pretty(&res_json)?);
+        }
+
+        return Ok(());
+    }
 
     if verbose {
         info!(


### PR DESCRIPTION
### Description
- Plugin should return consistent output for all commands

### Testing steps
- [ ] If you try to `forc index revert` to beta-3-playground without authentication, you should get the 401 unauthorized JSON response in stdout

### Changelog 
- chore: make plugin output consistent