### PR TITLE
fix: don't panic on failed put_object

### DIFF
--- a/packages/fuel-indexer/src/database.rs
+++ b/packages/fuel-indexer/src/database.rs
@@ -168,7 +168,7 @@ Do your WASM modules need to be rebuilt?"#,
         match queries::get_object(conn, query).await {
             Ok(v) => Some(v),
             Err(e) => {
-                error!("Failed to put object: {:?}", e);
+                error!("Failed to get object: {:?}", e);
                 None
             }
         }

--- a/packages/fuel-indexer/src/database.rs
+++ b/packages/fuel-indexer/src/database.rs
@@ -152,9 +152,9 @@ Do your WASM modules need to be rebuilt?"#,
             .as_mut()
             .expect("No stashed connection for put. Was a transaction started?");
 
-        queries::put_object(conn, query_text, bytes)
-            .await
-            .expect("Failed to put object.");
+        if let Err(e) = queries::put_object(conn, query_text, bytes).await {
+            error!("Failed to put object: {:?}", e);
+        }
     }
 
     pub async fn get_object(&mut self, type_id: i64, object_id: u64) -> Option<Vec<u8>> {
@@ -167,7 +167,10 @@ Do your WASM modules need to be rebuilt?"#,
 
         match queries::get_object(conn, query).await {
             Ok(v) => Some(v),
-            Err(_e) => None,
+            Err(e) => {
+                error!("Failed to put object: {:?}", e);
+                None
+            }
         }
     }
 


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- If for whatever reason `put_object` fails, we currently panic
- We should allow for the failure gracefully
- Error is:
```text
2023-06-07T01:01:50.452282Z  INFO sqlx::query: INSERT INTO fuel_indexer_test.transaction (id, …; rows affected: 1, rows returned: 0, elapsed: 1.063ms

INSERT INTO
  fuel_indexer_test.transaction (id, block, hash, object)
VALUES
  (
    7005739969560339248,
    3761688992633087027,
    '18c478c3b5bbc51ba76bc3372b4593599295d591f885bf3ec354b3e14a492444',
    $1 :: bytea
  ) ON CONFLICT(id) DO
UPDATE
SET
  id = 7005739969560339248,
  block = 3761688992633087027,
  hash = '18c478c3b5bbc51ba76bc3372b4593599295d591f885bf3ec354b3e14a492444'

thread 'tokio-runtime-worker' panicked at 'Failed to put object.: Database(PgDatabaseError { severity: Error, code: "23503", message: "insert or update on table \"transaction\" violates foreign key constraint \"fk_transaction_block__block_id\"", detail: Some("Key (block)=(3761688992633087027) is not present in table \"block\"."), hint: None, position: None, where: None, schema: Some("fuel_indexer_test"), table: Some("transaction"), column: None, data_type: None, constraint: Some("fk_transaction_block__block_id"), file: Some("ri_triggers.c"), line: Some(2539), routine: Some("ri_ReportViolation") })', packages/fuel-indexer/src/database.rs:157:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Testing steps

- N/A

### Changelog

- fix: don't panic on failed put_object
