### PR TITLE
chore: reduce CI run time for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,8 @@ jobs:
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
-    if: needs.set-env-vars.outputs.IS_RELEASE != 'true'
+      - check-is-semver-branch
+    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
     strategy:
       matrix:
         command:
@@ -154,10 +155,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}'
   cargo-clippy:
-    if: needs.set-env-vars.outputs.IS_RELEASE != 'true'
+    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
+      - check-is-semver-branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -182,10 +184,11 @@ jobs:
       - name: cargo fmt --all --verbose -- --check
         run: cargo fmt --all --verbose -- --check
   cargo-test-unit-tests:
-    if: needs.set-env-vars.outputs.IS_RELEASE != 'true'
+    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
+      - check-is-semver-branch
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -213,10 +216,11 @@ jobs:
           cargo test --locked --all-targets --workspace --exclude
           fuel-indexer-tests --exclude plugin-tests
   cargo-test-e2e-and-integration-tests:
-    if: needs.set-env-vars.outputs.IS_RELEASE != 'true'
+    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
+      - check-is-semver-branch
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -363,7 +367,7 @@ jobs:
   publish-docker-image:
     needs:
       - set-env-vars
-    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER == 'true'
+    if: needs.set-env-vars.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -681,7 +685,6 @@ jobs:
       - name: Publish crates
         uses: katyo/publish-crates@v2
         with:
-          publish-delay: 30000
           registry-token: '${{ secrets.CARGO_REGISTRY_TOKEN }}'
       - name: Notify Slack On Failure
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       IS_MASTER: '${{ steps.set-env.outputs.IS_MASTER }}'
       IS_RELEASE: '${{ steps.set-env.outputs.IS_RELEASE }}'
       IS_RELEASE_OR_MASTER: '${{ steps.set-env.outputs.IS_RELEASE_OR_MASTER }}'
+      IS_RELEASE_OR_MASTER_OR_SEMVER: '${{ steps.set-env.outputs.IS_RELEASE_OR_MASTER_OR_SEMVER }}'
     steps:
       - name: Set env vars
         id: set-env
@@ -60,6 +61,8 @@ jobs:
 
           echo "IS_RELEASE_OR_MASTER=${{ env.IS_RELEASE_OR_MASTER }}" >>
           $GITHUB_OUTPUT
+
+          echo "IS_RELEASE_OR_MASTER_OR_SEMVER=[[ ${{ env.BRANCH_NAME }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]" >> $GITHUB_OUTPUT
   check-is-semver-branch:
     if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true'
     needs:
@@ -104,8 +107,7 @@ jobs:
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
-      - check-is-semver-branch
-    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
+    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_SEMVER != 'true'
     strategy:
       matrix:
         command:
@@ -155,11 +157,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}'
   cargo-clippy:
-    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
+    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_SEMVER != 'true'
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
-      - check-is-semver-branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -184,11 +185,10 @@ jobs:
       - name: cargo fmt --all --verbose -- --check
         run: cargo fmt --all --verbose -- --check
   cargo-test-unit-tests:
-    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
+    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_SEMVER != 'true'
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
-      - check-is-semver-branch
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -216,11 +216,10 @@ jobs:
           cargo test --locked --all-targets --workspace --exclude
           fuel-indexer-tests --exclude plugin-tests
   cargo-test-e2e-and-integration-tests:
-    if: ${{ (needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER != 'true') && (needs.check-is-semver-branch.outputs.is_semver_branch != 'true' ) }}
+    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_SEMVER != 'true'
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
-      - check-is-semver-branch
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
### Description

This PR makes a number of changes to the CI pipeline:
- `cargo build`, `cargo clippy`, and `cargo test` will not run on merges to master, release publishes, or on version bump PRs
-- We disallow merging to `develop` unless these steps successfully pass, so we are essentially running redundant tasks whenever we release a new version.
- Publishing should now happen in parallel.
-- The [GitHub action that we use to publish crates](https://github.com/katyo/publish-crates) states that it determines the correct order for publishing according to dependencies.

### Testing steps

CI should pass. 

### Notes

I kept our default indexer checks for the release as it seems like a good idea to ensure those pass before a version is completely released to the public. Also, I adjusted the `publish-docker-image` step to only run on releases instead of both releases and merges to master.