### PR TITLE
enhancement: add plugin command to kill indexer process

### DIFF
--- a/plugins/forc-index/src/cli.rs
+++ b/plugins/forc-index/src/cli.rs
@@ -2,9 +2,10 @@
 pub(crate) use crate::commands::{
     auth::Command as AuthCommand, build::Command as BuildCommand,
     check::Command as CheckCommand, deploy::Command as DeployCommand,
-    init::Command as InitCommand, new::Command as NewCommand,
-    remove::Command as RemoveCommand, revert::Command as RevertCommand,
-    start::Command as StartCommand, welcome::Command as WelcomeCommand,
+    init::Command as InitCommand, kill::Command as KillCommand,
+    new::Command as NewCommand, remove::Command as RemoveCommand,
+    revert::Command as RevertCommand, start::Command as StartCommand,
+    welcome::Command as WelcomeCommand,
 };
 use clap::{Parser, Subcommand};
 use forc_postgres::{
@@ -33,6 +34,7 @@ pub enum ForcIndex {
     Build(BuildCommand),
     Auth(AuthCommand),
     Postgres(ForcPostgresOpt),
+    Kill(KillCommand),
     //Welcome(WelcomeCommand),
 }
 
@@ -60,5 +62,6 @@ pub async fn run_cli() -> Result<(), anyhow::Error> {
             ForcPostgres::Drop(command) => pg_commands::drop::exec(command).await,
             ForcPostgres::Start(command) => pg_commands::start::exec(command).await,
         },
+        ForcIndex::Kill(command) => crate::commands::kill::exec(command),
     }
 }

--- a/plugins/forc-index/src/commands/kill.rs
+++ b/plugins/forc-index/src/commands/kill.rs
@@ -1,0 +1,16 @@
+use crate::{ops::forc_index_kill, utils::defaults};
+use clap::Parser;
+
+/// Kill the indexer process. Note that this command will kill any process
+/// listening on the default indexer port or the port specified by the `--port` flag.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Port on which the process is listening.
+    #[clap(long, default_value = defaults::GRAPHQL_API_PORT, help = "Port at which to detect indexer service API is running.")]
+    pub port: String,
+}
+
+pub fn exec(command: Command) -> anyhow::Result<()> {
+    forc_index_kill::kill(command)?;
+    Ok(())
+}

--- a/plugins/forc-index/src/commands/mod.rs
+++ b/plugins/forc-index/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod build;
 pub mod check;
 pub mod deploy;
 pub mod init;
+pub mod kill;
 pub mod new;
 pub mod remove;
 pub mod revert;

--- a/plugins/forc-index/src/ops/forc_index_kill.rs
+++ b/plugins/forc-index/src/ops/forc_index_kill.rs
@@ -1,0 +1,44 @@
+use crate::cli::KillCommand;
+use std::process::Command;
+use tracing::info;
+
+pub fn kill(command: KillCommand) -> anyhow::Result<()> {
+    let port_number = command.port.parse::<u16>().unwrap();
+
+    kill_process_by_port(port_number)?;
+
+    Ok(())
+}
+
+fn kill_process_by_port(port: u16) -> anyhow::Result<()> {
+    let output = Command::new("lsof")
+        .arg("-ti")
+        .arg(format!(":{}", port))
+        .output()?;
+
+    let pid_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    if pid_str.is_empty() {
+        return Err(anyhow::anyhow!(
+            "❌ No process is listening on port {}",
+            port
+        ));
+    }
+
+    let pid = pid_str
+        .parse::<i32>()
+        .map_err(|e| anyhow::anyhow!("❌ Failed to parse PID: {}", e))?;
+
+    Command::new("kill")
+        .arg("-9")
+        .arg(pid.to_string())
+        .status()
+        .map_err(|e| anyhow::anyhow!("❌ Failed to kill process: {}", e))?;
+
+    info!(
+        "✅ Sucessfully killed process {} listening on port {}",
+        pid, port
+    );
+
+    Ok(())
+}

--- a/plugins/forc-index/src/ops/mod.rs
+++ b/plugins/forc-index/src/ops/mod.rs
@@ -3,6 +3,7 @@ pub mod forc_index_build;
 pub mod forc_index_check;
 pub mod forc_index_deploy;
 pub mod forc_index_init;
+pub mod forc_index_kill;
 pub mod forc_index_new;
 pub mod forc_index_remove;
 pub mod forc_index_revert;


### PR DESCRIPTION
Killing the indexer process:

```
forc-index kill
✅ Sucessfully killed process 85790 listening on port 29987
```

No process to kill:

```
forc-index kill
Error: ❌ No process is listening on port 29987
```

Same, but with a user-specified port:

```
forc-index kill --port 12345
Error: ❌ No process is listening on port 12345
```