### PR TITLE
chore: remove `.expect()` from GraphQL query flow

### DIFF
--- a/packages/fuel-indexer-graphql/src/graphql.rs
+++ b/packages/fuel-indexer-graphql/src/graphql.rs
@@ -192,10 +192,17 @@ impl Selections {
                     sub_selections,
                     alias,
                 } => {
-                    let field_type = schema
-                        .parsed()
-                        .graphql_type(cond, name)
-                        .expect("Unable to retrieve field type");
+                    let field_type =
+                        schema.parsed().graphql_type(cond, name).ok_or_else(|| {
+                            if let Some(c) = cond {
+                                GraphqlError::UnrecognizedField(
+                                    c.to_string(),
+                                    name.to_string(),
+                                )
+                            } else {
+                                GraphqlError::UnrecognizedType(name.to_string())
+                            }
+                        })?;
                     let _ = sub_selections.resolve_fragments(
                         schema,
                         Some(&field_type.clone()),


### PR DESCRIPTION
### Description

Remove a use of `.expect()` in the control flow for GraphQL queries.

### Testing steps

CI should pass. This change propagates an error to the user instead of crashing the indexer service.
