### PR TITLE
fix: spawn a tokio::task for kill_confirm.await to fix indexer SIGTERM

### DIFF
--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -364,10 +364,12 @@ async fn create_service_task(
                         killer.store(true, Ordering::SeqCst);
                         // If requester wants to be notified
                         if let Some(notify) = request.notify {
-                            // Wait for the indexer to stop
-                            kill_confirm.await.unwrap();
-                            // And send the notification
-                            notify.send(()).unwrap();
+                            tokio::spawn(async {
+                                // Wait for the indexer to stop
+                                kill_confirm.await.unwrap();
+                                // And send the notification
+                                notify.send(()).unwrap();
+                            });
                         }
                     } else {
                         warn!("Stop Indexer: No indexer with the name Indexer({uid})");


### PR DESCRIPTION
### Description

Spawn a separate `tokio::task` to await indexer kill confirmation and notify the listener.

This may have something to do with https://github.com/FuelLabs/fuel-indexer/issues/1191



