### PR TITLE
fix: bump cursor when unique constraint fails due to ID derivation

### DIFF
--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -376,8 +376,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                         // sqlx v0.7 let's you determine if this was specifically a unique constraint violation
                         // but sqlx v0.6 does not so we use a best guess.
                         //
-                        // This is a temporary workaround - skipping bad items - until we formally decide on
-                        // the best way to fix https://github.com/FuelLabs/fuel-indexer/issues/1083
+                        // TODO: https://github.com/FuelLabs/fuel-indexer/issues/1093
                         if inner.constraint().is_some() {
                             // Just bump the cursor and keep going
                             warn!("Constraint violation. Continuing...");

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -313,64 +313,53 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                         } = g.to_owned();
 
                         Consensus::Genesis(Genesis {
-                            chain_config_hash: <[u8; 32]>::try_from(
+                            chain_config_hash: <[u8; 32]>::from(
                                 chain_config_hash.to_owned().0 .0,
                             )
-                            .unwrap()
                             .into(),
-                            coins_root: <[u8; 32]>::try_from(coins_root.0 .0.to_owned())
-                                .unwrap()
+                            coins_root: <[u8; 32]>::from(coins_root.0 .0.to_owned())
                                 .into(),
-                            contracts_root: <[u8; 32]>::try_from(
+                            contracts_root: <[u8; 32]>::from(
                                 contracts_root.0 .0.to_owned(),
                             )
-                            .unwrap()
                             .into(),
-                            messages_root: <[u8; 32]>::try_from(
+                            messages_root: <[u8; 32]>::from(
                                 messages_root.0 .0.to_owned(),
                             )
-                            .unwrap()
                             .into(),
                         })
                     }
                     ClientConsensus::PoAConsensus(poa) => Consensus::PoA(PoA {
-                        signature: <[u8; 64]>::try_from(poa.signature.0 .0.to_owned())
-                            .unwrap()
-                            .into(),
+                        signature: <[u8; 64]>::from(poa.signature.0 .0.to_owned()).into(),
                     }),
                 };
 
                 // TODO: https://github.com/FuelLabs/fuel-indexer/issues/286
                 let block = BlockData {
                     height: block.header.height.clone().into(),
-                    id: Bytes32::from(<[u8; 32]>::try_from(block.id.0 .0).unwrap()),
+                    id: Bytes32::from(<[u8; 32]>::from(block.id.0 .0)),
                     producer,
                     time: block.header.time.0.to_unix(),
                     consensus,
                     header: Header {
-                        id: Bytes32::from(
-                            <[u8; 32]>::try_from(block.header.id.0 .0).unwrap(),
-                        ),
+                        id: Bytes32::from(<[u8; 32]>::from(block.header.id.0 .0)),
                         da_height: block.header.da_height.0,
                         transactions_count: block.header.transactions_count.0,
                         output_messages_count: block.header.output_messages_count.0,
-                        transactions_root: Bytes32::from(
-                            <[u8; 32]>::try_from(block.header.transactions_root.0 .0)
-                                .unwrap(),
-                        ),
-                        output_messages_root: Bytes32::from(
-                            <[u8; 32]>::try_from(block.header.output_messages_root.0 .0)
-                                .unwrap(),
-                        ),
+                        transactions_root: Bytes32::from(<[u8; 32]>::from(
+                            block.header.transactions_root.0 .0,
+                        )),
+                        output_messages_root: Bytes32::from(<[u8; 32]>::from(
+                            block.header.output_messages_root.0 .0,
+                        )),
                         height: block.header.height.0,
-                        prev_root: Bytes32::from(
-                            <[u8; 32]>::try_from(block.header.prev_root.0 .0).unwrap(),
-                        ),
+                        prev_root: Bytes32::from(<[u8; 32]>::from(
+                            block.header.prev_root.0 .0,
+                        )),
                         time: block.header.time.0.to_unix(),
-                        application_hash: Bytes32::from(
-                            <[u8; 32]>::try_from(block.header.application_hash.0 .0)
-                                .unwrap(),
-                        ),
+                        application_hash: Bytes32::from(<[u8; 32]>::from(
+                            block.header.application_hash.0 .0,
+                        )),
                     },
                     transactions,
                 };
@@ -386,7 +375,11 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                     IndexerError::SqlxError(sqlx::Error::Database(inner)) => {
                         // sqlx v0.7 let's you determine if this was specifically a unique constraint violation
                         // but sqlx v0.6 does not so we use a best guess.
+                        //
+                        // This is a temporary workaround - skipping bad items - until we formally decide on
+                        // the best way to fix https://github.com/FuelLabs/fuel-indexer/issues/1083
                         if inner.constraint().is_some() {
+                            // Just bump the cursor and keep going
                             warn!("Constraint violation. Continuing...");
                             next_cursor = cursor;
                             continue;


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- PR bumps the executor's cursor, in order to move to the next set of data, when a sqlx constraint error is encountered. More info in https://github.com/FuelLabs/fuel-indexer/issues/1083

### Testing steps

- [ ] Deploy a default indexer locally, around block ~62K after you see a sqlx constraint error, the executor should just bump the cursor and keep indexing data
  - On develop, you will see the sqlx constraint error happens 10 times, and the executor dies
  - More info in https://github.com/FuelLabs/fuel-indexer/issues/1083

### Changelog

- fix: bump cursor when unique constraint fails due to ID derivation
