### PR TITLE
Fix unreported WASM runtime error

### DIFF
--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -675,7 +675,7 @@ impl Executor for WasmIndexExecutor {
                 return Err(IndexerError::from(e));
             }
             Ok(Ok(Err(e))) => {
-                error!("WasmIndexExecutor handle_events failed: {e:?}.");
+                error!("WasmIndexExecutor WASM module failed: {e:?}.");
                 self.db.lock().await.revert_transaction().await?;
                 return Err(IndexerError::from(e));
             }


### PR DESCRIPTION
### Description

This PR fixes unreported Runtime errors. There are three levels of errors from `handle_events`: elapsed, join error, or (WASM) runtime error. Currently, on `develop`, the runtime error is not reported.

### Testing steps

Set `start_block: 8322` in `fuel-explorer` and run:

```
cargo run -p fuel-indexer -- run --run-migrations --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --manifest examples/fuel-explorer/fuel-explorer/fuel_explorer.manifest.yaml --replace-indexer
```

On `develop`, there is no error. On this branch, `fuel-explorer` fails.

See #1090 for additional information.

### Changelog

* Report WASM runtime errors from WasmIndexExecutor
