### PR TITLE
fix: bump default indexer timeout + cleanup transaction creation in DB

### DIFF
--- a/packages/fuel-indexer-api-server/src/uses.rs
+++ b/packages/fuel-indexer-api-server/src/uses.rs
@@ -158,7 +158,7 @@ pub(crate) async fn stop_indexer(
 
     let mut conn = pool.acquire().await?;
 
-    let _ = queries::start_transaction(&mut conn).await?;
+    let _res = queries::start_transaction(&mut conn).await?;
 
     if let Err(e) = queries::remove_indexer(&mut conn, &namespace, &identifier).await {
         queries::revert_transaction(&mut conn).await?;
@@ -192,7 +192,7 @@ pub(crate) async fn revert_indexer(
     }
 
     let mut conn = pool.acquire().await?;
-    let _ = queries::start_transaction(&mut conn).await?;
+    let _res = queries::start_transaction(&mut conn).await?;
 
     let indexer_id = queries::get_indexer_id(&mut conn, &namespace, &identifier).await?;
     let wasm =
@@ -244,7 +244,7 @@ pub(crate) async fn register_indexer_assets(
     if let Some(mut multipart) = multipart {
         let mut conn = pool.acquire().await?;
 
-        let _ = queries::start_transaction(&mut conn).await?;
+        let _res = queries::start_transaction(&mut conn).await?;
 
         while let Some(field) = multipart.next_field().await.unwrap() {
             let name = field.name().unwrap_or("").to_string();

--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -862,6 +862,7 @@ pub async fn get_nonce(
     Ok(Nonce { uid, expiry })
 }
 
+#[cfg_attr(feature = "metrics", metrics)]
 pub async fn remove_latest_assets_for_indexer(
     conn: &mut PoolConnection<Postgres>,
     namespace: &str,

--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -122,4 +122,4 @@ pub const RATE_LIMIT_WINDOW_SIZE: u64 = 5;
 pub const LOG_LEVEL: &str = "info";
 
 /// Maximum amount of time (seconds) that an indexer's `handle_events` function can take before being timed out.
-pub const INDEXER_HANDLER_TIMEOUT: u64 = 2;
+pub const INDEXER_HANDLER_TIMEOUT: u64 = 5;

--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -28,7 +28,10 @@ pub const POSTGRES_PORT: &str = "5432";
 /// Postgres password.
 pub const POSTGRES_PASSWORD: &str = "postgres";
 
+/// Number of failed calls to allow before stopping the indexer.
 pub const INDEX_FAILED_CALLS: usize = 10;
+
+/// Stop indexers that have seen `MAX_EMPTY_BLOCK_REQUESTS`.
 pub const STOP_IDLE_INDEXERS: bool = false;
 
 /// Max body size for GraphQL API requests.

--- a/packages/fuel-indexer/src/database.rs
+++ b/packages/fuel-indexer/src/database.rs
@@ -139,7 +139,7 @@ Do your WASM modules need to be rebuilt?"#,
 
                 self.stashed
                     .as_mut()
-                    .expect("Failed to re-open transaction.")
+                    .expect("(put_object) Failed to re-open transaction.")
             }
         };
 
@@ -159,7 +159,7 @@ Do your WASM modules need to be rebuilt?"#,
 
                 self.stashed
                     .as_mut()
-                    .expect("Failed to re-open transaction.")
+                    .expect("(get_object) Failed to re-open transaction.")
             }
         };
 

--- a/packages/fuel-indexer/src/database.rs
+++ b/packages/fuel-indexer/src/database.rs
@@ -1,5 +1,5 @@
 use crate::ffi;
-use crate::{IndexerError, IndexerResult, Manifest};
+use crate::{IndexerResult, Manifest};
 use fuel_indexer_database::{
     queries, types::IdCol, IndexerConnection, IndexerConnectionPool,
 };
@@ -11,7 +11,7 @@ use wasmer::Instance;
 /// Database for an executor instance, with schema info.
 #[derive(Debug)]
 pub struct Database {
-    pub pool: IndexerConnectionPool,
+    pool: IndexerConnectionPool,
     stashed: Option<IndexerConnection>,
     pub namespace: String,
     pub identifier: String,
@@ -40,28 +40,32 @@ impl Database {
     }
 
     pub async fn start_transaction(&mut self) -> IndexerResult<usize> {
-        let mut conn = self.pool.acquire().await?;
-        let result = queries::execute_query(&mut conn, "BEGIN".into()).await?;
-
+        let conn = self.pool.acquire().await?;
         self.stashed = Some(conn);
-
+        info!("Connection stashed as: {:?}", self.stashed);
+        let conn = self.stashed.as_mut().expect(
+            "No stashed connection for start transaction. Was a transaction started?",
+        );
+        let result = queries::start_transaction(conn).await?;
         Ok(result)
     }
 
     pub async fn commit_transaction(&mut self) -> IndexerResult<usize> {
-        let mut conn = self
+        let conn = self
             .stashed
-            .take()
-            .ok_or(IndexerError::NoTransactionError)?;
-        Ok(queries::execute_query(&mut conn, "COMMIT".into()).await?)
+            .as_mut()
+            .expect("No stashed connection for commit. Was a transaction started?");
+        let res = queries::commit_transaction(conn).await?;
+        Ok(res)
     }
 
     pub async fn revert_transaction(&mut self) -> IndexerResult<usize> {
-        let mut conn = self
+        let conn = self
             .stashed
-            .take()
-            .ok_or(IndexerError::NoTransactionError)?;
-        Ok(queries::execute_query(&mut conn, "ROLLBACK".into()).await?)
+            .as_mut()
+            .expect("No stashed connection for revert. Was a transaction started?");
+        let res = queries::revert_transaction(conn).await?;
+        Ok(res)
     }
 
     fn upsert_query(
@@ -131,17 +135,10 @@ Do your WASM modules need to be rebuilt?"#,
 
         let query_text = self.upsert_query(table, &columns, inserts, updates);
 
-        let conn = match self.stashed.as_mut() {
-            Some(conn) => conn,
-            None => {
-                error!("(put_object) No transaction has been opened.");
-                let _ = self.start_transaction().await.unwrap();
-
-                self.stashed
-                    .as_mut()
-                    .expect("(put_object) Failed to re-open transaction.")
-            }
-        };
+        let conn = self
+            .stashed
+            .as_mut()
+            .expect("No stashed connection for put. Was a transaction started?");
 
         queries::put_object(conn, query_text, bytes)
             .await
@@ -151,17 +148,10 @@ Do your WASM modules need to be rebuilt?"#,
     pub async fn get_object(&mut self, type_id: i64, object_id: u64) -> Option<Vec<u8>> {
         let table = &self.tables[&type_id];
         let query = self.get_query(table, object_id);
-        let conn = match self.stashed.as_mut() {
-            Some(conn) => conn,
-            None => {
-                error!("(get_object) No transaction has been opened.");
-                let _ = self.start_transaction().await.unwrap();
-
-                self.stashed
-                    .as_mut()
-                    .expect("(get_object) Failed to re-open transaction.")
-            }
-        };
+        let conn = self
+            .stashed
+            .as_mut()
+            .expect("No stashed connection for get. Was a transaction started?");
 
         match queries::get_object(conn, query).await {
             Ok(v) => Some(v),


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- PR extends indexer timeout, and tries to re-establish a transaction on `put_object` and `get_object`
- Playground is crashing due to error:
```text

2023-05-26T15:31:15.306379Z  INFO fuel_indexer::ffi: 110: Handling a transaction (>'.')>
2023-05-26T15:31:15.307022Z ERROR fuel_indexer::executor: 562: WasmIndexExecutor handle_events timed out: Elapsed(()).
2023-05-26T15:31:15.307104Z  INFO sqlx::query: INSERT INTO fuel_indexer_test.transaction (id, …; rows affected: 1, rows returned: 0, elapsed: 282.167µs

INSERT INTO
  fuel_indexer_test.transaction (id, block, hash, object)
VALUES
  (
    3991704639109347385,
    7017841000420106850,
    'dd744ec3eccfabfaf991f893d4c20d4e759a8e98cb1da40bce13d0a9a7a6883b',
    $1 :: bytea
  ) ON CONFLICT(id) DO
UPDATE
SET
  block = 7017841000420106850,
  hash = 'dd744ec3eccfabfaf991f893d4c20d4e759a8e98cb1da40bce13d0a9a7a6883b'

2023-05-26T15:31:15.307327Z  INFO fuel_indexer::ffi: 110: Handling a transaction (>'.')>
2023-05-26T15:31:15.307995Z  INFO sqlx::query: ROLLBACK; rows affected: 0, rows returned: 0, elapsed: 850.695µs
thread 'tokio-runtime-worker' panicked at 'No transaction has been opened.', packages/fuel-indexer/src/database.rs:137:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2023-05-26T15:31:15.308113Z ERROR fuel_indexer::executor: 284: Indexer executor failed Elapsed(Elapsed(())), retrying.
```

### Testing steps

- [ ] CI should pass
- [ ] Set `INDEXER_HANDLER_TIMEOUT` to 0
- [ ] Start the service
- [ ] Deploy an indexer
- [ ] You should see timeout errors until `INDEX_FAILED_CALLS` is met
  - This should happen consistently, every time 
  - On master, these actions ☝🏽  will produce this panic

```text
2023-05-26T16:46:22.411967Z ERROR fuel_indexer::executor: 562: WasmIndexExecutor handle_events timed out: Elapsed(()).
2023-05-26T16:46:22.413017Z ERROR fuel_indexer::executor: 284: Indexer executor failed Elapsed(Elapsed(())), retrying.
2023-05-26T16:46:22.413160Z  INFO fuel_indexer::ffi: 110: Processing a block. (>'.')>
thread 'tokio-runtime-worker' panicked at 'No transaction has been opened.', packages/fuel-indexer/src/database.rs:137:14
```

### Changelog

- fix: bump default indexer timeout + cleanup transaction creation in DB
