### PR TITLE
fix: remove `fuel-indexer-utils` from `fuel-indexer-macros` Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,7 +3071,6 @@ dependencies = [
  "fuel-indexer-plugin",
  "fuel-indexer-schema",
  "fuel-indexer-types",
- "fuel-indexer-utils",
  "fuels",
  "fuels-code-gen",
  "fuels-macros",

--- a/packages/fuel-indexer-macros/Cargo.toml
+++ b/packages/fuel-indexer-macros/Cargo.toml
@@ -31,7 +31,6 @@ syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 fuel-indexer-plugin = { workspace = true }
-fuel-indexer-utils = { workspace = true }
 fuels-macros = { version = "0.40.0", default-features = false }
 fuels-types = { version = "0.40.0", default-features = false }
 serde = { workspace = true }


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

Somehow `fuel-indexer-utils` made it back into the `Cargo.toml` as we pushed changes.

### Testing steps

CI should pass.
