### PR TITLE
ci: streamline crate publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,8 +542,6 @@ jobs:
   # TODO: publish these in parallel
   publish:
     needs:
-      - publish-fuel-indexer-binaries
-      - publish-docker-image
       - set-env-vars
     if: needs.set-env-vars.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #971.

### Description

Removes successful binary and Docker image publishing as dependencies for crate publishing.

### Testing steps

CI should pass.

### Changelog

[Remove dependency on binary and Docker image publish for crate publis…](https://github.com/FuelLabs/fuel-indexer/commit/87bd2cacd900d5041f8229c33bc939e4625fab96)
