### PR TITLE
use tokio::runtime::Handle::current() in get_object and put_object

### DIFF
--- a/packages/fuel-indexer/src/ffi.rs
+++ b/packages/fuel-indexer/src/ffi.rs
@@ -119,8 +119,7 @@ fn get_object(env: &IndexEnv, type_id: i64, ptr: u32, len_ptr: u32) -> u32 {
 
     let id = get_object_id(mem, ptr);
 
-    // TODO: stash this thing somewhere??
-    let rt = tokio::runtime::Runtime::new().expect("Could not create tokio runtime.");
+    let rt = tokio::runtime::Handle::current();
     let bytes = rt.block_on(async { env.db.lock().await.get_object(type_id, id).await });
 
     if let Some(bytes) = bytes {
@@ -157,8 +156,7 @@ fn put_object(env: &IndexEnv, type_id: i64, ptr: u32, len: u32) {
 
     let columns: Vec<FtColumn> = bincode::deserialize(&bytes).expect("Serde error.");
 
-    // TODO: stash this??
-    let rt = tokio::runtime::Runtime::new().expect("Could not create tokio runtime.");
+    let rt = tokio::runtime::Handle::current();
     rt.block_on(async {
         env.db
             .lock()


### PR DESCRIPTION
### Description

Since `get_object` and `put_object` are called inside the context of a `tokio` runtime, we can reuse it with `tokio::runtime::Handle::current()`

This _seems_ to improve both the stability and performance when running the indexer on my laptop. Also, we shouldn't ever see this anymore:
```
2023-07-03T16:09:43.068240Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.068544Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.068953Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.069532Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.073578Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.073912Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.074177Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.074841Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.075160Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.075641Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.075953Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.076320Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.076783Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.077044Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.077395Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.077696Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
2023-07-03T16:09:43.078004Z ERROR fuel_indexer::database: 162: Failed to put object: Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
```

### Testing steps

```
cargo run -p fuel-indexer -- run --run-migrations --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --manifest packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml --replace-indexer
```

### Changelog

* get current `tokio` runtime with `tokio::runtime::Handle::current()`
