### PR TITLE
enhancement: convert Scalar types into `Json` and `Blob`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,6 +3232,7 @@ dependencies = [
 name = "fuel-indexer-types"
 version = "0.11.2"
 dependencies = [
+ "bincode",
  "chrono",
  "fuel-tx",
  "fuel-types 0.26.2",

--- a/examples/hello-world-native/hello-indexer-native/src/main.rs
+++ b/examples/hello-world-native/hello-indexer-native/src/main.rs
@@ -74,7 +74,7 @@ mod hello_world_native {
 
                 // Here we show an example of an arbtrarily sized Blob type. These Blob types
                 // support data up to 10485760 bytes in length
-                visits: Blob(vec![1u8, 2, 3, 4, 5, 6, 7, 8]),
+                visits: vec![1u8, 2, 3, 4, 5, 6, 7, 8].into(),
             },
         };
 

--- a/examples/hello-world-native/hello-indexer-native/src/main.rs
+++ b/examples/hello-world-native/hello-indexer-native/src/main.rs
@@ -74,7 +74,7 @@ mod hello_world_native {
 
                 // Here we show an example of an arbtrarily sized Blob type. These Blob types
                 // support data up to 10485760 bytes in length
-                visits: vec![1u8, 2, 3, 4, 5, 6, 7, 8],
+                visits: Blob(vec![1u8, 2, 3, 4, 5, 6, 7, 8]),
             },
         };
 

--- a/examples/hello-world/hello-indexer/src/lib.rs
+++ b/examples/hello-world/hello-indexer/src/lib.rs
@@ -80,7 +80,7 @@ mod hello_world_indexer {
 
                 // Here we show an example of an arbtrarily sized Blob type. These Blob types
                 // support data up to 10485760 bytes in length
-                visits: vec![1u8, 2, 3, 4, 5, 6, 7, 8],
+                visits: Blob(vec![1u8, 2, 3, 4, 5, 6, 7, 8]),
             },
         };
 

--- a/examples/hello-world/hello-indexer/src/lib.rs
+++ b/examples/hello-world/hello-indexer/src/lib.rs
@@ -80,7 +80,7 @@ mod hello_world_indexer {
 
                 // Here we show an example of an arbtrarily sized Blob type. These Blob types
                 // support data up to 10485760 bytes in length
-                visits: Blob(vec![1u8, 2, 3, 4, 5, 6, 7, 8]),
+                visits: vec![1u8, 2, 3, 4, 5, 6, 7, 8].into(),
             },
         };
 

--- a/packages/fuel-indexer-schema/src/lib.rs
+++ b/packages/fuel-indexer-schema/src/lib.rs
@@ -130,9 +130,7 @@ impl FtColumn {
                 );
                 FtColumn::Timestamp(Some(int8))
             }
-            ColumnType::Blob => {
-                FtColumn::Blob(Some(fuel_indexer_types::Blob(bytes[..size].to_vec())))
-            }
+            ColumnType::Blob => FtColumn::Blob(Some(bytes[..size].to_vec().into())),
             ColumnType::ForeignKey => {
                 panic!("ForeignKey not supported for FtColumn.");
             }
@@ -262,9 +260,9 @@ impl FtColumn {
                 None => String::from(NULL_VALUE),
             },
             FtColumn::Blob(value) => match value {
-                Some(fuel_indexer_types::Blob(val)) => {
-                    let x = hex::encode(val);
-                    format!("'{}'", x)
+                Some(blob) => {
+                    let x = hex::encode(blob.as_ref());
+                    format!("'{x}'")
                 }
                 None => String::from(NULL_VALUE),
             },

--- a/packages/fuel-indexer-schema/src/lib.rs
+++ b/packages/fuel-indexer-schema/src/lib.rs
@@ -130,7 +130,9 @@ impl FtColumn {
                 );
                 FtColumn::Timestamp(Some(int8))
             }
-            ColumnType::Blob => FtColumn::Blob(Some(bytes[..size].to_vec())),
+            ColumnType::Blob => {
+                FtColumn::Blob(Some(fuel_indexer_types::Blob(bytes[..size].to_vec())))
+            }
             ColumnType::ForeignKey => {
                 panic!("ForeignKey not supported for FtColumn.");
             }
@@ -259,10 +261,11 @@ impl FtColumn {
                 Some(val) => format!("{val}"),
                 None => String::from(NULL_VALUE),
             },
+
             FtColumn::Blob(value) => match value {
-                Some(val) => {
-                    let x = hex::encode(val);
-                    format!("'{x}'")
+                Some(fuel_indexer_types::Blob(val)) => {
+                    let x = hex::encode(&val);
+                    format!("'{}'", x)
                 }
                 None => String::from(NULL_VALUE),
             },

--- a/packages/fuel-indexer-schema/src/lib.rs
+++ b/packages/fuel-indexer-schema/src/lib.rs
@@ -261,10 +261,9 @@ impl FtColumn {
                 Some(val) => format!("{val}"),
                 None => String::from(NULL_VALUE),
             },
-
             FtColumn::Blob(value) => match value {
                 Some(fuel_indexer_types::Blob(val)) => {
-                    let x = hex::encode(&val);
+                    let x = hex::encode(val);
                     format!("'{}'", x)
                 }
                 None => String::from(NULL_VALUE),

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
@@ -139,7 +139,7 @@ mod fuel_indexer_test {
             id: result,
             result,
             gas_used,
-            blob: Blob(vec![1u8, 1, 1, 1, 1]),
+            blob: vec![1u8, 1, 1, 1, 1].into(),
         };
 
         entity.save();

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
@@ -139,7 +139,7 @@ mod fuel_indexer_test {
             id: result,
             result,
             gas_used,
-            blob: vec![1u8, 1, 1, 1, 1],
+            blob: Blob(vec![1u8, 1, 1, 1, 1]),
         };
 
         entity.save();

--- a/packages/fuel-indexer-types/Cargo.toml
+++ b/packages/fuel-indexer-types/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = { workspace = true }
 description = "Fuel Indexer Types"
 
 [dependencies]
+bincode = "1.3"
 chrono = { version = "0.4", features = ["serde"] }
 fuel-tx = { version = "0.26.0", features = ["serde"] }
 fuel-types = "0.26.0"

--- a/packages/fuel-indexer-types/src/lib.rs
+++ b/packages/fuel-indexer-types/src/lib.rs
@@ -39,6 +39,18 @@ impl From<Vec<u8>> for Blob {
     }
 }
 
+impl AsRef<[u8]> for Blob {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Blob> for Vec<u8> {
+    fn from(value: Blob) -> Self {
+        value.0
+    }
+}
+
 #[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Json(pub String);
 
@@ -89,7 +101,7 @@ mod tests {
         let as_bytes: Blob = id.into();
 
         assert_eq!(as_json, Json("123".to_string()));
-        assert_eq!(as_bytes, Blob(vec![123]));
+        assert_eq!(as_bytes, Blob(vec![123, 0, 0, 0, 0, 0, 0, 0]));
     }
 
     #[test]
@@ -109,7 +121,7 @@ mod tests {
         let as_bytes: Blob = int.into();
 
         assert_eq!(as_json, Json("1234567890".to_string()));
-        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 152, 0, 0, 0, 0]));
+        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 73, 0, 0, 0, 0]));
     }
 
     #[test]
@@ -122,7 +134,7 @@ mod tests {
         assert_eq!(
             as_bytes,
             Blob(vec![
-                25, 17, 224, 201, 87, 110, 69, 7, 0, 0, 0, 0, 0, 0, 0, 0
+                121, 223, 13, 134, 72, 112, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             ])
         );
     }
@@ -144,7 +156,7 @@ mod tests {
         let as_bytes: Blob = uint.into();
 
         assert_eq!(as_json, Json("1234567890".to_string()));
-        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 152, 0, 0, 0, 0]));
+        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 73, 0, 0, 0, 0]));
     }
 
     #[test]
@@ -157,7 +169,7 @@ mod tests {
         assert_eq!(
             as_bytes,
             Blob(vec![
-                25, 17, 224, 201, 87, 110, 69, 7, 0, 0, 0, 0, 0, 0, 0, 0
+                121, 223, 13, 134, 72, 112, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             ])
         );
     }
@@ -169,6 +181,6 @@ mod tests {
         let as_bytes: Blob = timestamp.into();
 
         assert_eq!(as_json, Json("1234567890".to_string()));
-        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 152, 0, 0, 0, 0]));
+        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 73, 0, 0, 0, 0]));
     }
 }

--- a/packages/fuel-indexer-types/src/lib.rs
+++ b/packages/fuel-indexer-types/src/lib.rs
@@ -5,7 +5,6 @@ pub mod tx;
 
 pub use crate::abi::*;
 pub use crate::tx::*;
-use bincode;
 pub use fuel_types::{
     Address, AssetId, Bytes32, Bytes4, Bytes8, ContractId, MessageId, Salt, Word,
 };

--- a/packages/fuel-indexer-types/src/lib.rs
+++ b/packages/fuel-indexer-types/src/lib.rs
@@ -5,6 +5,7 @@ pub mod tx;
 
 pub use crate::abi::*;
 pub use crate::tx::*;
+use bincode;
 pub use fuel_types::{
     Address, AssetId, Bytes32, Bytes4, Bytes8, ContractId, MessageId, Salt, Word,
 };
@@ -29,10 +30,45 @@ pub type UInt16 = u128;
 pub type Timestamp = u64;
 pub type Charfield = String;
 pub type Boolean = bool;
-pub type Blob = Vec<u8>;
+
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Hash)]
+pub struct Blob(pub Vec<u8>);
+
+impl From<Vec<u8>> for Blob {
+    fn from(value: Vec<u8>) -> Self {
+        Blob(value)
+    }
+}
 
 #[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Json(pub String);
+
+macro_rules! json_impl {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for Json {
+                fn from(value: $ty) -> Self {
+                    Json(value.to_string())
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! blob_impl {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for Blob {
+                fn from(value: $ty) -> Self {
+                    Blob::from(bincode::serialize(&value).unwrap().to_vec())
+                }
+            }
+        )*
+    }
+}
+
+json_impl!(i32, i64, i128, u32, u64, u128);
+blob_impl!(i32, i64, i128, u32, u64, u128);
 
 // IMPORTANT: https://github.com/launchbadge/sqlx/issues/499
 pub fn type_id(namespace: &str, type_name: &str) -> i64 {
@@ -41,4 +77,99 @@ pub fn type_id(namespace: &str, type_name: &str) -> i64 {
         &Sha256::digest(format!("{namespace}:{type_name}").as_bytes())[..8],
     );
     i64::from_le_bytes(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_into_json_blob_id() {
+        let id: ID = 123;
+        let as_json: Json = id.into();
+        let as_bytes: Blob = id.into();
+
+        assert_eq!(as_json, Json("123".to_string()));
+        assert_eq!(as_bytes, Blob(vec![123]));
+    }
+
+    #[test]
+    fn test_into_json_blob_int4() {
+        let int: Int4 = 42;
+        let as_json: Json = int.into();
+        let as_bytes: Blob = int.into();
+
+        assert_eq!(as_json, Json("42".to_string()));
+        assert_eq!(as_bytes, Blob(vec![42, 0, 0, 0]));
+    }
+
+    #[test]
+    fn test_into_json_blob_int8() {
+        let int: Int8 = 1234567890;
+        let as_json: Json = int.into();
+        let as_bytes: Blob = int.into();
+
+        assert_eq!(as_json, Json("1234567890".to_string()));
+        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 152, 0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn test_into_json_blob_int16() {
+        let int: Int16 = 123456789012345;
+        let as_json: Json = int.into();
+        let as_bytes: Blob = int.into();
+
+        assert_eq!(as_json, Json("123456789012345".to_string()));
+        assert_eq!(
+            as_bytes,
+            Blob(vec![
+                25, 17, 224, 201, 87, 110, 69, 7, 0, 0, 0, 0, 0, 0, 0, 0
+            ])
+        );
+    }
+
+    #[test]
+    fn test_into_json_blob_uint4() {
+        let uint: UInt4 = 7;
+        let as_json: Json = uint.into();
+        let as_bytes: Blob = uint.into();
+
+        assert_eq!(as_json, Json("7".to_string()));
+        assert_eq!(as_bytes, Blob(vec![7, 0, 0, 0]));
+    }
+
+    #[test]
+    fn test_into_json_blob_uint8() {
+        let uint: UInt8 = 1234567890;
+        let as_json: Json = uint.into();
+        let as_bytes: Blob = uint.into();
+
+        assert_eq!(as_json, Json("1234567890".to_string()));
+        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 152, 0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn test_into_json_blob_uint16() {
+        let uint: UInt16 = 123456789012345;
+        let as_json: Json = uint.into();
+        let as_bytes: Blob = uint.into();
+
+        assert_eq!(as_json, Json("123456789012345".to_string()));
+        assert_eq!(
+            as_bytes,
+            Blob(vec![
+                25, 17, 224, 201, 87, 110, 69, 7, 0, 0, 0, 0, 0, 0, 0, 0
+            ])
+        );
+    }
+
+    #[test]
+    fn test_into_json_blob_timestamp() {
+        let timestamp: Timestamp = 1234567890;
+        let as_json: Json = timestamp.into();
+        let as_bytes: Blob = timestamp.into();
+
+        assert_eq!(as_json, Json("1234567890".to_string()));
+        assert_eq!(as_bytes, Blob(vec![210, 2, 150, 152, 0, 0, 0, 0]));
+    }
 }


### PR DESCRIPTION
Closes #843

## Changelog
• Adds the macros`json_impl` and `blob_impl` macros for custom Scalar types. 
• Adds unit tests testing the underlying types of our scalar types.
• Changes the type of Blob from an alias to a custom type (see note below about this)
• Updates code elsewhere to integrate the Blob type. 

## NB
I had to make Blob a custom type as apposed to just an alias as it was before. This is because I could not implement a custom `From` trait on an alias of underlying type`Vec<u8>`. But when `Blob is :
```rust
pub struct Blob(pub Vec<u8>);
```
I can implement the From trait. This is because of the orphan rule.

##Testing
This unit test wont run in CI. I don't think we need it to necessarily, but to run the tests cd into 
`packages/fuel-indexer-types/src/` and run `cargo test` this will run the newly created unit tests in the `lib.rs` file

You want to see: 
```
running 8 tests
test tests::test_into_json_blob_int16 ... ok
test tests::test_into_json_blob_id ... ok
test tests::test_into_json_blob_int4 ... ok
test tests::test_into_json_blob_int8 ... ok
test tests::test_into_json_blob_timestamp ... ok
test tests::test_into_json_blob_uint16 ... ok
test tests::test_into_json_blob_uint4 ... ok
test tests::test_into_json_blob_uint8 ... ok
```