### PR TITLE
forc index kill: terminate or kill

### DIFF
--- a/plugins/forc-index/src/commands/kill.rs
+++ b/plugins/forc-index/src/commands/kill.rs
@@ -8,6 +8,9 @@ pub struct Command {
     /// Port on which the process is listening.
     #[clap(long, default_value = defaults::GRAPHQL_API_PORT, help = "Port at which to detect indexer service API is running.")]
     pub port: String,
+    /// Terminate or kill.
+    #[clap(short = '9')]
+    pub kill: bool,
 }
 
 pub fn exec(command: Command) -> anyhow::Result<()> {

--- a/plugins/forc-index/src/ops/forc_index_kill.rs
+++ b/plugins/forc-index/src/ops/forc_index_kill.rs
@@ -5,12 +5,12 @@ use tracing::info;
 pub fn kill(command: KillCommand) -> anyhow::Result<()> {
     let port_number = command.port.parse::<u16>().unwrap();
 
-    kill_process_by_port(port_number)?;
+    kill_process_by_port(port_number, command.kill)?;
 
     Ok(())
 }
 
-fn kill_process_by_port(port: u16) -> anyhow::Result<()> {
+fn kill_process_by_port(port: u16, kill: bool) -> anyhow::Result<()> {
     let output = Command::new("lsof")
         .arg("-ti")
         .arg(format!(":{}", port))
@@ -29,16 +29,18 @@ fn kill_process_by_port(port: u16) -> anyhow::Result<()> {
         .parse::<i32>()
         .map_err(|e| anyhow::anyhow!("❌ Failed to parse PID: {}", e))?;
 
-    Command::new("kill")
-        .arg("-9")
-        .arg(pid.to_string())
-        .status()
-        .map_err(|e| anyhow::anyhow!("❌ Failed to kill process: {}", e))?;
+    let signal = if kill { "kill" } else { "terminate" };
 
-    info!(
-        "✅ Sucessfully killed process {} listening on port {}",
-        pid, port
-    );
+    let mut cmd = Command::new("kill");
+    if kill {
+        cmd.arg("-9");
+    }
+    cmd.arg(pid.to_string())
+        .status()
+        .map_err(|e| anyhow::anyhow!("❌ Failed to {signal} process: {}", e))?;
+
+    let signal = if kill { "killed" } else { "terminated" };
+    info!("✅ Sucessfully {signal} process {pid} listening on port {port}");
 
     Ok(())
 }


### PR DESCRIPTION
### Description

This PR changes the default behavior of `forc index kill` to send the `TERM` signal and adds a `-9` flag to send the `KILL` signal instead. This way, the behavior matches the Linux `kill` command.

The motivation for this is that `fuel-indexer` may be running with `--embedded-database`, in which case the current behavior of `forc index kill` won't allow `fuel-indexer` to shut down the embedded `postgres` process—it will be left alive.

If the user attempts to start `fuel-indexer` again with `--embedded` database, they will get an error.

### Testing steps

Please provide the _exact_ testing steps for the reviewer(s) if this PR requires testing.

### Changelog

Please add a neat Changelog info here according to our [Contributor's Guide](./CONTRIBUTING.md).
