### PR TITLE
fix: add sql endpoint auth + make `run_query` fail gracefully

### DIFF
--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -202,6 +202,7 @@ impl WebApi {
         if config.accept_sql_queries {
             sql_routes = Router::new()
                 .route("/:namespace/:identifier", post(sql_query))
+                .layer(AuthenticationMiddleware::from(&config))
                 .layer(Extension(pool.clone()))
                 .layer(RequestBodyLimitLayer::new(max_body_size));
         }

--- a/packages/fuel-indexer-api-server/src/uses.rs
+++ b/packages/fuel-indexer-api-server/src/uses.rs
@@ -423,9 +423,14 @@ pub async fn get_metrics(_req: Request<Body>) -> impl IntoResponse {
 /// Return the results from a validated, arbitrary SQL query.
 pub async fn sql_query(
     Path((_namespace, _identifier)): Path<(String, String)>,
+    Extension(claims): Extension<Claims>,
     Extension(pool): Extension<IndexerConnectionPool>,
     Json(query): Json<SqlQuery>,
 ) -> ApiResult<axum::Json<Value>> {
+    if claims.is_unauthenticated() {
+        return Err(ApiError::Http(HttpError::Unauthorized));
+    }
+
     let SqlQuery { query } = query;
     SqlQueryValidator::validate_sql_query(&query)?;
     let mut conn = pool.acquire().await?;

--- a/packages/fuel-indexer-api-server/src/uses.rs
+++ b/packages/fuel-indexer-api-server/src/uses.rs
@@ -430,7 +430,6 @@ pub async fn sql_query(
     if claims.is_unauthenticated() {
         return Err(ApiError::Http(HttpError::Unauthorized));
     }
-
     let SqlQuery { query } = query;
     SqlQueryValidator::validate_sql_query(&query)?;
     let mut conn = pool.acquire().await?;

--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -67,7 +67,10 @@ pub async fn run_query(
         .fetch_all(conn)
         .await?
         .iter()
-        .map(|r| r.get::<JsonValue, usize>(0))
+        .filter_map(|r| match r.try_get::<JsonValue, usize>(0) {
+            Ok(v) => Some(v),
+            Err(_e) => None,
+        })
         .collect())
 }
 


### PR DESCRIPTION
- [ ] Please add proper labels
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)

### Description

- Adds auth to the new `/sql` query endpoint
  - Should we also add this to the GraphQL query routes?
- Fixes a bug where `run_query` panics if no results are returned

### Testing steps
- [ ] Start the service running the explorer on beta-3 with `--accept-sql-queries` and auth enabled

```bash
> cargo run --bin fuel-indexer -- run --run-migrations --accept-sql-queries --fuel-node-host beta-3.fuel.network --fuel-node-port 80 --replace-indexer --auth-enabled --auth-strategy jwt --jwt-issuer FuelLabs
```
- [ ] Try to query for data without auth, should return unauthorized response
```bash
> curl http://localhost:29987/api/sql/fuel/explorer -d '{"query":"SELECT json_agg(t) FROM (SELECT * FROM fuel_explorer.output WHERE id IN (2, 23)) t;"}' -H "Content-type: application/json"

{"details":"Unauthorized.","success":"false"}%
```
- [ ] Authenticate with `forc index auth`
- [ ] Use the same request except with auth this time - should return empty results set
  - On `master` this would panic 
```bash
> curl http://localhost:29987/api/sql/fuel/explorer -d '{"query":"SELECT json_agg(t) FROM (SELECT * FROM fuel_explorer.output WHERE id IN (2, 23)) t;"}' -H "Content-type: application/json" -H "Authorization: $MY_TOKEN"

{"data":[]}%
```

Please provide the _exact_ testing steps for the reviewer(s) if this PR requires testing.

### Changelog

- fix: add sql endpoint auth + make `run_query` fail gracefully
