### PR TITLE
fix: create foreign keys if not exists

### DIFF
--- a/packages/fuel-indexer-database/database-types/src/lib.rs
+++ b/packages/fuel-indexer-database/database-types/src/lib.rs
@@ -448,7 +448,7 @@ impl CreateStatement for ForeignKey {
         match self.db_type {
             DbType::Postgres => {
                 format!(
-                    "ALTER TABLE {}.{} ADD CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {}.{}({}) ON DELETE {} ON UPDATE {} INITIALLY DEFERRED;",
+                    "ALTER TABLE {}.{} ADD CONSTRAINT {} FOREIGN KEY IF NOT EXISTS ({}) REFERENCES {}.{}({}) ON DELETE {} ON UPDATE {} INITIALLY DEFERRED;",
                     self.namespace,
                     self.table_name,
                     self.name(),


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- If you try to re-deploy an indexer when its table already exists, you'll run into a FK error

### Testing steps

Please provide the _exact_ testing steps for the reviewer(s) if this PR requires testing.

### Changelog

- fix: create foreign keys if not exists
