### PR TITLE
`auth` password input message 

### DIFF
--- a/docs/src/reference-guide/authentication/index.md
+++ b/docs/src/reference-guide/authentication/index.md
@@ -19,7 +19,7 @@ forc index auth --url https://indexer.fuel.network:29987
 You will first be prompted for the password for your wallet:
 
 ```text
-Please enter your password:
+Please enter your wallet password:
 ```
 
 After successfully entering your wallet password you should be presented with your new JWT token.


### PR DESCRIPTION
## Changes

- Added `wallet` into example prompt for documentation

## Notes

Now that [Update password input message](https://github.com/FuelLabs/forc-wallet/issues/111) is merged we can update the docs for the example input that the user will see - once we bump versions to use this change

## Related

Closes #838 