### PR TITLE
enhancement: add schema cache to API server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "uluru",
 ]
 
 [[package]]
@@ -7662,6 +7663,15 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]

--- a/packages/fuel-indexer-api-server/Cargo.toml
+++ b/packages/fuel-indexer-api-server/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4", features = ["limit", "buffer"] }
 tower-http = { version = "0.3", features = ["fs", "trace", "cors", "limit"] }
 tracing = { workspace = true }
+uluru = "3.0"
 
 [features]
 default = ["metrics"]

--- a/packages/fuel-indexer-schema/src/db/manager.rs
+++ b/packages/fuel-indexer-schema/src/db/manager.rs
@@ -50,7 +50,6 @@ impl SchemaManager {
         namespace: &str,
         identifier: &str,
     ) -> IndexerSchemaDbResult<Schema> {
-        // TODO: might be nice to cache this data in server?
         Schema::load_from_db(&self.pool, namespace, identifier).await
     }
 }

--- a/packages/fuel-indexer-schema/src/db/tables.rs
+++ b/packages/fuel-indexer-schema/src/db/tables.rs
@@ -526,9 +526,6 @@ pub struct Schema {
 
 impl Schema {
     /// Load a `Schema` from the database.
-
-    // TODO: Might be expensive to always load this from the DB each time. Maybe
-    // we can cache and stash this somewhere?
     pub async fn load_from_db(
         pool: &IndexerConnectionPool,
         namespace: &str,


### PR DESCRIPTION
### Description

Adds an LRU cache for `Schema`s that have been loaded from the DB.

### Testing steps

CI should pass.

#### Manual Testing
Compare the logs and speed of loading the schema between develop and this branch. This branch should be noticeably faster.

### Changelog

- [Add schema cache to API server](https://github.com/FuelLabs/fuel-indexer/commit/613f79ed576253e5c60cb5a9753a205afacb65b4)
