### PR TITLE
bugfix: try pinning toolchain version

### DIFF
--- a/fuel-toolchain.toml
+++ b/fuel-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "beta-3"
+
+[components]
+forc = "0.37.0" 


### PR DESCRIPTION
Only way to test this is to try redeploying it to our production environment. 

If I run at the root:
`forc --version` 
I see `0.37.0`

If I run `forc --version`  in some other dir I see `0.38.0` so this correctly pins the version. 

I don't think this will fix the bug. But thought its interesting because of [this](https://fuellabs.slack.com/archives/C031TTYJM60/p1682627834906569). Useful to know we can pin forc versions, I didn't know it was possible prior to reading that thread. 