### PR TITLE
fix: various auth updates

### DIFF
--- a/packages/fuel-indexer-api-server/src/models.rs
+++ b/packages/fuel-indexer-api-server/src/models.rs
@@ -53,11 +53,6 @@ impl Claims {
         &self.sub
     }
 
-    /// The issuer of the claims.
-    pub fn iss(&self) -> &str {
-        &self.iss
-    }
-
     /// Like `Claims::new`, but with `iat` and `exp` values that indicate
     /// the claims have yet to be authenticated.
     pub fn unauthenticated() -> Self {

--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -430,8 +430,6 @@ pub async fn register_indexer(
     pubkey: Option<&str>,
     created_at: DateTime<Utc>,
 ) -> sqlx::Result<RegisteredIndexer> {
-    println!(">> PUBKEY 1st: {pubkey:?}");
-
     if let Some(index) = get_indexer(conn, namespace, identifier).await? {
         return Ok(index);
     }
@@ -900,7 +898,6 @@ pub async fn indexer_owned_by(
     identifier: &str,
     pubkey: &str,
 ) -> sqlx::Result<()> {
-    println!(">> PUBKEY: {pubkey}");
     let row = sqlx::query(&format!("SELECT COUNT(*)::int FROM index_registry WHERE namespace = '{namespace}' AND identifier = '{identifier}' AND pubkey = '{pubkey}'"))
         .fetch_one(conn)
         .await?;

--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -430,6 +430,8 @@ pub async fn register_indexer(
     pubkey: Option<&str>,
     created_at: DateTime<Utc>,
 ) -> sqlx::Result<RegisteredIndexer> {
+    println!(">> PUBKEY 1st: {pubkey:?}");
+
     if let Some(index) = get_indexer(conn, namespace, identifier).await? {
         return Ok(index);
     }
@@ -898,11 +900,12 @@ pub async fn indexer_owned_by(
     identifier: &str,
     pubkey: &str,
 ) -> sqlx::Result<()> {
-    let row = sqlx::query(&format!("SELECT COUNT(*) FROM index_registry WHERE namespace = '{namespace}' AND identifier = '{identifier}' AND pubkey = '{pubkey}'"))
+    println!(">> PUBKEY: {pubkey}");
+    let row = sqlx::query(&format!("SELECT COUNT(*)::int FROM index_registry WHERE namespace = '{namespace}' AND identifier = '{identifier}' AND pubkey = '{pubkey}'"))
         .fetch_one(conn)
         .await?;
 
-    let count: i32 = row.get(0);
+    let count = row.get::<i32, usize>(0);
     if count == 1 {
         return Ok(());
     }


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- Whilst deploying an indexer to the playground I noticed authentication was buggy
- This PR fixes 3 issues:
  - Removes auth from `register_indexer_assets`
  - Fixes sqlx type issue in `queries::indexer_owned_by`
  - Uses the public key in `index_registry` (not the issuer)
- This was previously unnoticed cause I never run the indexer locally with auth (will change that going forward)
- Obviously an integration test would help here. Happy for anyone to open that PR ;) 

### Testing steps

- [ ] You will need two accounts in your `forc-wallet` (account index `0` and account index `1`)
- [ ] Start the service with auth enabled on beta3
```bash
cargo run --bin fuel-indexer -- run --run-migrations --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --auth-enabled --auth-strategy jwt --jwt-secret abcdefg --jwt-issuer FuelLabs
```
- [ ] Authenticate using your first account `forc index auth`
- [ ] Use this token to deploy an indexer `forc index deploy --auth $TOKEN1`
  - On master this fails due to the SQLx type issue _and_ the unnecessary authentication check
- [ ] Authenticate using your second account `forc index auth`
- [ ] Use this token to try to remove the indexer your just deployed `forc index remove --auth $TOKEN2`
  - This will fail as `Unauthorized`
 

### Changelog

- fix: various auth updates
