### PR TITLE
enhancement: add instantiation helpers for union types

### DIFF
--- a/examples/fuel-explorer/fuel-explorer/schema/fuel_explorer.schema.graphql
+++ b/examples/fuel-explorer/fuel-explorer/schema/fuel_explorer.schema.graphql
@@ -237,7 +237,7 @@ type Block {
   id: ID!
   block_id: BlockId!
   header: Header!
-  # consensus: Consensus!
+  consensus: Consensus!
   #   transactions: [TransactionIdFragment]!
 }
 

--- a/examples/fuel-explorer/fuel-explorer/src/lib.rs
+++ b/examples/fuel-explorer/fuel-explorer/src/lib.rs
@@ -99,44 +99,18 @@ impl From<fuel::ClientPanicReason> for PanicReason {
 impl From<fuel::Consensus> for Consensus {
     fn from(consensus: fuel::Consensus) -> Self {
         match consensus {
-            fuel::Consensus::Genesis(g) => {
-                // TODO: Create UID here.
-                let id = 1;
-                Self {
-                    id,
-                    label: Some(ConsensusLabel::Genesis.into()),
-                    chain_config_hash: Some(g.chain_config_hash),
-                    coins_root: Some(g.coins_root),
-                    contracts_root: Some(g.contracts_root),
-                    messages_root: Some(g.messages_root),
-                    signature: None,
-                }
-            }
+            fuel::Consensus::Genesis(g) => Consensus::from(Genesis::new(
+                g.chain_config_hash,
+                g.coins_root,
+                g.contracts_root,
+                g.messages_root,
+                ConsensusLabel::Genesis.into(),
+            )),
             fuel::Consensus::PoA(poa) => {
-                // TODO: Create UID here.
-                let id = 1;
-                Self {
-                    id,
-                    label: Some(ConsensusLabel::PoA.into()),
-                    chain_config_hash: None,
-                    coins_root: None,
-                    contracts_root: None,
-                    messages_root: None,
-                    signature: Some(poa.signature),
-                }
+                Consensus::from(PoA::new(poa.signature, ConsensusLabel::PoA.into()))
             }
             fuel::Consensus::Unknown => {
-                // TODO: Create UID here.
-                let id = 1;
-                Self {
-                    id,
-                    label: Some(ConsensusLabel::Unknown.into()),
-                    chain_config_hash: None,
-                    coins_root: None,
-                    contracts_root: None,
-                    messages_root: None,
-                    signature: None,
-                }
+                Consensus::from(Unknown::new(ConsensusLabel::Unknown.into()))
             }
         }
     }
@@ -984,7 +958,7 @@ pub mod explorer_index {
             id,
             block_id: block_data.header.id,
             header: header.id,
-            // consensus: consensus.id,
+            consensus: consensus.id,
         };
 
         // Save partial block

--- a/packages/fuel-indexer-macros/src/helpers.rs
+++ b/packages/fuel-indexer-macros/src/helpers.rs
@@ -77,6 +77,7 @@ lazy_static! {
     ]);
 }
 
+/// Parameters for generating traits for different `TypeKind` variants.
 pub enum TraitGenerationParameters<'a> {
     ObjectType {
         strct: Ident,
@@ -614,6 +615,7 @@ pub fn generate_struct_new_method_impl(
     }
 }
 
+/// Generate `From` trait implementations for each member type in a union.
 pub fn generate_from_traits_for_union(
     schema: &ParsedGraphQLSchema,
     union_obj: &UnionType,
@@ -640,6 +642,8 @@ pub fn generate_from_traits_for_union(
                 set
             });
 
+        // Member fields that match with union fields are checked for optionality
+        // and are assigned accordingly.
         let common_fields = union_field_set.intersection(&member_fields).fold(
             quote! {},
             |acc, common_field| {
@@ -670,6 +674,7 @@ pub fn generate_from_traits_for_union(
             },
         );
 
+        // Any member fields that don't have a match with union fields should be assigned to None.
         let disjoint_fields = union_field_set.difference(&member_fields).fold(
             quote! {},
             |acc, disjoint_field| {

--- a/packages/fuel-indexer-macros/src/schema.rs
+++ b/packages/fuel-indexer-macros/src/schema.rs
@@ -633,15 +633,15 @@ fn process_type_def(
 
             let object_trait_impls = generate_object_trait_impls(
                 ident.clone(),
-                strct_fields.clone(),
+                strct_fields,
                 type_id,
                 field_extractors,
                 from_row,
                 to_row,
                 schema.is_native,
                 TraitGenerationParameters::UnionType {
-                    schema: &schema,
-                    union_obj: &obj,
+                    schema,
+                    union_obj: obj,
                     union_ident: ident,
                     union_field_set,
                 },

--- a/packages/fuel-indexer-schema/src/parser.rs
+++ b/packages/fuel-indexer-schema/src/parser.rs
@@ -40,6 +40,9 @@ pub struct ParsedGraphQLSchema {
     /// A mapping of fully qualified field names to their field types.
     pub field_type_mappings: HashMap<String, String>,
 
+    // A mapping of fully qualified field names to their respective optionalities.
+    pub field_type_optionality: HashMap<String, bool>,
+
     /// All unique names of scalar types in the schema.
     pub scalar_names: HashSet<String>,
 
@@ -64,6 +67,7 @@ impl Default for ParsedGraphQLSchema {
             parsed_type_names: HashSet::new(),
             field_type_mappings: HashMap::new(),
             object_field_mappings: HashMap::new(),
+            field_type_optionality: HashMap::new(),
             scalar_names: HashSet::new(),
             ast,
         }
@@ -90,6 +94,7 @@ impl ParsedGraphQLSchema {
         let mut union_names = HashSet::new();
         let mut virtual_type_names = HashSet::new();
         let mut field_type_mappings = HashMap::new();
+        let mut field_type_optionality = HashMap::new();
 
         // Parse _everything_ in the GraphQL schema
         if let Some(schema) = schema {
@@ -121,6 +126,10 @@ impl ParsedGraphQLSchema {
 
                                 parsed_type_names.insert(field_name.clone());
                                 field_mapping.insert(field_name, field_typ_name.clone());
+                                field_type_optionality.insert(
+                                    field_id.clone(),
+                                    field.node.ty.node.nullable,
+                                );
                                 field_type_mappings.insert(field_id, field_typ_name);
                             }
                             object_field_mappings.insert(obj_name, field_mapping);
@@ -197,6 +206,7 @@ impl ParsedGraphQLSchema {
             field_type_mappings,
             scalar_names,
             ast,
+            field_type_optionality,
         })
     }
 


### PR DESCRIPTION
### Description

This PR adds instantiation helpers to GraphQL union types.

### Testing steps

CI should pass. There aren't any real testing steps here; as a proof, in the `fuel-explorer` example, the instantiation for the `Consensus` type has been changed to leverage the new instantiation functionality implemented by this PR. Feel free to make the same changes on `develop` and verify that they do not work there and that the changes *do* work on this branch.

### Changelog

- Add `From` trait impls to each member of a union type
-- Add `generate_from_traits_for_union` helper
-- Combine instantiation trait generators into the flow of `generate_object_trait_impls`
- Add `field_type_optionality` to `ParsedGraphQLSchema` to easily determine field nullability
