### PR TITLE
fix: update default indexer schema type

### DIFF
--- a/plugins/forc-index/src/utils/defaults.rs
+++ b/plugins/forc-index/src/utils/defaults.rs
@@ -199,7 +199,7 @@ pub mod {indexer_name}_index_mod {{
 pub fn default_indexer_schema() -> String {
     r#"type Block {
     id: ID!
-    height: UInt8!
+    height: UInt4!
     hash: Bytes32! @unique
 }
 


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- Default indexer was not updated properly with new block height type

### Testing steps

- `forc index new && forc index build`

### Changelog

- fix: update default indexer schema type
