### PR TITLE
fix: fix manifest creation in benchmarks

### DIFF
--- a/packages/fuel-indexer-benchmarks/benches/wasm/examples/fuel_explorer.rs
+++ b/packages/fuel-indexer-benchmarks/benches/wasm/examples/fuel_explorer.rs
@@ -1,14 +1,24 @@
 use criterion::Criterion;
-use fuel_indexer_benchmarks::{create_wasm_indexer_benchmark, create_wasm_manifest};
+use fuel_indexer_benchmarks::create_wasm_indexer_benchmark;
 use fuel_indexer_lib::{config::IndexerConfig, manifest::Manifest};
 
 fn setup_fuel_explorer_manifest() -> Manifest {
-    create_wasm_manifest(
-        "indexer_benchmarks",
-        "fuel_explorer",
-        "examples/fuel-explorer/fuel-explorer/schema/fuel_explorer.schema.graphql",
-        "target/wasm32-unknown-unknown/release/fuel_explorer.wasm",
-    )
+    let manifest_str = r#"
+namespace: indexer_benchmarks 
+abi: ~
+identifier: fuel_explorer
+fuel_client: ~
+graphql_schema: ../../examples/fuel-explorer/fuel-explorer/schema/fuel_explorer.schema.graphql
+module:
+  wasm: ../../target/wasm32-unknown-unknown/release/fuel_explorer.wasm
+metrics: ~
+contract_id: ~
+start_block: ~
+end_block: ~
+resumable: ~
+    "#;
+
+    Manifest::try_from(manifest_str).unwrap()
 }
 
 // The `criterion_group!` macro requires that target functions have a name.

--- a/packages/fuel-indexer-benchmarks/src/lib.rs
+++ b/packages/fuel-indexer-benchmarks/src/lib.rs
@@ -1,15 +1,12 @@
 use criterion::Criterion;
 use fuel_core_client::client::FuelClient;
-use fuel_indexer::Module;
 use fuel_indexer::{
     executor::retrieve_blocks_from_node, prelude::fuel::BlockData, Executor,
     IndexerConfig, Manifest, WasmIndexExecutor,
 };
 use fuel_indexer_database::IndexerConnectionPool;
 use fuel_indexer_lib::config::DatabaseConfig;
-use fuel_indexer_lib::manifest::ContractIds;
 use fuel_indexer_tests::fixtures::TestPostgresDb;
-use std::path::Path;
 use std::str::FromStr;
 
 /// Location of Fuel node to be used for block retrieval.
@@ -33,48 +30,6 @@ async fn get_blocks(start_cursor: u64, num_blocks: usize) -> Result<Vec<BlockDat
     .expect("Could not retrieve blocks from node");
 
     Ok(blocks)
-}
-
-pub fn create_wasm_manifest(
-    namespace: &str,
-    identifier: &str,
-    schema_path: &str,
-    wasm_module_path: &str,
-) -> Manifest {
-    let schema_path = Path::new(WORKSPACE_ROOT)
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join(schema_path)
-        .as_path()
-        .to_str()
-        .unwrap()
-        .to_string();
-    let module_path = Path::new(WORKSPACE_ROOT)
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join(wasm_module_path)
-        .as_path()
-        .to_str()
-        .unwrap()
-        .to_string();
-
-    Manifest {
-        namespace: namespace.to_string(),
-        identifier: identifier.to_string(),
-        graphql_schema: schema_path,
-        module: Module::Wasm(module_path),
-        abi: None,
-        fuel_client: None,
-        metrics: None,
-        contract_id: ContractIds::Single(None),
-        start_block: None,
-        end_block: None,
-        resumable: None,
-    }
 }
 
 /// Create WASM executor for use in a benchmarking function.


### PR DESCRIPTION
### Description

Fix manifest creation in benchmarks.

### Testing steps

Run `cargo bench` in the benchmarks folder and ensure that there are no compiler errors.