### PR TITLE
docs: adjust docs to include `--block-page-size` on start commands

### DIFF
--- a/docs/src/forc-index/start.md
+++ b/docs/src/forc-index/start.md
@@ -22,6 +22,9 @@ OPTIONS:
         --auth-strategy <AUTH_STRATEGY>
             Authentication scheme used.
 
+        --block-page-size <BLOCK_PAGE_SIZE>
+            Amount of blocks to return in a request to a Fuel node. [default: 10]
+
     -c, --config <FILE>
             Indexer service config file.
 

--- a/docs/src/getting-started/starting-the-fuel-indexer.md
+++ b/docs/src/getting-started/starting-the-fuel-indexer.md
@@ -18,6 +18,9 @@ OPTIONS:
         --auth-strategy <AUTH_STRATEGY>
             Authentication scheme used.
 
+        --block-page-size <BLOCK_PAGE_SIZE>
+            Amount of blocks to return in a request to a Fuel node. [default: 10]
+
     -c, --config <FILE>
             Indexer service config file.
 
@@ -67,9 +70,6 @@ OPTIONS:
 
         --metrics
             Use Prometheus metrics reporting.
-
-        --node-block-page-size <NODE_BLOCK_PAGE_SIZE>
-            Amount of blocks to return in a request to a Fuel node. [default: 10]
 
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.


### PR DESCRIPTION
### Description

Add `--block-page-size` flag to `fuel-indexer run` and `forc index start`.

### Testing steps

N/A