### PR TITLE
fix: update docs/examples

### DIFF
--- a/ci/Dockerfile.fuel-node
+++ b/ci/Dockerfile.fuel-node
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.68.1 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.69.0 AS chef
 
 WORKDIR /build/
 

--- a/examples/hello-world-native/README.md
+++ b/examples/hello-world-native/README.md
@@ -5,21 +5,21 @@
 ### Start a Fuel node
 
 ```bash
-cargo run --bin hello-world-node
+cargo run -p hello-world-node --bin hello-world-node
 ```
 
 ### Start the indexer service
 
 ```bash
-cargo run --bin hello_indexer_native -- \
-    --manifest examples/hello-world-native/hello-indexer-native/hello_indexer_native.manifest.yaml
+cargo run -p hello_indexer_native --bin hello_indexer_native -- \
+    --manifest hello-indexer-native/hello_indexer_native.manifest.yaml
     --run-migrations
 ```
 
 ### Trigger some data
 
 ```bash
-cargo run --bin hello-world-data
+cargo run -p hello-world-data --bin hello-world-data
 ```
 
 ### Query some data

--- a/examples/hello-world-native/README.md
+++ b/examples/hello-world-native/README.md
@@ -12,7 +12,7 @@ cargo run -p hello-world-node --bin hello-world-node
 
 ```bash
 cargo run -p hello_indexer_native --bin hello_indexer_native -- \
-    --manifest hello-indexer-native/hello_indexer_native.manifest.yaml
+    --manifest hello-indexer-native/hello_indexer_native.manifest.yaml \
     --run-migrations
 ```
 

--- a/examples/hello-world-native/README.md
+++ b/examples/hello-world-native/README.md
@@ -2,6 +2,8 @@
 
 ## Usage
 
+> NOTE: Commands are run from the project root at `/path/to/repository/fuel-indexer`
+
 ### Start a Fuel node
 
 ```bash
@@ -12,7 +14,7 @@ cargo run -p hello-world-node --bin hello-world-node
 
 ```bash
 cargo run -p hello_indexer_native --bin hello_indexer_native -- \
-    --manifest hello-indexer-native/hello_indexer_native.manifest.yaml \
+    --manifest examples/hello-world-native/hello-indexer-native/hello_indexer_native.manifest.yaml \
     --run-migrations
 ```
 
@@ -25,8 +27,8 @@ cargo run -p hello-world-data --bin hello-world-data
 ### Query some data
 
 ```bash
-curl -X POST http://0.0.0.0:29987/api/graph/fuel_examples/hello_indexer_native \
-   -H 'content-type: application/json' \
+curl -X POST http://localhost:29987/api/graph/fuel_examples/hello_indexer_native \
+   -H 'Content-Type: application/graphql' \
    -d '{"query": "query { salutation { id message_hash message greeter first_seen last_seen }}", "params": "b"}' \
 | json_pp
 ```

--- a/examples/hello-world-native/hello-indexer-native/Cargo.toml
+++ b/examples/hello-world-native/hello-indexer-native/Cargo.toml
@@ -11,7 +11,7 @@ fuel-indexer-macros = { workspace = true, default-features = false }
 fuel-indexer-plugin = { workspace = true, features = ["native-execution"] }
 fuel-indexer-schema = { workspace = true, default-features = false }
 fuel-tx = { workspace = true }
-fuels = { default-features = false, workspace = true }
+fuels = { default-features = false, workspace = true, features = ["std"] }
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", default-features = false }
-serde = { default-features = false, features = ["derive"], workspace = true }
+serde = { workspace = true }

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -39,7 +39,7 @@ Ensure that test data was indexed via a GraphQL query.
 
 ```bash
 curl -X POST http://0.0.0.0:29987/api/graph/fuel_examples/hello_indexer \
-   -H 'content-type: application/json' \
+   -H 'Content-Type: application/graphql' \
    -d '{"query": "query { salutation { id message_hash message greeter first_seen last_seen }}", "params": "b"}' \
 | json_pp
 ```

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -22,9 +22,7 @@ docker compose up --build
 forc index deploy \
    --path hello-indexer \
    --target-dir /path/to/repository/fuel-indexer \
-   --url http://0.0.0.0:29987 \
-   --target wasm32-unknown-unknown \
-   --release
+   --url http://0.0.0.0:29987
 ```
 
 ### Interact
@@ -32,7 +30,7 @@ forc index deploy \
 Trigger some test data by simulating a contract call.
 
 ```bash
-cargo run --bin hello-world-data -- --host 0.0.0.0:4000
+cargo run -p hello-world-data --bin hello-world-data -- --host 0.0.0.0:4000
 ```
 
 ### Validate

--- a/packages/fuel-indexer-lib/src/manifest.rs
+++ b/packages/fuel-indexer-lib/src/manifest.rs
@@ -36,12 +36,27 @@ pub enum Module {
     Native,
 }
 
+impl From<PathBuf> for Module {
+    fn from(path: PathBuf) -> Self {
+        Self::Wasm(path.to_str().unwrap().to_string())
+    }
+}
+
 impl ToString for Module {
     fn to_string(&self) -> String {
         match self {
-            Self::Wasm(o) => o.clone(),
+            Self::Wasm(o) => o.to_string(),
+            Self::Native => "native".to_string(),
+        }
+    }
+}
+
+impl AsRef<Path> for Module {
+    fn as_ref(&self) -> &Path {
+        match self {
+            Self::Wasm(o) => Path::new(o),
             Self::Native => {
-                unimplemented!("Only wasm execution supports module path access.")
+                unimplemented!("Only WASM execution supports module path access.")
             }
         }
     }

--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -11,7 +11,7 @@ use reqwest::{
     StatusCode,
 };
 use serde_json::{to_string_pretty, value::Value, Map};
-use std::time::Duration;
+use std::{path::Path, time::Duration};
 use tracing::{error, info};
 
 const STEADY_TICK_INTERVAL: u64 = 120;
@@ -43,7 +43,7 @@ pub fn init(command: DeployCommand) -> anyhow::Result<()> {
             verbose,
             locked,
             native,
-            target_dir,
+            target_dir: target_dir.clone(),
         })?;
     }
 
@@ -53,12 +53,26 @@ pub fn init(command: DeployCommand) -> anyhow::Result<()> {
     let manifest = Manifest::from_file(&manifest_path)?;
 
     let Manifest {
-        graphql_schema,
+        mut graphql_schema,
         namespace,
         identifier,
-        module,
+        mut module,
         ..
     } = manifest;
+
+    if path.is_some() {
+        if let Some(t) = target_dir {
+            graphql_schema = Path::new(&t)
+                .join(graphql_schema)
+                .to_str()
+                .unwrap()
+                .to_string();
+
+            module = Path::new(&t).join(module).into();
+        } else {
+            anyhow::bail!("--target-dir must be specified when --path is specified.");
+        }
+    }
 
     let form = Form::new()
         .file("manifest", &manifest_path)?

--- a/plugins/forc-index/src/utils/defaults.rs
+++ b/plugins/forc-index/src/utils/defaults.rs
@@ -28,7 +28,7 @@ fuel-indexer-macros = {{ version = "0.11", default-features = false }}
 fuel-indexer-plugin = {{ version = "0.11", features = ["native-execution"] }}
 fuel-indexer-schema = {{ version = "0.11", default-features = false }}
 fuel-tx = "0.26"
-fuels = {{ version = "0.40.0", default-features = false }}
+fuels = {{ version = "0.40.0", default-features = false, features = ["std"] }}
 getrandom = {{ version = "0.2", features = ["js"] }}
 serde = {{ version = "1.0", default-features = false, features = ["derive"] }}
 "#


### PR DESCRIPTION
### Description
- PR does a few things
  - Updates docs for the examples
  - Removes `api-server` and `fuel-core-lib` feature flagging from native execution
  - Fixes a bug in `forc index deploy` where the `--path` isn't respected relative to the `--target-dir`

### Testing steps 
- [ ] Build plugin locally `cargo build -p forc-index --release --locked`
- [ ] Start fuel node `cargo run -p fuel-node --bin fuel-node`
- [ ] Start the service `cargo run --bin fuel-indexer -- run --run-migrations`
- [ ] `cd examples/block-explorer && forc-index deploy --path explorer-indexer --target-dir /path/to/fuel-indexer` 
  - This ☝🏽 would fail on master


### Changelog 
- docs: update docs for examples 
- fix: ensure that `forc index deploy` respects `--path` relative to `--target-dir`