### PR TITLE
docs: add GraphQL functionality table

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,10 @@ type Account {
 }
 ```
 
+### GraphQL Functionality
+
+While we do our best to maintain compliance with the GraphQL specification and parity with other implementations, there are a few things that are under development or will not be implemented. You can find more information in [the GraphQL chapter of the book](https://fuellabs.github.io/fuel-indexer/master/reference-guide/components/graphql/index.html).
+
 ## Modules
 
 Within the context of the Fuel indexer, WebAssembly (WASM) modules are binaries that are compiled to a `wasm32-unknown-unknown` target, which can then be deployed to a running indexer service.

--- a/docs/src/reference-guide/components/graphql/index.md
+++ b/docs/src/reference-guide/components/graphql/index.md
@@ -5,4 +5,32 @@ The Fuel indexer uses GraphQL to in order to allow users to query for indexed da
 - [Schema](./schema.md)
 - [Directives](./directives.md)
 - [GraphQL API Server](./api-server.md)
-- [Queries](./queries.md)
+- [Queries](./queries/index.md)
+
+## Supported Functionality
+
+While we do our best to maintain compliance with the GraphQL specification and parity with other implementations, there are a few things that are under development or will not be implemented. Here's a table describing our GraphQL functionality:
+
+```text
+✅ -- implemented
+🚧 -- planned or in development
+⛔ -- will not implement
+```
+
+| Functionality | Status | Notes |
+|------|----------|-------|
+| Arguments | ✅ | [read the Search and Filtering section](./queries/search-filtering.md) |
+| Aliases | ✅ | |
+| Fragments | ✅ | inline fragments are currently not supported |
+| Introspection | ✅ | |
+| GraphQL Playground | ✅ | [read the Playground section](./playground.md) |
+| Pagination | ✅ | [read the Pagination section](./queries/pagination.md) |
+| Directives | 🚧 | [read the Directives section](./directives.md) |
+| List Types | 🚧 | |
+| Union Types | 🚧 | |
+| Federation | 🚧 | |
+| Variables | ⛔ | |
+| Mutations | ⛔ | |
+| Enums | ⛔ | |
+| Interfaces | ⛔ | |
+| Input Types| ⛔ | |


### PR DESCRIPTION
Closes #904.

### Description
- Adds a table that describes our GraphQL current and future functionality as well as what we won't add

### Testing steps
CI should pass; only documentation was added

### Changelog
- https://github.com/FuelLabs/fuel-indexer/commit/d82d28d1791babd274883a26770308396cadf8f7 - introduce table to docs

### Notes
Regarding the planned or in-progress bits, I added what I've heard being mentioned over the last couple months. I'm not tied to any of it; just added it to flesh things out.