### PR TITLE
enhancement: re-export indexer `fuel-indexer-*` dependencies under `fuel-indexer-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,8 +3222,6 @@ version = "0.15.1"
 dependencies = [
  "fuel-indexer-macros",
  "fuel-indexer-plugin",
- "fuel-indexer-schema",
- "fuels",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash 0.8.3",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bitflags",
  "bytes 1.4.0",
  "bytestring",
@@ -468,13 +468,13 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "5.0.8"
+version = "5.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae09afb01514b3dbd6328547b2b11fcbcb0205d9c5e6f2e17e60cb166a82d7f"
+checksum = "364423936c4b828ac1615ce325e528c5afbe6e6995d799ee5683c7d36720dfa4"
 dependencies = [
- "async-graphql-derive 5.0.8",
- "async-graphql-parser 5.0.8",
- "async-graphql-value 5.0.8",
+ "async-graphql-derive 5.0.9",
+ "async-graphql-parser 5.0.9",
+ "async-graphql-value 5.0.9",
  "async-stream",
  "async-trait",
  "base64 0.13.1",
@@ -501,11 +501,11 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-axum"
-version = "5.0.8"
+version = "5.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c17392185400a1eb3621b7fa52154b23c0d546b399a481d282cd403af4ff7e"
+checksum = "f05d3a107ce33726d3bdb3fc5d760c84fc2b2f29db18f359a2f05d1efa3a7ac4"
 dependencies = [
- "async-graphql 5.0.8",
+ "async-graphql 5.0.9",
  "async-trait",
  "axum 0.6.18",
  "bytes 1.4.0",
@@ -534,12 +534,12 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "5.0.8"
+version = "5.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60ae62851dd3ff9a7550aee75e848e8834b75285b458753e98dd71d0733ad3f2"
+checksum = "23a06320343bbe0a1f2e29ec6d1ed34e0460f10e6827b3154a78e4ccc039dbc4"
 dependencies = [
  "Inflector",
- "async-graphql-parser 5.0.8",
+ "async-graphql-parser 5.0.9",
  "darling 0.14.4",
  "proc-macro-crate",
  "proc-macro2",
@@ -562,11 +562,11 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "5.0.8"
+version = "5.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6ee332acd99d2c50c3443beae46e9ed784c205eead9a668b7b5118b4a60a8b"
+checksum = "46ce3b4b57e2a4630ea5e69eeb02fb5ee3c5f48754fcf7fd6a7bf3b4f96538f0"
 dependencies = [
- "async-graphql-value 5.0.8",
+ "async-graphql-value 5.0.9",
  "pest",
  "serde",
  "serde_json",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "5.0.8"
+version = "5.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122da50452383410545b9428b579f4cda5616feb6aa0aff0003500c53fcff7b7"
+checksum = "637c6b5a755133d47c9829df04b7a5e2f1856fe4c1101f581650c93198eba103"
 dependencies = [
  "bytes 1.4.0",
  "indexmap",
@@ -670,7 +670,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -771,7 +771,7 @@ dependencies = [
  "async-trait",
  "axum-core 0.3.4",
  "axum-macros",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bitflags",
  "bytes 1.4.0",
  "futures-util",
@@ -842,7 +842,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -896,9 +896,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -1010,7 +1010,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "constant_time_eq",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1123,9 +1123,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1297,25 +1297,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
- "clap_derive 4.2.0",
+ "clap_derive 4.3.0",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.4.1",
+ "clap_lex 0.5.0",
  "strsim",
 ]
 
@@ -1334,14 +1334,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1355,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cobs"
@@ -1374,7 +1374,7 @@ dependencies = [
  "bincode",
  "bs58",
  "coins-core",
- "digest 0.10.6",
+ "digest 0.10.7",
  "getrandom 0.2.9",
  "hmac 0.12.1",
  "k256",
@@ -1411,7 +1411,7 @@ dependencies = [
  "base64 0.12.3",
  "bech32 0.7.3",
  "blake2",
- "digest 0.10.6",
+ "digest 0.10.7",
  "generic-array 0.14.7",
  "hex",
  "ripemd",
@@ -1452,15 +1452,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1afa0591b1021e427e548a1f0f147fe6168f6c7c7f7006bace77f28856051b8"
 dependencies = [
  "cynic-proc-macros",
- "reqwest 0.11.17",
+ "reqwest 0.11.18",
  "serde",
  "serde_json",
  "static_assertions",
@@ -1889,7 +1889,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1922,7 +1922,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1994,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
@@ -2113,7 +2113,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
@@ -2176,7 +2176,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2189,7 +2189,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2210,7 +2210,7 @@ dependencies = [
  "darling 0.20.1",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2312,7 +2312,7 @@ checksum = "dd65f1b59dd22d680c7a626cc4a000c1e03d241c51c3e034d2bc9f1e90734f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2430,7 +2430,7 @@ dependencies = [
  "indicatif",
  "owo-colors",
  "rand 0.8.5",
- "reqwest 0.11.17",
+ "reqwest 0.11.18",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2585,7 +2585,7 @@ dependencies = [
  "async-graphql 4.0.16",
  "async-trait",
  "axum 0.5.17",
- "clap 4.2.7",
+ "clap 4.3.0",
  "derive_more",
  "enum-iterator 1.4.1",
  "fuel-core-chain-config",
@@ -2658,7 +2658,7 @@ dependencies = [
  "hex",
  "hyper-rustls 0.22.1",
  "itertools 0.10.5",
- "reqwest 0.11.17",
+ "reqwest 0.11.18",
  "serde",
  "serde_json",
  "tai64",
@@ -2965,7 +2965,7 @@ name = "fuel-indexer-api-server"
 version = "0.15.1"
 dependencies = [
  "anyhow",
- "async-graphql 5.0.8",
+ "async-graphql 5.0.9",
  "async-graphql-axum",
  "async-std",
  "axum 0.6.18",
@@ -3017,9 +3017,9 @@ dependencies = [
 name = "fuel-indexer-graphql"
 version = "0.15.1"
 dependencies = [
- "async-graphql 5.0.8",
- "async-graphql-parser 5.0.8",
- "async-graphql-value 5.0.8",
+ "async-graphql 5.0.9",
+ "async-graphql-parser 5.0.9",
+ "async-graphql-value 5.0.9",
  "fuel-indexer-database",
  "fuel-indexer-database-types",
  "fuel-indexer-schema",
@@ -3037,7 +3037,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap 3.2.25",
- "fuel-indexer-types",
  "http",
  "serde",
  "serde_json",
@@ -3058,20 +3057,21 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "fuel-indexer-macros"
 version = "0.15.1"
 dependencies = [
- "async-graphql-parser 5.0.8",
+ "async-graphql-parser 5.0.9",
  "fuel-abi-types 0.2.1",
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
  "fuel-indexer-plugin",
  "fuel-indexer-schema",
  "fuel-indexer-types",
+ "fuel-indexer-utils",
  "fuels",
  "fuels-code-gen",
  "fuels-macros",
@@ -3083,7 +3083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "syn 2.0.16",
+ "syn 2.0.18",
  "trybuild",
 ]
 
@@ -3138,7 +3138,7 @@ dependencies = [
 name = "fuel-indexer-schema"
 version = "0.15.1"
 dependencies = [
- "async-graphql-parser 5.0.8",
+ "async-graphql-parser 5.0.9",
  "fuel-indexer-database",
  "fuel-indexer-database-types",
  "fuel-indexer-types",
@@ -3155,9 +3155,7 @@ dependencies = [
 name = "fuel-indexer-test"
 version = "0.0.0"
 dependencies = [
- "fuel-indexer-macros",
- "fuel-indexer-plugin",
- "fuel-indexer-schema",
+ "fuel-indexer-utils",
  "fuels",
  "serde",
 ]
@@ -3188,7 +3186,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "rand 0.8.5",
- "reqwest 0.11.17",
+ "reqwest 0.11.18",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3219,12 +3217,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuel-indexer-utils"
+version = "0.15.1"
+dependencies = [
+ "fuel-indexer-macros",
+ "fuel-indexer-plugin",
+ "fuel-indexer-schema",
+ "fuels",
+ "serde",
+]
+
+[[package]]
 name = "fuel-merkle"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b13103bf12f62930dd26f75f90d6a95d952fdcd677a356f57d8ef8df7ae02b84"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "fuel-storage",
  "hashbrown 0.13.2",
  "hex",
@@ -3313,9 +3322,7 @@ dependencies = [
 name = "fuel_explorer"
 version = "0.0.0"
 dependencies = [
- "fuel-indexer-macros",
- "fuel-indexer-plugin",
- "fuel-indexer-schema",
+ "fuel-indexer-utils",
  "fuels",
  "serde",
 ]
@@ -3588,7 +3595,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3623,11 +3630,11 @@ dependencies = [
 
 [[package]]
 name = "generational-arena"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3912,9 +3919,7 @@ dependencies = [
 name = "hello_indexer"
 version = "0.0.0"
 dependencies = [
- "fuel-indexer-macros",
- "fuel-indexer-plugin",
- "fuel-indexer-schema",
+ "fuel-indexer-utils",
  "fuels",
  "serde",
 ]
@@ -3925,9 +3930,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "fuel-indexer",
- "fuel-indexer-macros",
- "fuel-indexer-plugin",
- "fuel-indexer-schema",
+ "fuel-indexer-utils",
  "fuels",
  "serde",
 ]
@@ -3990,7 +3993,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4153,6 +4156,19 @@ dependencies = [
  "rustls-native-certs 0.6.2",
  "tokio 1.28.1",
  "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper 0.14.26",
+ "rustls 0.21.1",
+ "tokio 1.28.1",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -4330,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -4420,7 +4436,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "pem",
  "ring",
  "serde",
@@ -4559,9 +4575,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "local-channel"
@@ -4694,7 +4710,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5005,7 +5021,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5171,7 +5187,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash 0.4.2",
  "sha2 0.10.6",
@@ -5255,7 +5271,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5292,7 +5308,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "reqwest 0.11.17",
+ "reqwest 0.11.18",
  "sqlx",
  "thiserror",
  "tokio 1.28.1",
@@ -5360,7 +5376,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5528,9 +5544,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5640,9 +5656,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -5803,13 +5819,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -5829,9 +5845,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "region"
@@ -5893,11 +5909,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes 1.4.0",
  "cookie",
  "cookie_store",
@@ -5908,7 +5924,7 @@ dependencies = [
  "http",
  "http-body 0.4.5",
  "hyper 0.14.26",
- "hyper-rustls 0.23.2",
+ "hyper-rustls 0.24.0",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -5919,14 +5935,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.9",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.28.1",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5968,7 +5984,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6099,6 +6115,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct 0.7.0",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6128,7 +6156,17 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -6279,9 +6317,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6332,7 +6370,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -6423,7 +6461,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6459,7 +6497,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6480,7 +6518,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -6514,7 +6552,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6534,9 +6572,7 @@ checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 name = "simple-wasm"
 version = "0.0.0"
 dependencies = [
- "fuel-indexer-macros",
- "fuel-indexer-plugin",
- "fuel-indexer-schema",
+ "fuel-indexer-utils",
  "fuel-tx",
  "fuels",
  "serde",
@@ -6985,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7077,7 +7113,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -7207,7 +7243,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -7262,6 +7298,16 @@ dependencies = [
  "rustls 0.20.8",
  "tokio 1.28.1",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio 1.28.1",
 ]
 
 [[package]]
@@ -7328,15 +7374,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -7419,7 +7465,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -7621,9 +7667,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -7822,7 +7868,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -7856,7 +7902,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7869,9 +7915,9 @@ checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77053dc709db790691d3732cfc458adc5acc881dec524965c608effdcd9c581"
+checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
 dependencies = [
  "leb128",
 ]
@@ -8115,9 +8161,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "58.0.0"
+version = "60.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372eecae2d10a5091c2005b32377d7ecd6feecdf2c05838056d02d8b4f07c429"
+checksum = "bd06cc744b536e30387e72a48fdd492105b9c938bb4f415c39c616a7a0a697ad"
 dependencies = [
  "leb128",
  "memchr",
@@ -8127,9 +8173,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d47446190e112ab1579ab40b3ad7e319d859d74e5134683f04e9f0747bf4173"
+checksum = "5abe520f0ab205366e9ac7d3e6b2fc71de44e32a2b58f2ec871b6b575bdcea3b"
 dependencies = [
  "wast",
 ]
@@ -8589,7 +8635,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
    "examples/hello-world/hello-indexer",
    "examples/hello-world/hello-world-data",
    "examples/hello-world/hello-world-node",
+   "packages/fuel-indexer",
    "packages/fuel-indexer-api-server",
    "packages/fuel-indexer-database",
    "packages/fuel-indexer-database/database-types",
@@ -24,8 +25,7 @@ members = [
    "packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm",
    "packages/fuel-indexer-tests/components/web-api",
    "packages/fuel-indexer-types",
-   "packages/fuel-indexer",
-   "plugins/forc-index-tests",
+   "packages/fuel-indexer-utils",
    "plugins/forc-index",
    "plugins/forc-index-tests",
    "plugins/forc-postgres",
@@ -43,6 +43,7 @@ default-members = [
    "packages/fuel-indexer-plugin",
    "packages/fuel-indexer-schema",
    "packages/fuel-indexer-types",
+   "packages/fuel-indexer-utils",
    "plugins/forc-index",
    "plugins/forc-postgres",
 ]
@@ -77,6 +78,7 @@ fuel-indexer-plugin = { version = "0.15.1", path = "./packages/fuel-indexer-plug
 fuel-indexer-postgres = { version = "0.15.1", path = "./packages/fuel-indexer-database/postgres" }
 fuel-indexer-schema = { version = "0.15.1", path = "./packages/fuel-indexer-schema", default-features = false }
 fuel-indexer-types = { version = "0.15.1", path = "./packages/fuel-indexer-types" }
+fuel-indexer-utils = { version = "0.15.1", path = "./packages/fuel-indexer-utils" }
 clap = "3.1"
 bincode = "1.3.3"
 fuel-tx = { version = "0.26", default-features = false }

--- a/examples/fuel-explorer/fuel-explorer/Cargo.toml
+++ b/examples/fuel-explorer/fuel-explorer/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { workspace = true, default-features = false }
-fuel-indexer-plugin = { workspace = true }
-fuel-indexer-schema = { workspace = true, default-features = false }
+fuel-indexer-utils = { workspace = true }
 fuels = { workspace = true }
 serde = { workspace = true }

--- a/examples/fuel-explorer/fuel-explorer/src/lib.rs
+++ b/examples/fuel-explorer/fuel-explorer/src/lib.rs
@@ -1,5 +1,8 @@
 extern crate alloc;
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::*;
+#[allow(unused_imports)]
+use fuel_indexer_utils::utilities::*;
 
 pub enum ConsensusLabel {
     Unknown,

--- a/examples/fuel-explorer/fuel-explorer/src/lib.rs
+++ b/examples/fuel-explorer/fuel-explorer/src/lib.rs
@@ -1,8 +1,5 @@
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
 use fuel_indexer_utils::prelude::*;
-#[allow(unused_imports)]
-use fuel_indexer_utils::utilities::*;
 
 pub enum ConsensusLabel {
     Unknown,

--- a/examples/hello-world-native/hello-indexer-native/Cargo.toml
+++ b/examples/hello-world-native/hello-indexer-native/Cargo.toml
@@ -7,8 +7,6 @@ publish = false
 [dependencies]
 async-trait = { version = "0.1" }
 fuel-indexer = { workspace = true }
-fuel-indexer-macros = { workspace = true, default-features = false }
-fuel-indexer-plugin = { workspace = true, features = ["native-execution"] }
-fuel-indexer-schema = { workspace = true, default-features = false }
+fuel-indexer-utils = { workspace = true, features = ["native-execution"] }
 fuels = { workspace = true }
 serde = { workspace = true }

--- a/examples/hello-world-native/hello-indexer-native/src/main.rs
+++ b/examples/hello-world-native/hello-indexer-native/src/main.rs
@@ -18,10 +18,7 @@
 //! cargo run -p hello-world-data --bin hello-world-data
 //! ```
 extern crate alloc;
-use fuel_indexer::prelude::*;
-use fuel_indexer_utils::macros::indexer;
 use fuel_indexer_utils::prelude::*;
-use fuel_indexer_utils::utilities::*;
 
 #[indexer(
     manifest = "examples/hello-world-native/hello-indexer-native/hello_indexer_native.manifest.yaml"

--- a/examples/hello-world-native/hello-indexer-native/src/main.rs
+++ b/examples/hello-world-native/hello-indexer-native/src/main.rs
@@ -19,8 +19,9 @@
 //! ```
 extern crate alloc;
 use fuel_indexer::prelude::*;
-use fuel_indexer_macros::indexer;
-use fuel_indexer_plugin::prelude::*;
+use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::*;
+use fuel_indexer_utils::utilities::*;
 
 #[indexer(
     manifest = "examples/hello-world-native/hello-indexer-native/hello_indexer_native.manifest.yaml"

--- a/examples/hello-world/hello-indexer/Cargo.toml
+++ b/examples/hello-world/hello-indexer/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { workspace = true, default-features = false }
-fuel-indexer-plugin = { workspace = true }
-fuel-indexer-schema = { workspace = true, default-features = false }
+fuel-indexer-utils = { workspace = true }
 fuels = { default-features = false, workspace = true }
 serde = { workspace = true }

--- a/examples/hello-world/hello-indexer/src/lib.rs
+++ b/examples/hello-world/hello-indexer/src/lib.rs
@@ -27,9 +27,7 @@
 //! ```
 
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
 use fuel_indexer_utils::prelude::*;
-use fuel_indexer_utils::utilities::*;
 
 #[indexer(manifest = "examples/hello-world/hello-indexer/hello_indexer.manifest.yaml")]
 mod hello_world_indexer {

--- a/examples/hello-world/hello-indexer/src/lib.rs
+++ b/examples/hello-world/hello-indexer/src/lib.rs
@@ -27,8 +27,9 @@
 //! ```
 
 extern crate alloc;
-use fuel_indexer_macros::indexer;
-use fuel_indexer_plugin::prelude::*;
+use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::*;
+use fuel_indexer_utils::utilities::*;
 
 #[indexer(manifest = "examples/hello-world/hello-indexer/hello_indexer.manifest.yaml")]
 mod hello_world_indexer {

--- a/packages/fuel-indexer-lib/Cargo.toml
+++ b/packages/fuel-indexer-lib/Cargo.toml
@@ -13,7 +13,6 @@ description = "Fuel Indexer Library"
 anyhow = "1.0"
 bincode = { workspace = true }
 clap = { features = ["cargo", "derive", "env"], workspace = true }
-fuel-indexer-types = { workspace = true }
 http = { version = "0.2", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/fuel-indexer-lib/src/utils.rs
+++ b/packages/fuel-indexer-lib/src/utils.rs
@@ -1,6 +1,5 @@
 use crate::{config::IndexerConfig, defaults};
 use anyhow::Result;
-use fuel_indexer_types::scalar::Bytes32;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
@@ -227,49 +226,6 @@ pub async fn init_logging(config: &IndexerConfig) -> anyhow::Result<()> {
             .init();
     }
     Ok(())
-}
-
-pub mod indexer_utils {
-    use fuel_indexer_types::SizedAsciiString;
-
-    use super::{sha256_digest, Bytes32};
-
-    pub fn u64_id(d: &[u8; 8]) -> u64 {
-        u64::from_le_bytes(*d)
-    }
-
-    pub fn first8_bytes_to_u64(data: impl AsRef<[u8]>) -> u64 {
-        let data = sha256_digest(&data);
-        let mut buff = [0u8; 8];
-        buff.copy_from_slice(&data.as_bytes()[..8]);
-        u64_id(&buff)
-    }
-
-    pub fn first32_bytes_to_bytes32(data: impl AsRef<[u8]>) -> Bytes32 {
-        let data = sha256_digest(&data);
-        let mut buff = [0u8; 32];
-        buff.copy_from_slice(&data.as_bytes()[..32]);
-        Bytes32::from(buff)
-    }
-
-    pub fn u64_id_from_inputs(id: &[u8; 32], inputs: Vec<u8>) -> u64 {
-        let inputs = [id.to_vec(), inputs].concat();
-        first8_bytes_to_u64(inputs)
-    }
-
-    pub fn bytes32_from_inputs(id: &[u8; 32], inputs: Vec<u8>) -> Bytes32 {
-        let inputs = [id.to_vec(), inputs].concat();
-        first32_bytes_to_bytes32(inputs)
-    }
-
-    pub fn trim_sized_ascii_string<const LEN: usize>(
-        s: &SizedAsciiString<LEN>,
-    ) -> String {
-        let mut s = s.to_string();
-        let n = s.trim_end_matches(' ').len();
-        s.truncate(n);
-        s
-    }
 }
 
 pub fn format_exec_msg(exec_name: &str, path: Option<String>) -> String {

--- a/packages/fuel-indexer-macros/Cargo.toml
+++ b/packages/fuel-indexer-macros/Cargo.toml
@@ -31,6 +31,7 @@ syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 fuel-indexer-plugin = { workspace = true }
+fuel-indexer-utils = { workspace = true }
 fuels-macros = { version = "0.40.0", default-features = false }
 fuels-types = { version = "0.40.0", default-features = false }
 serde = { workspace = true }

--- a/packages/fuel-indexer-macros/src/native.rs
+++ b/packages/fuel-indexer-macros/src/native.rs
@@ -39,13 +39,11 @@ fn native_prelude() -> proc_macro2::TokenStream {
         // all dependencies explicity (preferably through a single crate).
         use fuel_indexer_utils::{
             plugin::{
+                bincode, deserialize,
+                serde_json, serialize,
                 native::*,
                 serde::{Deserialize, Serialize},
                 types::*,
-            },
-            prelude::{
-                bincode, deserialize,
-                serde_json, serialize,
             },
         };
         use fuels::{

--- a/packages/fuel-indexer-macros/src/native.rs
+++ b/packages/fuel-indexer-macros/src/native.rs
@@ -35,22 +35,26 @@ fn native_prelude() -> proc_macro2::TokenStream {
 
         static mut db: Option<Arc<Mutex<Database>>> = None;
 
+        // TODO: Eventually prevent these types of implicity imports and have users import
+        // all dependencies explicity (preferably through a single crate).
         use fuel_indexer_utils::{
-            fuels::{
-                core::abi_decoder::ABIDecoder,
-                macros::{Parameterize, Tokenizable},
-                types::{
-                    traits::{Parameterize, Tokenizable},
-                    StringToken,
-                },
+            plugin::{
+                native::*,
+                serde::{Deserialize, Serialize},
+                types::*,
             },
-            native::*,
             prelude::{
                 bincode, deserialize,
                 serde_json, serialize,
             },
-            serde::{Deserialize, Serialize},
-            types::*,
+        };
+        use fuels::{
+            core::abi_decoder::ABIDecoder,
+            macros::{Parameterize, Tokenizable},
+            types::{
+                traits::{Parameterize, Tokenizable},
+                StringToken,
+            },
         };
     }
 }

--- a/packages/fuel-indexer-macros/src/native.rs
+++ b/packages/fuel-indexer-macros/src/native.rs
@@ -31,20 +31,26 @@ pub fn handler_block_native(
 /// indexer module, not within the scope of the entire lib module.
 fn native_prelude() -> proc_macro2::TokenStream {
     quote! {
-        use fuel_indexer_plugin::native::*;
-        use fuel_indexer_plugin::{{serialize, deserialize}, types::*, serde::{Deserialize, Serialize}, serde_json};
-
-        // TODO: Eventually prevent these types of implicity imports and have users import
-        // all dependencies explicity (preferably through a single crate).
-        use fuels::{
-            core::abi_decoder::ABIDecoder,
-            macros::{Parameterize, Tokenizable},
-            types::{StringToken, traits::{Tokenizable, Parameterize}},
-        };
-
         type B256 = [u8; 32];
 
         static mut db: Option<Arc<Mutex<Database>>> = None;
 
+        use fuel_indexer_utils::{
+            fuels::{
+                core::abi_decoder::ABIDecoder,
+                macros::{Parameterize, Tokenizable},
+                types::{
+                    traits::{Parameterize, Tokenizable},
+                    StringToken,
+                },
+            },
+            native::*,
+            prelude::{
+                bincode, deserialize,
+                serde_json, serialize,
+            },
+            serde::{Deserialize, Serialize},
+            types::*,
+        };
     }
 }

--- a/packages/fuel-indexer-macros/src/wasm.rs
+++ b/packages/fuel-indexer-macros/src/wasm.rs
@@ -12,7 +12,7 @@ pub fn handler_block_wasm(
 
         #[no_mangle]
         fn handle_events(blob: *mut u8, len: usize) {
-            use fuel_indexer_plugin::deserialize;
+            use fuel_indexer_utils::prelude::deserialize;
             let bytes = unsafe { Vec::from_raw_parts(blob, len, len) };
             let blocks: Vec<BlockData> = match deserialize(&bytes) {
                 Ok(blocks) => blocks,
@@ -38,25 +38,26 @@ pub fn handler_block_wasm(
 fn wasm_prelude() -> proc_macro2::TokenStream {
     quote! {
         use alloc::{format, vec, vec::Vec};
-        use fuel_indexer_plugin::{
-            serialize,
-            deserialize,
-            wasm::{Logger, FromHex, Digest, Sha256, Entity},
-            types::*,
-            bincode,
-            serde::{Deserialize, Serialize},
-            serde_json
-        };
-
-        // TODO: Eventually prevent these types of implicity imports and have users import
-        // all dependencies explicity (preferably through a single crate).
-        use fuels::{
-            core::abi_decoder::ABIDecoder,
-            macros::{Parameterize, Tokenizable},
-            types::{StringToken, traits::{Tokenizable, Parameterize}},
-        };
         use std::str::FromStr;
 
         type B256 = [u8; 32];
+
+        use fuel_indexer_utils::{
+            fuels::{
+                core::abi_decoder::ABIDecoder,
+                macros::{Parameterize, Tokenizable},
+                types::{
+                    traits::{Parameterize, Tokenizable},
+                    StringToken,
+                },
+            },
+            prelude::{
+                bincode, deserialize,
+                serde_json, serialize,
+            },
+            serde::{Deserialize, Serialize},
+            types::*,
+            wasm::{Digest, Entity, FromHex, Logger, Sha256},
+        };
     }
 }

--- a/packages/fuel-indexer-macros/src/wasm.rs
+++ b/packages/fuel-indexer-macros/src/wasm.rs
@@ -12,7 +12,7 @@ pub fn handler_block_wasm(
 
         #[no_mangle]
         fn handle_events(blob: *mut u8, len: usize) {
-            use fuel_indexer_utils::prelude::deserialize;
+            use fuel_indexer_utils::plugin::deserialize;
             let bytes = unsafe { Vec::from_raw_parts(blob, len, len) };
             let blocks: Vec<BlockData> = match deserialize(&bytes) {
                 Ok(blocks) => blocks,
@@ -42,22 +42,26 @@ fn wasm_prelude() -> proc_macro2::TokenStream {
 
         type B256 = [u8; 32];
 
+        // TODO: Eventually prevent these types of implicity imports and have users import
+        // all dependencies explicity (preferably through a single crate).
         use fuel_indexer_utils::{
-            fuels::{
-                core::abi_decoder::ABIDecoder,
-                macros::{Parameterize, Tokenizable},
-                types::{
-                    traits::{Parameterize, Tokenizable},
-                    StringToken,
-                },
+            plugin::{
+                serde::{Deserialize, Serialize},
+                types::*,
+                wasm::{Digest, Entity, FromHex, Logger, Sha256},
             },
             prelude::{
                 bincode, deserialize,
                 serde_json, serialize,
             },
-            serde::{Deserialize, Serialize},
-            types::*,
-            wasm::{Digest, Entity, FromHex, Logger, Sha256},
+        };
+        use fuels::{
+            core::abi_decoder::ABIDecoder,
+            macros::{Parameterize, Tokenizable},
+            types::{
+                traits::{Parameterize, Tokenizable},
+                StringToken,
+            },
         };
     }
 }

--- a/packages/fuel-indexer-macros/src/wasm.rs
+++ b/packages/fuel-indexer-macros/src/wasm.rs
@@ -46,13 +46,11 @@ fn wasm_prelude() -> proc_macro2::TokenStream {
         // all dependencies explicity (preferably through a single crate).
         use fuel_indexer_utils::{
             plugin::{
+                bincode, deserialize,
+                serde_json, serialize,
                 serde::{Deserialize, Serialize},
                 types::*,
                 wasm::{Digest, Entity, FromHex, Logger, Sha256},
-            },
-            prelude::{
-                bincode, deserialize,
-                serde_json, serialize,
             },
         };
         use fuels::{

--- a/packages/fuel-indexer-plugin/src/lib.rs
+++ b/packages/fuel-indexer-plugin/src/lib.rs
@@ -25,13 +25,7 @@ pub mod types {
 }
 
 pub mod utils {
-    pub use fuel_indexer_lib::utils::{
-        indexer_utils::{
-            bytes32_from_inputs, first32_bytes_to_bytes32, first8_bytes_to_u64,
-            trim_sized_ascii_string, u64_id, u64_id_from_inputs,
-        },
-        sha256_digest,
-    };
+    pub use fuel_indexer_lib::utils::sha256_digest;
 }
 
 pub use bincode;

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { workspace = true, default-features = false }
-fuel-indexer-plugin = { workspace = true }
-fuel-indexer-schema = { workspace = true, default-features = false }
+fuel-indexer-utils = { workspace = true }
 fuels = { workspace = true }
 serde = { workspace = true }

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
@@ -1,7 +1,8 @@
 extern crate alloc;
 
-use fuel_indexer_macros::indexer;
-use fuel_indexer_plugin::utils::*;
+use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::*;
+use fuel_indexer_utils::utilities::*;
 
 #[indexer(
     manifest = "packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml"

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/src/lib.rs
@@ -1,8 +1,6 @@
 extern crate alloc;
 
-use fuel_indexer_utils::macros::indexer;
 use fuel_indexer_utils::prelude::*;
-use fuel_indexer_utils::utilities::*;
 
 #[indexer(
     manifest = "packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml"

--- a/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
+++ b/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/Cargo.toml
@@ -8,9 +8,7 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fuel-indexer-macros = { workspace = true, default-features = false }
-fuel-indexer-plugin = { workspace = true }
-fuel-indexer-schema = { workspace = true, default-features = false }
+fuel-indexer-utils = { workspace = true }
 fuel-tx = { workspace = true }
 fuels = { workspace = true }
 serde = { workspace = true }

--- a/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(

--- a/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/src/lib.rs
+++ b/packages/fuel-indexer-tests/components/indices/simple-wasm/simple-wasm/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::*;
 
 #[indexer(
     manifest = "packages/fuel-indexer-tests/components/indices/simple-wasm/simple_wasm.yaml"

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.stderr
@@ -1,4 +1,4 @@
-error: Type with ident 'Ident { ident: "BadType", span: #0 bytes(224..231) }' not defined in the ABI.
+error: Type with ident 'Ident { ident: "BadType", span: #0 bytes(225..232) }' not defined in the ABI.
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
   |
   | #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
@@ -68,7 +68,7 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::prelude::BlockData;
+2  | use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0422]: cannot find struct, variant or union type `BlockData` in this scope
@@ -83,7 +83,7 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::prelude::BlockData;
+2  | use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0433]: failed to resolve: use of undeclared crate or module `fuel`
@@ -101,6 +101,8 @@ help: consider importing one of these items
 2  | use fuel_indexer_plugin::prelude::fuel::TransactionStatusData;
    |
 2  | use fuel_indexer_types::fuel::TransactionStatusData;
+   |
+2  | use fuel_indexer_utils::plugin::prelude::fuel::TransactionStatusData;
    |
 help: if you import `TransactionStatusData`, refer to it directly
    |
@@ -120,53 +122,11 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::Transaction;
    |
-2  | use fuel_indexer_utils::prelude::HeaderData;
+2  | use fuel_indexer_utils::plugin::prelude::fuel::Transaction;
    |
-
-error[E0422]: cannot find struct, variant or union type `TransactionData` in this scope
- --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
-  |
-  |         transactions: vec![TransactionData {
-  |                            ^^^^^^^^^^^^^^^ not found in this scope
-  |
-help: consider importing one of these items
+2  | use fuels::prelude::Transaction;
    |
-2  | use fuel_indexer_plugin::prelude::TransactionData;
-   |
-2  | use fuel_indexer_types::prelude::TransactionData;
-   |
-2  | use fuel_indexer_utils::prelude::TransactionData;
-   |
-
-error[E0433]: failed to resolve: use of undeclared type `ClientTransactionStatusData`
- --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
-  |
-  |             status: ClientTransactionStatusData::default(),
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransactionStatusData`
-  |
-help: consider importing one of these items
-   |
-2  | use fuel_indexer_plugin::prelude::ClientTransactionStatusData;
-   |
-2  | use fuel_indexer_types::prelude::ClientTransactionStatusData;
-   |
-2  | use fuel_indexer_utils::prelude::ClientTransactionStatusData;
-   |
-
-error[E0433]: failed to resolve: use of undeclared type `ClientTransaction`
- --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
-  |
-  |             transaction: ClientTransaction::default(),
-  |                          ^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransaction`
-  |
-help: consider importing one of these items
-   |
-2  | use fuel_indexer_plugin::prelude::ClientTransaction;
-   |
-2  | use fuel_indexer_types::prelude::ClientTransaction;
-   |
-2  | use fuel_indexer_utils::prelude::ClientTransaction;
-   |
+     and 2 other candidates
 
 error[E0425]: cannot find function `serialize` in this scope
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
@@ -180,7 +140,7 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_plugin::serialize;
    |
-2  | use fuel_indexer_utils::serialize;
+2  | use fuel_indexer_utils::plugin::serialize;
    |
 
 error[E0425]: cannot find function `handle_events` in this scope

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.stderr
@@ -1,4 +1,4 @@
-error: Type with ident 'Ident { ident: "BadType", span: #0 bytes(217..224) }' not defined in the ABI.
+error: Type with ident 'Ident { ident: "BadType", span: #0 bytes(224..231) }' not defined in the ABI.
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
   |
   | #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
@@ -68,6 +68,8 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::BlockData;
    |
+2  | use fuel_indexer_utils::prelude::BlockData;
+   |
 
 error[E0422]: cannot find struct, variant or union type `BlockData` in this scope
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
@@ -80,6 +82,8 @@ help: consider importing one of these items
 2  | use fuel_indexer_plugin::prelude::BlockData;
    |
 2  | use fuel_indexer_types::fuel::BlockData;
+   |
+2  | use fuel_indexer_utils::prelude::BlockData;
    |
 
 error[E0433]: failed to resolve: use of undeclared crate or module `fuel`
@@ -116,11 +120,53 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::Transaction;
    |
-2  | use fuels::prelude::Transaction;
+2  | use fuel_indexer_utils::prelude::HeaderData;
    |
-2  | use fuels::tx::Transaction;
+
+error[E0422]: cannot find struct, variant or union type `TransactionData` in this scope
+ --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
+  |
+  |         transactions: vec![TransactionData {
+  |                            ^^^^^^^^^^^^^^^ not found in this scope
+  |
+help: consider importing one of these items
    |
-     and 1 other candidate
+2  | use fuel_indexer_plugin::prelude::TransactionData;
+   |
+2  | use fuel_indexer_types::prelude::TransactionData;
+   |
+2  | use fuel_indexer_utils::prelude::TransactionData;
+   |
+
+error[E0433]: failed to resolve: use of undeclared type `ClientTransactionStatusData`
+ --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
+  |
+  |             status: ClientTransactionStatusData::default(),
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransactionStatusData`
+  |
+help: consider importing one of these items
+   |
+2  | use fuel_indexer_plugin::prelude::ClientTransactionStatusData;
+   |
+2  | use fuel_indexer_types::prelude::ClientTransactionStatusData;
+   |
+2  | use fuel_indexer_utils::prelude::ClientTransactionStatusData;
+   |
+
+error[E0433]: failed to resolve: use of undeclared type `ClientTransaction`
+ --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
+  |
+  |             transaction: ClientTransaction::default(),
+  |                          ^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransaction`
+  |
+help: consider importing one of these items
+   |
+2  | use fuel_indexer_plugin::prelude::ClientTransaction;
+   |
+2  | use fuel_indexer_types::prelude::ClientTransaction;
+   |
+2  | use fuel_indexer_utils::prelude::ClientTransaction;
+   |
 
 error[E0425]: cannot find function `serialize` in this scope
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
@@ -133,6 +179,8 @@ help: consider importing one of these items
 2  | use fuel_indexer_lib::utils::serialize;
    |
 2  | use fuel_indexer_plugin::serialize;
+   |
+2  | use fuel_indexer_utils::serialize;
    |
 
 error[E0425]: cannot find function `handle_events` in this scope

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_include_self.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_include_self.rs
@@ -1,8 +1,6 @@
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
 
-#[indexer(
-    manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml"
-)]
+#[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
 mod indexer {
     fn function_one(self, event: SomeEvent) {
         let SomeEvent { id, account } = event;

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_include_self.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_include_self.rs
@@ -1,4 +1,4 @@
-use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::indexer;
 
 #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
 mod indexer {

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_include_self.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_include_self.stderr
@@ -1,10 +1,8 @@
 error: `self` argument not allowed in handler function.
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_args_include_self.rs
   |
-  | / #[indexer(
-  | |     manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml"
-  | | )]
-  | |__^
+  | #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `indexer` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_not_included.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_not_included.rs
@@ -1,4 +1,4 @@
-use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::indexer;
 
 #[indexer()]
 mod indexer {

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_not_included.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_args_not_included.rs
@@ -1,4 +1,4 @@
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
 
 #[indexer()]
 mod indexer {

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.stderr
@@ -68,7 +68,7 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::prelude::BlockData;
+2  | use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0422]: cannot find struct, variant or union type `BlockData` in this scope
@@ -83,7 +83,7 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::prelude::BlockData;
+2  | use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0433]: failed to resolve: use of undeclared type `Consensus`
@@ -98,7 +98,7 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::Consensus;
    |
-2  | use fuel_indexer_utils::prelude::HeaderData;
+2  | use fuel_indexer_utils::plugin::prelude::fuel::Consensus;
    |
 
 error[E0433]: failed to resolve: use of undeclared crate or module `fuel`
@@ -116,6 +116,8 @@ help: consider importing one of these items
 2  | use fuel_indexer_plugin::prelude::fuel::TransactionStatusData;
    |
 2  | use fuel_indexer_types::fuel::TransactionStatusData;
+   |
+2  | use fuel_indexer_utils::plugin::prelude::fuel::TransactionStatusData;
    |
 help: if you import `TransactionStatusData`, refer to it directly
    |
@@ -135,53 +137,11 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::Transaction;
    |
-2  | use fuel_indexer_utils::prelude::ConsensusData;
+2  | use fuel_indexer_utils::plugin::prelude::fuel::Transaction;
    |
-
-error[E0422]: cannot find struct, variant or union type `TransactionData` in this scope
- --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
-  |
-  |         transactions: vec![TransactionData {
-  |                            ^^^^^^^^^^^^^^^ not found in this scope
-  |
-help: consider importing one of these items
+2  | use fuels::prelude::Transaction;
    |
-2  | use fuel_indexer_plugin::prelude::TransactionData;
-   |
-2  | use fuel_indexer_types::prelude::TransactionData;
-   |
-2  | use fuel_indexer_utils::prelude::TransactionData;
-   |
-
-error[E0433]: failed to resolve: use of undeclared type `ClientTransactionStatusData`
- --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
-  |
-  |             status: ClientTransactionStatusData::default(),
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransactionStatusData`
-  |
-help: consider importing one of these items
-   |
-2  | use fuel_indexer_plugin::prelude::ClientTransactionStatusData;
-   |
-2  | use fuel_indexer_types::prelude::ClientTransactionStatusData;
-   |
-2  | use fuel_indexer_utils::prelude::ClientTransactionStatusData;
-   |
-
-error[E0433]: failed to resolve: use of undeclared type `ClientTransaction`
- --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
-  |
-  |             transaction: ClientTransaction::default(),
-  |                          ^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransaction`
-  |
-help: consider importing one of these items
-   |
-2  | use fuel_indexer_plugin::prelude::ClientTransaction;
-   |
-2  | use fuel_indexer_types::prelude::ClientTransaction;
-   |
-2  | use fuel_indexer_utils::prelude::ClientTransaction;
-   |
+     and 2 other candidates
 
 error[E0425]: cannot find function `serialize` in this scope
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
@@ -195,7 +155,7 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_plugin::serialize;
    |
-2  | use fuel_indexer_utils::serialize;
+2  | use fuel_indexer_utils::plugin::serialize;
    |
 
 error[E0425]: cannot find function `handle_events` in this scope

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.stderr
@@ -68,6 +68,8 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::BlockData;
    |
+2  | use fuel_indexer_utils::prelude::BlockData;
+   |
 
 error[E0422]: cannot find struct, variant or union type `BlockData` in this scope
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
@@ -81,6 +83,8 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::BlockData;
    |
+2  | use fuel_indexer_utils::prelude::BlockData;
+   |
 
 error[E0433]: failed to resolve: use of undeclared type `Consensus`
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
@@ -93,6 +97,8 @@ help: consider importing one of these items
 2  | use fuel_indexer_plugin::prelude::fuel::Consensus;
    |
 2  | use fuel_indexer_types::fuel::Consensus;
+   |
+2  | use fuel_indexer_utils::prelude::HeaderData;
    |
 
 error[E0433]: failed to resolve: use of undeclared crate or module `fuel`
@@ -129,11 +135,53 @@ help: consider importing one of these items
    |
 2  | use fuel_indexer_types::fuel::Transaction;
    |
-2  | use fuels::prelude::Transaction;
+2  | use fuel_indexer_utils::prelude::ConsensusData;
    |
-2  | use fuels::tx::Transaction;
+
+error[E0422]: cannot find struct, variant or union type `TransactionData` in this scope
+ --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
+  |
+  |         transactions: vec![TransactionData {
+  |                            ^^^^^^^^^^^^^^^ not found in this scope
+  |
+help: consider importing one of these items
    |
-     and 1 other candidate
+2  | use fuel_indexer_plugin::prelude::TransactionData;
+   |
+2  | use fuel_indexer_types::prelude::TransactionData;
+   |
+2  | use fuel_indexer_utils::prelude::TransactionData;
+   |
+
+error[E0433]: failed to resolve: use of undeclared type `ClientTransactionStatusData`
+ --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
+  |
+  |             status: ClientTransactionStatusData::default(),
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransactionStatusData`
+  |
+help: consider importing one of these items
+   |
+2  | use fuel_indexer_plugin::prelude::ClientTransactionStatusData;
+   |
+2  | use fuel_indexer_types::prelude::ClientTransactionStatusData;
+   |
+2  | use fuel_indexer_utils::prelude::ClientTransactionStatusData;
+   |
+
+error[E0433]: failed to resolve: use of undeclared type `ClientTransaction`
+ --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
+  |
+  |             transaction: ClientTransaction::default(),
+  |                          ^^^^^^^^^^^^^^^^^ use of undeclared type `ClientTransaction`
+  |
+help: consider importing one of these items
+   |
+2  | use fuel_indexer_plugin::prelude::ClientTransaction;
+   |
+2  | use fuel_indexer_types::prelude::ClientTransaction;
+   |
+2  | use fuel_indexer_utils::prelude::ClientTransaction;
+   |
 
 error[E0425]: cannot find function `serialize` in this scope
  --> ../fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.rs
@@ -146,6 +194,8 @@ help: consider importing one of these items
 2  | use fuel_indexer_lib::utils::serialize;
    |
 2  | use fuel_indexer_plugin::serialize;
+   |
+2  | use fuel_indexer_utils::serialize;
    |
 
 error[E0425]: cannot find function `handle_events` in this scope

--- a/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.rs
@@ -1,10 +1,8 @@
 extern crate alloc;
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}
 
-#[indexer(
-    manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml"
-)]
+#[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
 mod indexer {}

--- a/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.stderr
@@ -1,10 +1,8 @@
 error: No module body, must specify at least one handler function.
  --> ../fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.rs
   |
-  | / #[indexer(
-  | |     manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml"
-  | | )]
-  | |__^
+  | #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `indexer` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_multi_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_multi_type.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_multi_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_multi_type.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_single_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_single_type.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_utils::macros::indexer;
+use fuel_indexer_utils::prelude::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_single_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_single_type.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use fuel_indexer_macros::indexer;
+use fuel_indexer_utils::macros::indexer;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}

--- a/packages/fuel-indexer-utils/Cargo.toml
+++ b/packages/fuel-indexer-utils/Cargo.toml
@@ -12,9 +12,7 @@ description = "Utilities for use in an indexer to be deployed on the Fuel indexe
 [dependencies]
 fuel-indexer-macros = { default-features = false, workspace = true }
 fuel-indexer-plugin = { workspace = true }
-fuel-indexer-schema = { default-features = false, workspace = true }
-fuels = { default-features = false, workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 [features]
-native-execution = ["fuel-indexer-plugin/native-execution", "fuels/default"]
+native-execution = ["fuel-indexer-plugin/native-execution"]

--- a/packages/fuel-indexer-utils/Cargo.toml
+++ b/packages/fuel-indexer-utils/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fuel-indexer-utils"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Utilities for use in an indexer to be deployed on the Fuel indexer"
+
+[dependencies]
+fuel-indexer-macros = { default-features = false, workspace = true }
+fuel-indexer-plugin = { workspace = true }
+fuel-indexer-schema = { default-features = false, workspace = true }
+fuels = { default-features = false, workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+[features]
+native-execution = ["fuel-indexer-plugin/native-execution", "fuels/default"]

--- a/packages/fuel-indexer-utils/src/lib.rs
+++ b/packages/fuel-indexer-utils/src/lib.rs
@@ -1,6 +1,25 @@
-pub use fuel_indexer_macros as macros;
-pub use fuel_indexer_plugin::*;
-pub use fuel_indexer_schema;
-pub use fuels;
+//! # Fuel Indexer Utilities
+//!
+//! ## Quickstart: `prelude`
+//!
+//! You can quickly bootstrap an indexer by using types and traits from the `prelude` module.
+//!
+//! ```no_run
+//! # #[allow(unused)]
+//! use fuel_indexer_utils::prelude::*;
+//! ```
+//!
+//! Examples on how you can use the prelude can be found in
+//! the Hello World indexer example(https://fuellabs.github.io/fuel-indexer/master/examples/hello-world.html).
 
-pub mod utilities;
+mod utilities;
+
+pub mod prelude {
+    pub use crate::utilities::*;
+    pub use fuel_indexer_macros::indexer;
+    pub use fuel_indexer_plugin::prelude::*;
+}
+
+pub mod plugin {
+    pub use fuel_indexer_plugin::*;
+}

--- a/packages/fuel-indexer-utils/src/lib.rs
+++ b/packages/fuel-indexer-utils/src/lib.rs
@@ -1,0 +1,6 @@
+pub use fuel_indexer_macros as macros;
+pub use fuel_indexer_plugin::*;
+pub use fuel_indexer_schema;
+pub use fuels;
+
+pub mod utilities;

--- a/packages/fuel-indexer-utils/src/utilities.rs
+++ b/packages/fuel-indexer-utils/src/utilities.rs
@@ -1,0 +1,37 @@
+use crate::prelude::sha256_digest;
+use crate::prelude::{Bytes32, SizedAsciiString};
+
+pub fn u64_id(d: &[u8; 8]) -> u64 {
+    u64::from_le_bytes(*d)
+}
+
+pub fn first8_bytes_to_u64(data: impl AsRef<[u8]>) -> u64 {
+    let data = sha256_digest(&data);
+    let mut buff = [0u8; 8];
+    buff.copy_from_slice(&data.as_bytes()[..8]);
+    u64_id(&buff)
+}
+
+pub fn first32_bytes_to_bytes32(data: impl AsRef<[u8]>) -> Bytes32 {
+    let data = sha256_digest(&data);
+    let mut buff = [0u8; 32];
+    buff.copy_from_slice(&data.as_bytes()[..32]);
+    Bytes32::from(buff)
+}
+
+pub fn u64_id_from_inputs(id: &[u8; 32], inputs: Vec<u8>) -> u64 {
+    let inputs = [id.to_vec(), inputs].concat();
+    first8_bytes_to_u64(inputs)
+}
+
+pub fn bytes32_from_inputs(id: &[u8; 32], inputs: Vec<u8>) -> Bytes32 {
+    let inputs = [id.to_vec(), inputs].concat();
+    first32_bytes_to_bytes32(inputs)
+}
+
+pub fn trim_sized_ascii_string<const LEN: usize>(s: &SizedAsciiString<LEN>) -> String {
+    let mut s = s.to_string();
+    let n = s.trim_end_matches(' ').len();
+    s.truncate(n);
+    s
+}

--- a/packages/fuel-indexer-utils/src/utilities.rs
+++ b/packages/fuel-indexer-utils/src/utilities.rs
@@ -1,10 +1,12 @@
-use crate::prelude::sha256_digest;
-use crate::prelude::{Bytes32, SizedAsciiString};
+use fuel_indexer_plugin::prelude::sha256_digest;
+use fuel_indexer_plugin::types::{Bytes32, SizedAsciiString};
 
+/// Return a `u64` from a byte array.
 pub fn u64_id(d: &[u8; 8]) -> u64 {
     u64::from_le_bytes(*d)
 }
 
+/// Returns the first eight bytes of data as a `u64`.
 pub fn first8_bytes_to_u64(data: impl AsRef<[u8]>) -> u64 {
     let data = sha256_digest(&data);
     let mut buff = [0u8; 8];
@@ -12,6 +14,7 @@ pub fn first8_bytes_to_u64(data: impl AsRef<[u8]>) -> u64 {
     u64_id(&buff)
 }
 
+/// Returns the first thirty-two bytes of data as a `Bytes32`.
 pub fn first32_bytes_to_bytes32(data: impl AsRef<[u8]>) -> Bytes32 {
     let data = sha256_digest(&data);
     let mut buff = [0u8; 32];
@@ -19,16 +22,19 @@ pub fn first32_bytes_to_bytes32(data: impl AsRef<[u8]>) -> Bytes32 {
     Bytes32::from(buff)
 }
 
+/// Returns a `u64` from a byte vector to be used as an ID for an entity record.
 pub fn u64_id_from_inputs(id: &[u8; 32], inputs: Vec<u8>) -> u64 {
     let inputs = [id.to_vec(), inputs].concat();
     first8_bytes_to_u64(inputs)
 }
 
+/// Returns a `Bytes32` from a byte vector.
 pub fn bytes32_from_inputs(id: &[u8; 32], inputs: Vec<u8>) -> Bytes32 {
     let inputs = [id.to_vec(), inputs].concat();
     first32_bytes_to_bytes32(inputs)
 }
 
+/// Transform a `SizedAsciiString` into a `String` by trimming and truncating.
 pub fn trim_sized_ascii_string<const LEN: usize>(s: &SizedAsciiString<LEN>) -> String {
     let mut s = s.to_string();
     let n = s.trim_end_matches(' ').len();


### PR DESCRIPTION
Closes #867.

### Description

Re-exports `fuel-indexer-{macros, plugin, schema}` under `fuel-indexer-utils`

We will be able to change the `forc-index` defaults when we publish a new version of the `fuel-indexer-utils` crate.

### Testing steps

CI should pass.

### Changelog

[Re-export indexer fuel-indexer-* dependencies under fuel-indexer-utils](https://github.com/FuelLabs/fuel-indexer/commit/285c9ee4b3f4228d302fc12a43aad64c1789755b)
