### PR TITLE
fix: introspection response was nested one level too deep

### DIFF
--- a/packages/fuel-indexer-graphql/src/dynamic.rs
+++ b/packages/fuel-indexer-graphql/src/dynamic.rs
@@ -129,7 +129,7 @@ pub async fn execute_query(
             let introspection_results = dynamic_schema.execute(dynamic_request).await;
             let data = introspection_results.data.into_json()?;
 
-            Ok(serde_json::json!({ "data": data }))
+            Ok(data)
         }
         Some(_) | None => {
             let query =


### PR DESCRIPTION
### Description

Fixes introspection response nesting.

### Testing steps

CI should pass. Start the explorer indexer and open the playground link. Open developer tools and inspect the response for the introspection query. Introspection results should be under the `data` key. On master, they're currently under `data['data']`.

### Changelog

- Fix introspection response nesting
