### PR TITLE
chore: add docker multiplatform

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,7 @@
+[registries.crates-io]
+protocol = "sparse"
+
+# This is needed to enable cross-platform docker builds, as cargo doesn't use the correct linker sometimes:
+# https://github.com/rust-lang/cargo/issues/4133
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
   publish-docker-image:
     needs:
       - set-env-vars
-#    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER == 'true'
+    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
   publish-docker-image:
     needs:
       - set-env-vars
-    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER == 'true'
+#    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -398,10 +398,11 @@ jobs:
           username: fuellabs
           password: '${{ secrets.DOCKER_IO_READ_ONLY_TOKEN }}'
       - name: Build and push the image to ghcr.io
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: deployment/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: '${{ steps.meta.outputs.tags }}'
           labels: '${{ steps.meta.outputs.labels }}'

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,7 +1,12 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.69.0 AS chef
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+FROM --platform=$BUILDPLATFORM rust:1.69.0 AS chef
 
+ARG TARGETPLATFORM
+RUN cargo install cargo-chef
 WORKDIR /build/
+
+COPY --from=xx / /
 
 # hadolint ignore=DL3008
 RUN apt-get update -y && \
@@ -14,12 +19,14 @@ RUN apt-get update -y && \
     libclang-dev \
     lld \
     llvm \
-    pkg-config \
-    && apt-get clean
+    pkg-config
+   
+RUN xx-apt-get update && \
+    xx-apt-get install -y binutils g++ libc6-dev && \
+    apt-get clean
 
 FROM chef AS planner
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -30,13 +37,18 @@ COPY --from=planner /build/recipe.json recipe.json
 
 ENV SQLX_OFFLINE=true
 
-RUN cargo chef cook --release -p fuel-indexer --features fuel-core-lib --recipe-path recipe.json
-RUN cargo chef cook --release -p fuel-indexer-api-server --features fuel-core-lib --recipe-path recipe.json
+RUN xx-cargo chef cook --release -p fuel-indexer -p fuel-indexer-api-server --features fuel-core-lib --recipe-path recipe.json
 COPY . .
-RUN cargo build --release -p fuel-indexer -p fuel-indexer-api-server --features fuel-core-lib --all-targets
+RUN xx-cargo build --release -p fuel-indexer -p fuel-indexer-api-server --features fuel-core-lib \
+    && xx-verify ./target/$(xx-cargo --print-target-triple)/release/fuel-indexer \
+    && xx-verify ./target/$(xx-cargo --print-target-triple)/release/fuel-indexer-api-server \
+    && mv ./target/$(xx-cargo --print-target-triple)/release/fuel-indexer ./target/release/fuel-indexer \
+    && mv ./target/$(xx-cargo --print-target-triple)/release/fuel-indexer-api-server ./target/release/fuel-indexer-api-server \
+    && mv ./target/$(xx-cargo --print-target-triple)/release/fuel-indexer.d ./target/release/fuel-indexer.d \
+    && mv ./target/$(xx-cargo --print-target-triple)/release/fuel-indexer-api-server.d ./target/release/fuel-indexer-api-server.d
 
 # Stage 3: Run
-FROM ubuntu:22.04 AS run
+FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS run
 
 WORKDIR /root/
 

--- a/examples/fuel-explorer/README.md
+++ b/examples/fuel-explorer/README.md
@@ -10,12 +10,6 @@ The Fuel block explorer.
 
 Spin up containers for the Postgres database server and the indexer service.
 
-> IMPORTANT: If you're on a platform using Apple Silicon, you will have to build your image locally, rather than pulling an image from the image registry. We have [an open issue](https://github.com/FuelLabs/fuel-indexer/issues/578) to add support for ARM Arch64 images.
->
-> In order to use a local image you can just:
->   1. Build your image locally: `docker build -t fuel-indexer/local:latest -f deployment/Dockerfile .`
->   2. Update your `docker-compose.yaml` file with `image: fuel-indexer/local:latest` for the `fuel-indexer` service.
->
 > IMPORTANT: Ensure that any local Postgres instance on port 5432 is stopped.
 
 ```bash

--- a/examples/fuel-explorer/docker-compose.yaml
+++ b/examples/fuel-explorer/docker-compose.yaml
@@ -17,7 +17,6 @@ services:
       start_period: 80s
   fuel-indexer:
     image: ghcr.io/fuellabs/fuel-indexer:latest
-    platform: linux/amd64
     command: bash -c "sleep 2 && ./fuel-indexer run --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0 --run-migrations"
     ports:
       - "29987:29987"

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -10,12 +10,6 @@ A "Hello World" type of program for the Fuel Indexer service.
 
 Spin up containers for the Postgres database server and the indexer service.
 
-> IMPORTANT: If you're on a platform using Apple Silicon, you will have to build your image locally, rather than pulling an image from the image registry. We have [an open issue](https://github.com/FuelLabs/fuel-indexer/issues/578) to add support for ARM Arch64 images.
->
-> In order to use a local image you can just:
->   1. Build your image locally: `docker build -t fuel-indexer/local:latest -f deployment/Dockerfile .`
->   2. Update your `docker-compose.yaml` file with `image: fuel-indexer/local:latest` for the `fuel-indexer` service.
->
 > IMPORTANT: Ensure that any local Postgres instance on port 5432 is stopped.
 
 ```bash

--- a/examples/hello-world/docker-compose.yaml
+++ b/examples/hello-world/docker-compose.yaml
@@ -37,7 +37,6 @@ services:
       - postgres
   fuel-indexer:
     image: ghcr.io/fuellabs/fuel-indexer:latest
-    platform: linux/amd64
     command: bash -c "sleep 2 && ./fuel-indexer run --fuel-node-host fuel-node --postgres-host postgres --postgres-password postgres --graphql-api-host 0.0.0.0 --run-migrations"
     ports:
       - "29987:29987"

--- a/examples/hello-world/hello-world-node/src/main.rs
+++ b/examples/hello-world/hello-world-node/src/main.rs
@@ -3,6 +3,8 @@ use fuel_indexer_tests::defaults;
 use fuel_indexer_tests::fixtures::setup_test_fuel_node;
 use std::path::{Path, PathBuf};
 
+const NODE_TTL_SECS: u64 = 60 * 30;
+
 #[derive(Debug, Parser, Clone)]
 #[clap(
     name = "hello-world-node",
@@ -49,10 +51,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(defaults::FUEL_NODE_ADDR.to_string())
     };
 
-    println!("Spinning up test Fuel node; node will automatically exit in ten minutes.");
+    println!(
+        "Spinning up test Fuel node; node will automatically exit in {NODE_TTL_SECS} seconds."
+    );
     let server_handle =
         tokio::spawn(setup_test_fuel_node(chain_config, Some(contract_bin), host));
-    std::thread::sleep(std::time::Duration::from_secs(600));
+    std::thread::sleep(std::time::Duration::from_secs(NODE_TTL_SECS));
 
     server_handle.abort();
 


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- Adds cross platform support to our docker builds
- Based on fuel-core example https://github.com/FuelLabs/fuel-core/pull/1233
- [Previously the docker build step used to take around ~40 mins](https://github.com/FuelLabs/fuel-indexer/actions/runs/5509952533/jobs/10043437988)
  - With this change this step now takes around 60 mins
    - Twice as long cause it's building two images

### Testing steps

- [ ] View/use the image pushed by this PR 
  - That image is here https://github.com/FuelLabs/fuel-indexer/pkgs/container/fuel-indexer/108693557?tag=sha-e99a5b9
  - You should be able to pull down this image and run it on a `aarch64-apple-darwin` target 
- [ ] Should be able to run the hello-world example w/o having to build the image manually
  - `cd examples/hello-world && docker compose up`

### Changelog

- chore: add docker multiplatform support
