### PR TITLE
chore: reduce log spam

### DIFF
--- a/packages/fuel-indexer-lib/src/utils.rs
+++ b/packages/fuel-indexer-lib/src/utils.rs
@@ -192,7 +192,10 @@ pub async fn init_logging(config: &IndexerConfig) -> anyhow::Result<()> {
         .unwrap_or("info".to_string());
 
     if !config.verbose {
-        std::env::set_var(RUST_LOG, format!("{level},wasmer_compiler_cranelift=warn"));
+        std::env::set_var(
+            RUST_LOG,
+            format!("{level},wasmer_compiler_cranelift=warn,regalloc=warn,cranelift_codegen=warn"),
+        );
     }
 
     let filter = match env::var_os(RUST_LOG) {

--- a/packages/fuel-indexer-macros/src/indexer.rs
+++ b/packages/fuel-indexer-macros/src/indexer.rs
@@ -279,7 +279,7 @@ fn process_fn_items(
                     let manifest_contract_id = Bech32ContractId::from_str(#contract_id).expect("Failed to parse manifest 'contract_id' as Bech32ContractId");
                     let bech32_id = Bech32ContractId::from(id);
                     if bech32_id != manifest_contract_id {
-                        Logger::info("Not subscribed to this contract. Will skip this receipt event. <('-'<)");
+                        Logger::debug("Not subscribed to this contract. Will skip this receipt event. <('-'<)");
                         continue;
                     }
                 }
@@ -291,7 +291,7 @@ fn process_fn_items(
                 let bech32_id = Bech32ContractId::from(id);
 
                 if !contract_ids.contains(&bech32_id) {
-                    Logger::info("Not subscribed to this contract. Will skip this receipt event. <('-'<)");
+                    Logger::debug("Not subscribed to this contract. Will skip this receipt event. <('-'<)");
                     continue;
                 }
             }
@@ -390,7 +390,7 @@ fn process_fn_items(
                 match sel {
                     #(#abi_selectors)*
                     _ => {
-                        Logger::warn("Unknown selector; check ABI to make sure function outputs match to types");
+                        Logger::debug("Unknown selector; check ABI to make sure function outputs match to types");
                         usize::MAX
                     }
                 }
@@ -400,7 +400,7 @@ fn process_fn_items(
                 match sel {
                     #(#abi_selectors_to_fn_names)*
                     _ => {
-                        Logger::warn("Unknown selector; check ABI to make sure function outputs match to types");
+                        Logger::debug("Unknown selector; check ABI to make sure function outputs match to types");
                         "".to_string()
                     }
                 }
@@ -425,7 +425,7 @@ fn process_fn_items(
                 match ty_id {
                     #(#decoders),*
                     _ => {
-                        Logger::warn("Unknown type ID; check ABI to make sure types are correct.");
+                        Logger::debug("Unknown type ID; check ABI to make sure types are correct.");
                     },
                 }
             }
@@ -442,14 +442,14 @@ fn process_fn_items(
             pub fn decode_logdata(&mut self, rb: usize, data: Vec<u8>) {
                 match rb {
                     #(#log_type_decoders),*
-                    _ => Logger::warn("Unknown logged type ID; check ABI to make sure that logged types are correct.")
+                    _ => Logger::debug("Unknown logged type ID; check ABI to make sure that logged types are correct.")
                 }
             }
 
             pub fn decode_messagedata(&mut self, type_id: u64, data: Vec<u8>) {
                 match type_id {
                     #(#message_types_decoders),*
-                    _ => Logger::warn("Unknown message type ID; check ABI to make sure that message types are correct.")
+                    _ => Logger::debug("Unknown message type ID; check ABI to make sure that message types are correct.")
                 }
             }
 

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.stderr
@@ -64,11 +64,11 @@ error[E0412]: cannot find type `BlockData` in this scope
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::BlockData;
+2  + use fuel_indexer_plugin::prelude::BlockData;
    |
-2  | use fuel_indexer_types::fuel::BlockData;
+2  + use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::plugin::prelude::BlockData;
+2  + use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0422]: cannot find struct, variant or union type `BlockData` in this scope
@@ -79,11 +79,11 @@ error[E0422]: cannot find struct, variant or union type `BlockData` in this scop
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::BlockData;
+2  + use fuel_indexer_plugin::prelude::BlockData;
    |
-2  | use fuel_indexer_types::fuel::BlockData;
+2  + use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::plugin::prelude::BlockData;
+2  + use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0433]: failed to resolve: use of undeclared crate or module `fuel`
@@ -98,11 +98,11 @@ help: there is a crate or module with a similar name
    |                     ~~~~~
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::fuel::TransactionStatus;
+2  + use fuel_indexer_plugin::prelude::fuel::TransactionStatus;
    |
-2  | use fuel_indexer_types::fuel::TransactionStatus;
+2  + use fuel_indexer_types::fuel::TransactionStatus;
    |
-2  | use fuel_indexer_utils::plugin::prelude::fuel::TransactionStatus;
+2  + use fuel_indexer_utils::plugin::prelude::fuel::TransactionStatus;
    |
 help: if you import `TransactionStatus`, refer to it directly
    |
@@ -118,13 +118,13 @@ error[E0433]: failed to resolve: use of undeclared type `Transaction`
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::fuel::Transaction;
+2  + use fuel_indexer_plugin::prelude::fuel::Transaction;
    |
-2  | use fuel_indexer_types::fuel::Transaction;
+2  + use fuel_indexer_types::fuel::Transaction;
    |
-2  | use fuel_indexer_utils::plugin::prelude::fuel::Transaction;
+2  + use fuel_indexer_utils::plugin::prelude::fuel::Transaction;
    |
-2  | use fuels::prelude::Transaction;
+2  + use fuels::prelude::Transaction;
    |
      and 2 other candidates
 
@@ -136,11 +136,11 @@ error[E0425]: cannot find function `serialize` in this scope
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_lib::utils::serialize;
+2  + use fuel_indexer_lib::utils::serialize;
    |
-2  | use fuel_indexer_plugin::serialize;
+2  + use fuel_indexer_plugin::serialize;
    |
-2  | use fuel_indexer_utils::plugin::serialize;
+2  + use fuel_indexer_utils::plugin::serialize;
    |
 
 error[E0425]: cannot find function `handle_events` in this scope

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.stderr
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_schema_arg_is_invalid.stderr
@@ -64,11 +64,11 @@ error[E0412]: cannot find type `BlockData` in this scope
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::BlockData;
+2  + use fuel_indexer_plugin::prelude::BlockData;
    |
-2  | use fuel_indexer_types::fuel::BlockData;
+2  + use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::plugin::prelude::BlockData;
+2  + use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0422]: cannot find struct, variant or union type `BlockData` in this scope
@@ -79,11 +79,11 @@ error[E0422]: cannot find struct, variant or union type `BlockData` in this scop
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::BlockData;
+2  + use fuel_indexer_plugin::prelude::BlockData;
    |
-2  | use fuel_indexer_types::fuel::BlockData;
+2  + use fuel_indexer_types::fuel::BlockData;
    |
-2  | use fuel_indexer_utils::plugin::prelude::BlockData;
+2  + use fuel_indexer_utils::plugin::prelude::BlockData;
    |
 
 error[E0433]: failed to resolve: use of undeclared type `Consensus`
@@ -94,11 +94,11 @@ error[E0433]: failed to resolve: use of undeclared type `Consensus`
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::fuel::Consensus;
+2  + use fuel_indexer_plugin::prelude::fuel::Consensus;
    |
-2  | use fuel_indexer_types::fuel::Consensus;
+2  + use fuel_indexer_types::fuel::Consensus;
    |
-2  | use fuel_indexer_utils::plugin::prelude::fuel::Consensus;
+2  + use fuel_indexer_utils::plugin::prelude::fuel::Consensus;
    |
 
 error[E0433]: failed to resolve: use of undeclared crate or module `fuel`
@@ -113,11 +113,11 @@ help: there is a crate or module with a similar name
    |                     ~~~~~
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::fuel::TransactionStatus;
+2  + use fuel_indexer_plugin::prelude::fuel::TransactionStatus;
    |
-2  | use fuel_indexer_types::fuel::TransactionStatus;
+2  + use fuel_indexer_types::fuel::TransactionStatus;
    |
-2  | use fuel_indexer_utils::plugin::prelude::fuel::TransactionStatus;
+2  + use fuel_indexer_utils::plugin::prelude::fuel::TransactionStatus;
    |
 help: if you import `TransactionStatus`, refer to it directly
    |
@@ -133,13 +133,13 @@ error[E0433]: failed to resolve: use of undeclared type `Transaction`
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_plugin::prelude::fuel::Transaction;
+2  + use fuel_indexer_plugin::prelude::fuel::Transaction;
    |
-2  | use fuel_indexer_types::fuel::Transaction;
+2  + use fuel_indexer_types::fuel::Transaction;
    |
-2  | use fuel_indexer_utils::plugin::prelude::fuel::Transaction;
+2  + use fuel_indexer_utils::plugin::prelude::fuel::Transaction;
    |
-2  | use fuels::prelude::Transaction;
+2  + use fuels::prelude::Transaction;
    |
      and 2 other candidates
 
@@ -151,11 +151,11 @@ error[E0425]: cannot find function `serialize` in this scope
   |
 help: consider importing one of these items
    |
-2  | use fuel_indexer_lib::utils::serialize;
+2  + use fuel_indexer_lib::utils::serialize;
    |
-2  | use fuel_indexer_plugin::serialize;
+2  + use fuel_indexer_plugin::serialize;
    |
-2  | use fuel_indexer_utils::plugin::serialize;
+2  + use fuel_indexer_utils::plugin::serialize;
    |
 
 error[E0425]: cannot find function `handle_events` in this scope

--- a/packages/fuel-indexer/src/commands/run.rs
+++ b/packages/fuel-indexer/src/commands/run.rs
@@ -49,9 +49,6 @@ pub async fn exec(args: IndexerArgs) -> anyhow::Result<()> {
         }
         None => {
             service.register_indexers_from_registry().await?;
-            info!(
-                    "✨ ✨ GraphQL Playground at: http://localhost:29987/api/playground/:namespace/:identifier"
-                );
         }
     }
 

--- a/packages/fuel-indexer/src/database.rs
+++ b/packages/fuel-indexer/src/database.rs
@@ -5,7 +5,7 @@ use fuel_indexer_database::{
 };
 use fuel_indexer_schema::FtColumn;
 use std::collections::HashMap;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 use wasmer::Instance;
 
 /// Database for an executor instance, with schema info.
@@ -46,7 +46,7 @@ impl Database {
     pub async fn start_transaction(&mut self) -> IndexerResult<usize> {
         let conn = self.pool.acquire().await?;
         self.stashed = Some(conn);
-        info!("Connection stashed as: {:?}", self.stashed);
+        debug!("Connection stashed as: {:?}", self.stashed);
         let conn = self.stashed.as_mut().expect(
             "No stashed connection for start transaction. Was a transaction started?",
         );


### PR DESCRIPTION
### Description

When debugging a separate issue with full blocks, it was quite difficult to parse through the output as certain macro and database logs were printed for each contract and transaction in the block. As such, I elected to place said logs at the `DEBUG` log level so that users could more easily find the logs from their indexer modules.

### Testing steps

CI should pass. You can see the debug logs by appending `RUST_LOG="debug"` to the beginning of `fuel-indexer run`.

### Changelog
- [Move 'unknown X; check Y' type logs to debug; move stash conn log to debug](https://github.com/FuelLabs/fuel-indexer/commit/2a6c7508897d124cb4894d55e8005f06f37d7bc9)
- [Do not print playground link when starting without a manifest](https://github.com/FuelLabs/fuel-indexer/commit/ca6710d9499215fd6d0015cd9cc56979fe38c6a6)
