### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # Don't add the generated MDBook artifacts
 docs/book/
 
+.DS_Store
+
 .dockerignore
 *.swp
 *.db


### PR DESCRIPTION
### Description

I opened `fuel-indexer` in Finder, leaving some `.DS_Store` files around. We may as well add them to `.gitignore`.