### PR TITLE
chore: Remove `QueryRoot` workaround

### DIFF
--- a/packages/fuel-indexer-database/database-types/src/lib.rs
+++ b/packages/fuel-indexer-database/database-types/src/lib.rs
@@ -998,7 +998,7 @@ impl Table {
                     .flat_map(|m| {
                         let name = m.node.to_string();
                         parsed
-                            .object_field_mappings
+                            .object_field_mappings()
                             .get(&name)
                             .unwrap_or(&default_)
                             .iter()

--- a/packages/fuel-indexer-graphql/src/dynamic.rs
+++ b/packages/fuel-indexer-graphql/src/dynamic.rs
@@ -123,7 +123,7 @@ lazy_static! {
     /// so that they do not appear in the generated documentation. This is done
     /// to hide internal Fuel indexer entity types.
     static ref IGNORED_ENTITY_TYPES: HashSet<&'static str> =
-        HashSet::from(["IndexMetadataEntity", "QueryRoot"]);
+        HashSet::from(["IndexMetadataEntity"]);
 
     /// Entity fields that should be ignored when building the dynamic schema,
     /// so that they do not appear in the generated documentation. This is done
@@ -204,7 +204,7 @@ pub fn build_dynamic_schema(schema: &IndexerSchema) -> GraphqlResult<DynamicSche
 
     let sort_enum = Enum::new("SortOrder").item("asc").item("desc");
 
-    for (entity_type, field_map) in &schema.parsed().object_field_mappings {
+    for (entity_type, field_map) in schema.parsed().object_field_mappings() {
         if IGNORED_ENTITY_TYPES.contains(&entity_type.as_str()) {
             continue;
         }

--- a/packages/fuel-indexer-graphql/src/graphql.rs
+++ b/packages/fuel-indexer-graphql/src/graphql.rs
@@ -115,7 +115,7 @@ impl Selections {
                         .iter()
                         .map(|(arg, value)| {
                             parse_argument_into_param(
-                                subfield_type,
+                                Some(subfield_type),
                                 &arg.to_string(),
                                 value.node.clone(),
                                 schema,

--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -635,7 +635,7 @@ impl ParsedGraphQLSchema {
     }
 
     /// Return the GraphQL type for a given field name.
-    pub fn field_type(&self, cond: &str, name: &str) -> Option<&String> {
+    fn field_type(&self, cond: &str, name: &str) -> Option<&String> {
         match self.object_field_mappings().get(cond) {
             Some(fieldset) => fieldset.get(name),
             _ => {
@@ -648,10 +648,12 @@ impl ParsedGraphQLSchema {
         }
     }
 
+    /// Return the GraphQL type for a given entity.
     fn entity_type(&self, name: &str) -> Option<&String> {
         self.entity_names_to_types.get(name)
     }
 
+    /// Return the GraphQL type for a given entity or field.
     pub fn graphql_type(&self, cond: Option<&String>, name: &str) -> Option<&String> {
         match cond {
             Some(c) => self.field_type(c, name),

--- a/packages/fuel-indexer-macros/src/decoder.rs
+++ b/packages/fuel-indexer-macros/src/decoder.rs
@@ -80,7 +80,7 @@ impl Decoder for ImplementationDecoder {
                 let mut hasher = quote! { Sha256::new() };
 
                 let obj_field_names = parsed
-                    .object_field_mappings
+                    .object_field_mappings()
                     .get(&obj_name)
                     .expect("TypeDefinition not found in parsed GraphQL schema.")
                     .iter()
@@ -158,7 +158,7 @@ impl Decoder for ImplementationDecoder {
                     .flat_map(|m| {
                         let name = m.node.to_string();
                         parsed
-                            .object_field_mappings
+                            .object_field_mappings()
                             .get(&name)
                             .expect("Could not find union member in parsed schema.")
                             .iter()
@@ -315,7 +315,7 @@ impl From<ImplementationDecoder> for TokenStream {
                     .flat_map(|m| {
                         let name = m.node.to_string();
                         parsed
-                            .object_field_mappings
+                            .object_field_mappings()
                             .get(&name)
                             .expect("Could not find union member in parsed schema.")
                             .iter()
@@ -330,7 +330,7 @@ impl From<ImplementationDecoder> for TokenStream {
                     let member_ident = format_ident!("{}", m.to_string());
 
                     let member_fields = parsed
-                        .object_field_mappings
+                        .object_field_mappings()
                         .get(m.to_string().as_str())
                         .expect("Could not get field mappings for union member.")
                         .keys()
@@ -535,7 +535,7 @@ impl Decoder for ObjectDecoder {
                     .flat_map(|m| {
                         let name = m.node.to_string();
                         parsed
-                            .object_field_mappings
+                            .object_field_mappings()
                             .get(&name)
                             .expect("Could not find union member in parsed schema.")
                             .iter()

--- a/packages/fuel-indexer-schema/src/lib.rs
+++ b/packages/fuel-indexer-schema/src/lib.rs
@@ -17,7 +17,6 @@ pub mod db;
 
 /// Placeholder value for SQL `NULL` values.
 const NULL_VALUE: &str = "NULL";
-pub const QUERY_ROOT: &str = "QueryRoot";
 
 /// Result type used by indexer schema operations.
 pub type IndexerSchemaResult<T> = core::result::Result<T, IndexerSchemaError>;

--- a/packages/fuel-indexer-tests/tests/integration/graphql_schema.rs
+++ b/packages/fuel-indexer-tests/tests/integration/graphql_schema.rs
@@ -23,7 +23,7 @@ type Thing2 {
 }
 "#;
 
-    let mut schema = IndexerSchema::new(
+    let schema = IndexerSchema::new(
         "test_namespace",
         "index1",
         &GraphQLSchema::new(schema.to_owned()),
@@ -31,8 +31,6 @@ type Thing2 {
         ExecutionSource::Wasm,
     )
     .unwrap();
-
-    schema.register_queryroot_fields();
 
     schema
 }


### PR DESCRIPTION
### Description

Removes dependence on the concept of a `QueryRoot` in queries and schema construction.

### Testing steps

CI should pass. All functionality should still be the same; this should have no outward effect on the user.
