### PR TITLE
fix: ensure that unions are added to query root

### DIFF
--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -578,6 +578,11 @@ impl ParsedGraphQLSchema {
         self.unions.get(name)
     }
 
+    /// Return a mapping of union names to their `TypeDefinition`s.
+    pub fn unions(&self) -> &HashMap<String, TypeDefinition> {
+        &self.unions
+    }
+
     /// Return a list of all non-enum type definitions.
     pub fn non_enum_typdefs(&self) -> Vec<(&String, &TypeDefinition)> {
         self.type_defs

--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -578,11 +578,6 @@ impl ParsedGraphQLSchema {
         self.unions.get(name)
     }
 
-    /// Return a mapping of union names to their `TypeDefinition`s.
-    pub fn unions(&self) -> &HashMap<String, TypeDefinition> {
-        &self.unions
-    }
-
     /// Return a list of all non-enum type definitions.
     pub fn non_enum_typdefs(&self) -> Vec<(&String, &TypeDefinition)> {
         self.type_defs

--- a/packages/fuel-indexer-schema/src/db/tables.rs
+++ b/packages/fuel-indexer-schema/src/db/tables.rs
@@ -247,10 +247,9 @@ impl IndexerSchema {
         self.parsed.object_field_mappings.insert(
             QUERY_ROOT.to_string(),
             self.parsed
-                .objects()
-                .keys()
-                .chain(self.parsed.unions().keys())
-                .map(|k| (k.to_lowercase(), k.clone()))
+                .non_enum_typdefs()
+                .iter()
+                .map(|(k, _)| (k.to_lowercase(), k.to_string()))
                 .collect::<BTreeMap<String, String>>(),
         );
     }

--- a/packages/fuel-indexer-schema/src/db/tables.rs
+++ b/packages/fuel-indexer-schema/src/db/tables.rs
@@ -249,6 +249,7 @@ impl IndexerSchema {
             self.parsed
                 .objects()
                 .keys()
+                .chain(self.parsed.unions().keys())
                 .map(|k| (k.to_lowercase(), k.clone()))
                 .collect::<BTreeMap<String, String>>(),
         );


### PR DESCRIPTION
### Description

Ensures that unions are added to the query root so that they are available for querying.

### Testing steps

CI should pass.

#### Manual Testing

On develop:
- Start the fuel-explorer example, open up the playground, and attempt to run the following query:
```
query {
  transaction(order: { id: desc }, first: 5) {
    id
  }
}
```
- You should see an error.

On this branch:
- Repeat the steps above. You should see the results shown properly.
