### PR TITLE
enhancement: make `NODE_BLOCK_PAGE_SIZE` configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,9 @@
 # # Allow the web API to accept raw SQL queries.
 # accept_sql_queries: true
 
+# # Amount of blocks to return in a request to a Fuel node.
+# node_block_page_size: 10
+
 # # ***********************
 # # Fuel Node configuration
 # # ************************

--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,7 @@
 # accept_sql_queries: true
 
 # # Amount of blocks to return in a request to a Fuel node.
-# node_block_page_size: 10
+# block_page_size: 10
 
 # # ***********************
 # # Fuel Node configuration

--- a/deployment/charts/fuel-indexer/templates/fuel-indexer-deployment.yaml
+++ b/deployment/charts/fuel-indexer/templates/fuel-indexer-deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - "--verbose"
             - "--replace-indexer"
             - "--accept-sql-queries"
-            - "--node-block-page-size"
+            - "--block-page-size"
             - "25"
           env:
           - name: POSTGRES_PASSWORD

--- a/deployment/charts/fuel-indexer/templates/fuel-indexer-deployment.yaml
+++ b/deployment/charts/fuel-indexer/templates/fuel-indexer-deployment.yaml
@@ -59,6 +59,8 @@ spec:
             - "--verbose"
             - "--replace-indexer"
             - "--accept-sql-queries"
+            - "--node-block-page-size"
+            - "25"
           env:
           - name: POSTGRES_PASSWORD
             valueFrom:

--- a/docs/src/getting-started/starting-the-fuel-indexer.md
+++ b/docs/src/getting-started/starting-the-fuel-indexer.md
@@ -68,6 +68,9 @@ OPTIONS:
         --metrics
             Use Prometheus metrics reporting.
 
+        --node-block-page-size <NODE_BLOCK_PAGE_SIZE>
+            Amount of blocks to return in a request to a Fuel node. [default: 10]
+
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.
 

--- a/packages/fuel-indexer-lib/src/config/cli.rs
+++ b/packages/fuel-indexer-lib/src/config/cli.rs
@@ -183,7 +183,7 @@ pub struct IndexerArgs {
 
     /// Amount of blocks to return in a request to a Fuel node.
     #[clap(long, help = "Amount of blocks to return in a request to a Fuel node.", default_value_t = defaults::NODE_BLOCK_PAGE_SIZE)]
-    pub node_block_page_size: usize,
+    pub block_page_size: usize,
 }
 
 #[derive(Debug, Parser, Clone)]

--- a/packages/fuel-indexer-lib/src/config/cli.rs
+++ b/packages/fuel-indexer-lib/src/config/cli.rs
@@ -180,6 +180,10 @@ pub struct IndexerArgs {
     /// Allow the web API to accept raw SQL queries.
     #[clap(long, help = "Allow the web API to accept raw SQL queries.")]
     pub accept_sql_queries: bool,
+
+    /// Amount of blocks to return in a request to a Fuel node.
+    #[clap(long, help = "Amount of blocks to return in a request to a Fuel node.", default_value_t = defaults::NODE_BLOCK_PAGE_SIZE)]
+    pub node_block_page_size: usize,
 }
 
 #[derive(Debug, Parser, Clone)]

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -105,7 +105,7 @@ impl Default for IndexerArgs {
             rate_limit_window_size: Some(defaults::RATE_LIMIT_WINDOW_SIZE),
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: defaults::ACCEPT_SQL,
-            node_block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
+            block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
         }
     }
 }
@@ -236,7 +236,7 @@ impl From<IndexerArgs> for IndexerConfig {
             },
             replace_indexer: args.replace_indexer,
             accept_sql_queries: args.accept_sql_queries,
-            node_block_page_size: args.node_block_page_size,
+            node_block_page_size: args.block_page_size,
         };
 
         config
@@ -361,7 +361,7 @@ impl IndexerConfig {
             serde_yaml::Value::String("accept_sql_queries".into());
 
         let node_block_page_size_key =
-            serde_yaml::Value::String("node_block_page_size".into());
+            serde_yaml::Value::String("block_page_size".into());
 
         if let Some(accept_sql_queries) = content.get(accept_sql_config_key) {
             config.accept_sql_queries = accept_sql_queries.as_bool().unwrap();

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -105,6 +105,7 @@ impl Default for IndexerArgs {
             rate_limit_window_size: Some(defaults::RATE_LIMIT_WINDOW_SIZE),
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: defaults::ACCEPT_SQL,
+            node_block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
         }
     }
 }
@@ -133,6 +134,7 @@ pub struct IndexerConfig {
     pub rate_limit: RateLimitConfig,
     pub replace_indexer: bool,
     pub accept_sql_queries: bool,
+    pub node_block_page_size: usize,
 }
 
 impl Default for IndexerConfig {
@@ -153,6 +155,7 @@ impl Default for IndexerConfig {
             rate_limit: RateLimitConfig::default(),
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: defaults::ACCEPT_SQL,
+            node_block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
         }
     }
 }
@@ -233,6 +236,7 @@ impl From<IndexerArgs> for IndexerConfig {
             },
             replace_indexer: args.replace_indexer,
             accept_sql_queries: args.accept_sql_queries,
+            node_block_page_size: args.node_block_page_size,
         };
 
         config
@@ -319,6 +323,7 @@ impl From<ApiServerArgs> for IndexerConfig {
             },
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: args.accept_sql_queries,
+            node_block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
         };
 
         config
@@ -354,6 +359,9 @@ impl IndexerConfig {
 
         let accept_sql_config_key =
             serde_yaml::Value::String("accept_sql_queries".into());
+
+        let node_block_page_size_key =
+            serde_yaml::Value::String("node_block_page_size".into());
 
         if let Some(accept_sql_queries) = content.get(accept_sql_config_key) {
             config.accept_sql_queries = accept_sql_queries.as_bool().unwrap();
@@ -393,6 +401,10 @@ impl IndexerConfig {
 
         if let Some(indexer_net_config) = content.get(indexer_net_config_key) {
             config.indexer_net_config = indexer_net_config.as_bool().unwrap();
+        }
+
+        if let Some(node_block_page_size) = content.get(node_block_page_size_key) {
+            config.node_block_page_size = node_block_page_size.as_u64().unwrap() as usize;
         }
 
         let fuel_config_key = serde_yaml::Value::String("fuel_node".into());

--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -91,8 +91,8 @@ pub const VERBOSE_LOGGING: bool = false;
 /// Verbose output for database operations.
 pub const VERBOSE_DB_LOGGING: &str = "false";
 
-/// Amount of blocks to return in a GraphQL page.
-pub const NODE_GRAPHQL_PAGE_SIZE: usize = 10;
+/// Amount of blocks to return in a request to a Fuel node.
+pub const NODE_BLOCK_PAGE_SIZE: usize = 10;
 
 /// Start a local Fuel node.
 pub const LOCAL_FUEL_NODE: bool = false;

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -66,8 +66,8 @@ impl ExecutorSource {
     }
 }
 
-// Run the executor task until the kill switch is flipped, or until some other
-// stop criteria is met.
+/// Run the executor task until the kill switch is flipped, or until some other
+/// stop criteria is met.
 //
 // In general the logic in this function isn't very idiomatic, but that's because
 // types in `fuel_core_client` don't compile to WASM.
@@ -96,6 +96,8 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
     } else {
         config.fuel_node.to_string()
     };
+
+    let node_block_page_size = config.node_block_page_size;
 
     let mut next_cursor = if start_block > 1 {
         let decremented = start_block - 1;
@@ -128,7 +130,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
         loop {
             let (block_info, cursor) = match retrieve_blocks_from_node(
                 &client,
-                NODE_GRAPHQL_PAGE_SIZE,
+                node_block_page_size,
                 &next_cursor,
                 end_block,
             )


### PR DESCRIPTION
Closes #1128.

### Description

- Allow for configuration of `NODE_BLOCK_PAGE_SIZE`
- Add flag to documentation
- Change playground `NODE_BLOCK_PAGE_SIZE` value to 25

### Testing steps

CI should pass.

#### Manual Testing

Run the explorer example without the `--node-block-page size` flag; the service should request 10 blocks at a time. Run the explorer example again, but this time with `--node-block-page-size [NUM]`; the service should request `NUM` blocks at at time.
