### PR TITLE
Replace blocking `reqwest` usage with async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6769,10 +6769,12 @@ dependencies = [
  "tokio 1.29.1",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
+ "tokio-util 0.7.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.22.6",
  "winreg 0.10.1",
@@ -8901,6 +8903,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a3d1b4a575ffb873679402b2aedb3117555eb65c27b1b86c8a91e574bc2a2a"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/plugins/forc-index/Cargo.toml
+++ b/plugins/forc-index/Cargo.toml
@@ -26,7 +26,7 @@ hyper-rustls = { version = "0.23", features = ["http2"] }
 indicatif = "0.17"
 owo-colors = "1.3.0"
 rand = "0.8"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "multipart", "blocking"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "multipart", "stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.8"

--- a/plugins/forc-index/src/cli.rs
+++ b/plugins/forc-index/src/cli.rs
@@ -48,14 +48,14 @@ pub async fn run_cli() -> Result<(), anyhow::Error> {
     match opt.command {
         ForcIndex::Init(command) => crate::commands::init::exec(command),
         ForcIndex::New(command) => crate::commands::new::exec(command),
-        ForcIndex::Deploy(command) => crate::commands::deploy::exec(command),
+        ForcIndex::Deploy(command) => crate::commands::deploy::exec(command).await,
         ForcIndex::Start(command) => crate::commands::start::exec(command).await,
         ForcIndex::Check(command) => crate::commands::check::exec(command).await,
-        ForcIndex::Remove(command) => crate::commands::remove::exec(command),
+        ForcIndex::Remove(command) => crate::commands::remove::exec(command).await,
         ForcIndex::Build(command) => crate::commands::build::exec(command),
         ForcIndex::PullAbi(command) => crate::commands::pull_abi::exec(command).await,
         //ForcIndex::Welcome(command) => crate::commands::welcome::exec(command).await,
-        ForcIndex::Auth(command) => crate::commands::auth::exec(command),
+        ForcIndex::Auth(command) => crate::commands::auth::exec(command).await,
         ForcIndex::Postgres(opt) => match opt.command {
             ForcPostgres::Create(command) => pg_commands::create::exec(command).await,
             ForcPostgres::Stop(command) => pg_commands::stop::exec(command).await,

--- a/plugins/forc-index/src/commands/auth.rs
+++ b/plugins/forc-index/src/commands/auth.rs
@@ -19,7 +19,7 @@ pub struct Command {
     pub verbose: bool,
 }
 
-pub fn exec(command: Command) -> Result<()> {
-    forc_index_auth::init(command)?;
+pub async fn exec(command: Command) -> Result<()> {
+    forc_index_auth::init(command).await?;
     Ok(())
 }

--- a/plugins/forc-index/src/commands/deploy.rs
+++ b/plugins/forc-index/src/commands/deploy.rs
@@ -85,7 +85,7 @@ impl Default for Command {
         }
     }
 }
-pub fn exec(command: Command) -> Result<()> {
-    forc_index_deploy::init(command)?;
+pub async fn exec(command: Command) -> Result<()> {
+    forc_index_deploy::init(command).await?;
     Ok(())
 }

--- a/plugins/forc-index/src/commands/remove.rs
+++ b/plugins/forc-index/src/commands/remove.rs
@@ -31,7 +31,7 @@ pub struct Command {
     pub verbose: bool,
 }
 
-pub fn exec(command: Command) -> Result<()> {
-    forc_index_remove::init(command)?;
+pub async fn exec(command: Command) -> Result<()> {
+    forc_index_remove::init(command).await?;
     Ok(())
 }

--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -1,14 +1,14 @@
 use crate::{
     cli::{BuildCommand, DeployCommand},
     commands::build,
-    utils::project_dir_info,
+    utils::{file_part, project_dir_info},
 };
 use fuel_indexer_lib::manifest::Manifest;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::{
-    blocking::{multipart::Form, Client},
     header::{HeaderMap, AUTHORIZATION, CONNECTION},
-    StatusCode,
+    multipart::Form,
+    Client, StatusCode,
 };
 use serde_json::{to_string_pretty, value::Value, Map};
 use std::{path::Path, time::Duration};
@@ -17,7 +17,7 @@ use tracing::{error, info};
 const STEADY_TICK_INTERVAL: u64 = 120;
 const TCP_TIMEOUT: u64 = 3;
 
-pub fn init(command: DeployCommand) -> anyhow::Result<()> {
+pub async fn init(command: DeployCommand) -> anyhow::Result<()> {
     let DeployCommand {
         url,
         manifest,
@@ -69,10 +69,9 @@ pub fn init(command: DeployCommand) -> anyhow::Result<()> {
     }
 
     let form = Form::new()
-        .file("manifest", &manifest_path)?
-        .file("schema", manifest.graphql_schema())?
-        .file("wasm", manifest.module().to_string())?;
-
+        .part("manifest", file_part(&manifest_path).await?)
+        .part("schema", file_part(manifest.graphql_schema()).await?)
+        .part("wasm", file_part(manifest.module().to_string()).await?);
     let target = format!(
         "{url}/api/index/{}/{}",
         manifest.namespace(),
@@ -121,11 +120,13 @@ pub fn init(command: DeployCommand) -> anyhow::Result<()> {
         .multipart(form)
         .headers(headers)
         .send()
+        .await
         .expect("Failed to deploy indexer.");
 
     let status = res.status();
     let res_json = res
         .json::<Map<String, Value>>()
+        .await
         .expect("Failed to read JSON response.");
 
     if status != StatusCode::OK {

--- a/plugins/forc-index/src/ops/forc_index_remove.rs
+++ b/plugins/forc-index/src/ops/forc_index_remove.rs
@@ -1,14 +1,13 @@
 use crate::{cli::RemoveCommand, utils::project_dir_info};
 use fuel_indexer_lib::manifest::Manifest;
 use reqwest::{
-    blocking::Client,
     header::{HeaderMap, AUTHORIZATION},
-    StatusCode,
+    Client, StatusCode,
 };
 use serde_json::{to_string_pretty, value::Value, Map};
 use tracing::{error, info};
 
-pub fn init(command: RemoveCommand) -> anyhow::Result<()> {
+pub async fn init(command: RemoveCommand) -> anyhow::Result<()> {
     let RemoveCommand {
         path,
         manifest,
@@ -48,11 +47,13 @@ pub fn init(command: RemoveCommand) -> anyhow::Result<()> {
         .delete(&target)
         .headers(headers)
         .send()
+        .await
         .expect("Failed to remove indexer.");
 
     let status = res.status();
     let res_json = res
         .json::<Map<String, Value>>()
+        .await
         .expect("Failed to read JSON response.");
 
     if status != StatusCode::OK {

--- a/plugins/forc-index/src/ops/forc_index_welcome.rs
+++ b/plugins/forc-index/src/ops/forc_index_welcome.rs
@@ -179,7 +179,7 @@ async fn deploy_to_network(mut input: String, manifest: String) -> anyhow::Resul
                     };
                     start(start_command).await?;
                     build(build_command)?;
-                    deploy(deploy_command)?;
+                    deploy(deploy_command).await?;
                 }
                 "2" => {
                     // init for testnet
@@ -193,7 +193,7 @@ async fn deploy_to_network(mut input: String, manifest: String) -> anyhow::Resul
                     };
                     start(start_command).await?;
                     build(build_command)?;
-                    deploy(deploy_command)?;
+                    deploy(deploy_command).await?;
                 }
                 _ => {
                     println!("Invalid input. Please enter 1 or 2");

--- a/plugins/forc-index/src/utils.rs
+++ b/plugins/forc-index/src/utils.rs
@@ -1,5 +1,13 @@
+use reqwest::{multipart::Part, Body};
+use tokio::fs::File;
+use tokio::io;
+
 use crate::{defaults, defaults::manifest_name};
-use std::{fs::canonicalize, path::PathBuf, process::Command};
+use std::{
+    fs::canonicalize,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 pub fn dasherize_to_underscore(s: &str) -> String {
     str::replace(s, "-", "_")
@@ -69,4 +77,19 @@ pub fn center_align(s: &str, n: usize) -> String {
 
 pub fn rightpad_whitespace(s: &str, n: usize) -> String {
     format!("{s:0n$}")
+}
+
+pub async fn file_part<T: AsRef<Path>>(path: T) -> io::Result<Part> {
+    let path = path.as_ref();
+    let file_name = path
+        .file_name()
+        .map(|filename| filename.to_string_lossy().into_owned());
+    let file = File::open(path).await?;
+    let field = Part::stream(Body::from(file));
+
+    Ok(if let Some(file_name) = file_name {
+        field.file_name(file_name)
+    } else {
+        field
+    })
 }


### PR DESCRIPTION
For some reason the `forc-index deploy` command began to blow up on my machine. It seems like [`reqwest::blocking` was never supposed to play well with `tokio`](https://github.com/seanmonstar/reqwest/issues/1233) but somehow it did until now?

Anyways, this PR eliminates any usage of `reqwest::blocking` so this shouldn't be a problem anymore.

### Testing steps

- Try the affected commands: `auth`, `deploy`, `remove` and `welcome`

### Changelog

- fix: certain `forc-index` commands crashing `tokio`
