### PR TITLE
enhancement: construct subscribed contract set only once

### DIFF
--- a/packages/fuel-indexer-macros/src/indexer.rs
+++ b/packages/fuel-indexer-macros/src/indexer.rs
@@ -291,7 +291,7 @@ fn process_fn_items(
             }
             None => quote! {},
         },
-        ContractIds::Multiple(_contract_ids) => {
+        ContractIds::Multiple(_) => {
             quote! {
                 let bech32_id = Bech32ContractId::from(id);
 


### PR DESCRIPTION
This PR moves the construction of the `contract_ids` `HashSet` (if subscribing to multiple contracts) before all the loops (block/transaction/receipt).

An example output from the codegen:
```
 877   │     let contract_ids = HashSet::from([
 878   │         Bech32ContractId::from_str(
 879   │                 "fuel18hchrf7f4hnpkl84sqf8k0sk8gcauzeemzwgweea8dgr7eachv4s86r9t9",
 880   │             )
 881   │             .expect("Failed to parse manifest 'contract_id' as Bech32ContractId"),
 882   │         Bech32ContractId::from_str(
 883   │                 "fuel18hchrf7f4hnpkl84sqf8k0sk8gcauzeemzwgweea8dgr7eachv4s86abcd",
 884   │             )
 885   │             .expect("Failed to parse manifest 'contract_id' as Bech32ContractId"),
 886   │     ]);
 887   │     for block in blocks {
 888   │         if block.height < 1u64 {
 889   │             continue;
 890   │         }
 891   │         let mut decoder = Decoders::default();
 892   │         let ty_id = abi::BlockData::type_id();
 893   │         let data = bincode::serialize(&block).expect("Bad serialization.");
 894   │         decoder.decode_type(ty_id, data);
 895   │         for tx in block.transactions {
 896   │             let mut return_types = Vec::new();
 897   │             let mut callees = HashSet::new();
 898   │             for receipt in tx.receipts {
 899   │                 match receipt {
 900   │                     Receipt::Call {
 901   │                         id: contract_id,
 902   │                         amount,
 903   │                         asset_id,
 904   │                         gas,
 905   │                         param1,
 906   │                         to: id,
 907   │                         ..
 908   │                     } => {
 909   │                         let bech32_id = Bech32ContractId::from(id);
 910   │                         if !contract_ids.contains(&bech32_id) {
 911   │                             Logger::info(
 912   │                                 "Not subscribed to this contract. Will skip this receipt event. <('-'<)",
 913   │                             );
 914   │                             continue;
 915   │                         }
```

Manual testing steps:

1. Modify `fuel-indexer/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml` to include a second `contract_id`:
```
contract_id:
 - fuel1lun289ufekmnx55m540tj79a9e2mavaagxp3e6cekzfmjkpc8xxsqy42wh
 - fuel1lun289ufekmnx55m540tj79a9e2mavaagxp3e6cekzfmjkpc8xxsqy42wx
```

2. Check the generated code:

```
cargo expand -p fuel-indexer-test --target wasm32-unknown-unknown
```

3. Build the test module

```
./scripts/utils/build_test_wasm_module.bash
```

4. Run everything and trigger an event

```
cargo run -p fuel-node --bin fuel-node

cargo run -p web-api --bin web-api

cargo run --bin fuel-indexer -- run --run-migrations --manifest packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml

curl -X POSThttp://localhost:8000/block
```