### PR TITLE
fix: dispatch per block instead of per transaction

### DIFF
--- a/packages/fuel-indexer-macros/src/indexer.rs
+++ b/packages/fuel-indexer-macros/src/indexer.rs
@@ -576,9 +576,8 @@ fn process_fn_items(
                             }
                         }
                     }
-
-                    decoder.dispatch()#awaitness;
                 }
+                decoder.dispatch()#awaitness;
 
                 let metadata = IndexMetadataEntity{ id: block.height as u64, time: block.time as u64, block_height: block.height };
                 metadata.save()#awaitness;


### PR DESCRIPTION
### Description

The indexer currently dispatches a handler function _per transaction_ in a block; in effect, we're repeating an indexing function up to the max amount of transactions per block, if the only parameter is `BlockData`.

This PR ensures that we index _per block_ by moving the `decoder.dispatch()` call to the block iteration loop rather than the transaction iteration loop.

### Testing steps

CI should pass.

#### Reproduction

You can reproduce the bug by doing the following on the `develop` branch:
- Ensure DB is cleared.
- Add an logging call to an indexer
-- Feel free to add `info!("Block #{}", block_data.header.height);` to the `fuel-explorer` handler code.
- Compile the WASM module.
- Run the service with your adjusted indexer:
-- `cargo run -p fuel-indexer -- run --run-migrations --manifest examples/fuel-explorer/fuel-explorer/fuel_explorer.manifest.yaml --fuel-node-host beta-3.fuel.network --fuel-node-port 80`
- After about 30 seconds of running the indexer, stop it and look at the logs. You should see that some of the blocks are logged multiple times.
-- In my testing, this was apparent around block 1000.

For further proof, feel free to include the `--verbose` flag and check the database operations when a block is logged multiple times; you should see that the same database query is being executed the same amount of times.

#### Manual Testing

Run the same steps with this branch. You should see that there are no repeated logs or database queries for the same block.

### Notes

This may be related to #1111 as the amount of transactions and receipts dramatically increases in the 200K block range which means that the amount of `get_object` and `put_object` calls increases as well.
