### PR TITLE
chore: use `[default-members]` section in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,23 @@ members = [
    "plugins/forc-postgres",
    "plugins/forc-index-tests",
 ]
+default-members = [
+   "packages/fuel-indexer",
+   "packages/fuel-indexer-api-server",
+   "packages/fuel-indexer-database",
+   "packages/fuel-indexer-database/database-types",
+   "packages/fuel-indexer-database/postgres",
+   "packages/fuel-indexer-graphql",
+   "packages/fuel-indexer-graphql/parser",
+   "packages/fuel-indexer-lib",
+   "packages/fuel-indexer-macros",
+   "packages/fuel-indexer-metrics",
+   "packages/fuel-indexer-plugin",
+   "packages/fuel-indexer-schema",
+   "packages/fuel-indexer-types",
+   "plugins/forc-index",
+   "plugins/forc-postgres",
+]
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Closes #842.

## Changelog
- Introduce `[default-members]` section
- Change member inclusion to be more idiomatic

## Testing Plan
CI should pass.

## Notes
This change was done to prevent the issue of failed builds when running `cargo build` in the repository root. This structure comes from the [`axum` project](https://github.com/tokio-rs/axum/blob/main/Cargo.toml).

This change also reduces the overall build time of a bare `cargo build`, but makes changes to using the internal testing components. To use internal testing components, a dev should use `cargo run -p [package] --bin [package]`. So in this case of `fuel-node`, one would start it by using `cargo run -p fuel-node --bin fuel-node`.