### PR TITLE
fix: prevent serde error from crashing service

### DIFF
--- a/packages/fuel-indexer-macros/src/decoder.rs
+++ b/packages/fuel-indexer-macros/src/decoder.rs
@@ -673,14 +673,14 @@ impl From<ObjectDecoder> for TokenStream {
 
             impl From<#ident> for Json {
                 fn from(value: #ident) -> Self {
-                    let s = serde_json::to_string(&value).expect("Serde error.");
+                    let s = serde_json::to_string(&value).expect("Failed to serialize Entity.");
                     Self(s)
                 }
             }
 
             impl From<Json> for #ident {
                 fn from(value: Json) -> Self {
-                    let s: #ident = serde_json::from_str(&value.0).expect("Serde error.");
+                    let s: #ident = serde_json::from_str(&value.0).expect("Failed to deserialize Entity.");
                     s
                 }
             }
@@ -716,7 +716,7 @@ impl From<ObjectDecoder> for TokenStream {
                                 Some(d) => {
                                     match d.lock().await.get_object(Self::TYPE_ID, id).await {
                                         Some(bytes) => {
-                                            let columns: Vec<FtColumn> = bincode::deserialize(&bytes).expect("Serde error.");
+                                            let columns: Vec<FtColumn> = bincode::deserialize(&bytes).expect("Failed to deserialize Vec<FtColumn> for Entity::load.");
                                             let obj = Self::from_row(columns);
                                             Some(obj)
                                         },

--- a/packages/fuel-indexer-types/src/fuel.rs
+++ b/packages/fuel-indexer-types/src/fuel.rs
@@ -70,8 +70,17 @@ pub struct CommonMetadata {
 
 impl From<CommonMetadata> for Json {
     fn from(metadata: CommonMetadata) -> Self {
-        let s = serde_json::to_string(&metadata).expect("Serde error.");
+        let s = serde_json::to_string(&metadata)
+            .expect("Failed to serialize CommonMetadata.");
         Self(s)
+    }
+}
+
+impl From<Json> for CommonMetadata {
+    fn from(json: Json) -> Self {
+        let metadata: CommonMetadata =
+            serde_json::from_str(&json.0).expect("Failed to deserialize CommonMetadata.");
+        metadata
     }
 }
 
@@ -97,8 +106,17 @@ pub struct ScriptMetadata {
 
 impl From<ScriptMetadata> for Json {
     fn from(metadata: ScriptMetadata) -> Self {
-        let s = serde_json::to_string(&metadata).expect("Serde error.");
+        let s = serde_json::to_string(&metadata)
+            .expect("Failed to deserialize MintMetadata.");
         Self(s)
+    }
+}
+
+impl From<Json> for ScriptMetadata {
+    fn from(json: Json) -> Self {
+        let metadata: ScriptMetadata =
+            serde_json::from_str(&json.0).expect("Failed to deserialize ScriptMetadata.");
+        metadata
     }
 }
 
@@ -118,8 +136,17 @@ pub struct MintMetadata {
 
 impl From<MintMetadata> for Json {
     fn from(metadata: MintMetadata) -> Self {
-        let s = serde_json::to_string(&metadata).expect("Serde error.");
+        let s =
+            serde_json::to_string(&metadata).expect("Failed to serialize MintMetadata.");
         Self(s)
+    }
+}
+
+impl From<Json> for MintMetadata {
+    fn from(json: Json) -> Self {
+        let metadata: MintMetadata =
+            serde_json::from_str(&json.0).expect("Failed to deserialize MintMetadata.");
+        metadata
     }
 }
 
@@ -592,14 +619,15 @@ pub struct ProgramState {
 
 impl From<ProgramState> for Json {
     fn from(state: ProgramState) -> Self {
-        let s = serde_json::to_string(&state).expect("Serde error.");
+        let s = serde_json::to_string(&state).expect("Failed to serialize ProgramState.");
         Self(s)
     }
 }
 
 impl From<Json> for ProgramState {
     fn from(json: Json) -> Self {
-        let state: ProgramState = serde_json::from_str(&json.0).expect("Serde error.");
+        let state: ProgramState =
+            serde_json::from_str(&json.0).expect("Failed to deserialize ProgramState.");
         state
     }
 }

--- a/packages/fuel-indexer/src/ffi.rs
+++ b/packages/fuel-indexer/src/ffi.rs
@@ -154,7 +154,8 @@ fn put_object(env: &IndexEnv, type_id: i64, ptr: u32, len: u32) {
         bytes.extend_from_slice(&mem.data_unchecked()[range]);
     }
 
-    let columns: Vec<FtColumn> = bincode::deserialize(&bytes).expect("Serde error.");
+    let columns: Vec<FtColumn> = bincode::deserialize(&bytes)
+        .expect("Failed to deserialize Vec<FtColumn> for put_object.");
 
     let rt = tokio::runtime::Handle::current();
     rt.block_on(async {

--- a/packages/fuel-indexer/src/ffi.rs
+++ b/packages/fuel-indexer/src/ffi.rs
@@ -154,8 +154,16 @@ fn put_object(env: &IndexEnv, type_id: i64, ptr: u32, len: u32) {
         bytes.extend_from_slice(&mem.data_unchecked()[range]);
     }
 
-    let columns: Vec<FtColumn> = bincode::deserialize(&bytes)
-        .expect("Failed to deserialize Vec<FtColumn> for put_object.");
+    let columns: Vec<FtColumn> = match bincode::deserialize(&bytes) {
+        Ok(columns) => columns,
+        Err(e) => {
+            error!(
+                "Failed to deserialize Vec<FtColumn> for put_object: {:?}",
+                e
+            );
+            return;
+        }
+    };
 
     let rt = tokio::runtime::Handle::current();
     rt.block_on(async {


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- Prevents from panic'ing when `put_object` fails. 
  - Currently this crashes the entire service
  - Why does it fail? Not sure, but we can't bring down the entire service because of this
  - We successfully indexed 178,775 blocks before encountering this error - some type of blip?
- [Here is the elastic doc with the exact error](https://search-fuel-prod-sp5nn3gesvhmb5qjjcxarse5di.us-east-1.es.amazonaws.com/_dashboards/app/discover#/doc/a9bb0e30-7cfa-11ed-bb0a-9d1026406ebc/cwl-2023.07.12?id=37670455749185772964673089726982812396625972086305981568)

### Testing steps

- [ ] New indexer `forc index new indexer-test --namespace fuel`
- [ ] Use `178775` as your `start_block`
- [ ] Start the service on beta-3
```bash
cargo run -p fuel-indexer -- run --run-migrations --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --replace-indexer
```
- [ ] Deploy `forc index deploy`
- [ ] Should see no panic

### Changelog

- fix: prevent serde error from crashing service
