### PR TITLE
fix: bump array max size

### DIFF
--- a/packages/fuel-indexer-lib/src/lib.rs
+++ b/packages/fuel-indexer-lib/src/lib.rs
@@ -14,7 +14,7 @@ use quote::quote;
 use sha2::{Digest, Sha256};
 
 /// Max size of Postgres array types.
-pub const MAX_ARRAY_LENGTH: usize = 2500;
+pub const MAX_ARRAY_LENGTH: usize = 5000;
 
 /// The source of execution for the indexer.
 #[derive(Default, Clone, Debug)]


### PR DESCRIPTION
Thanks for opening a PR with the Fuel Indexer project, please review the **Checklist** below and ensure you've completed all of the necessary steps to make this PR review as painless as possible.


### Checklist
- [ ] Ensure your top-level commit message is inline with our [contributor guidelines](./CONTRIBUTING.md).
- [ ] Please add proper labels.
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)
- [ ] Please allow Codeowners at least 24 hours to do a first-pass review.
- [ ] Please add thorougly detailed testing steps below.
- [ ] Please keep your Changelog message short and sweet.

### Description

- Seeing another array size error on the playground

```bash
2023-08-04T21:14:10.166516Z  INFO fuel_indexer::database: 175: INSERT INTO fuel_explorer.output (id, recipient, amount, asset_id, is_coin, label, input_index, balance_root, state_root, is_contract, is_change, is_variable, contract, is_contract_created, is_unknown, object) VALUES (9615860387440682305, 'a1184d77d0d08a064e03b2bd9f50863e88faddea4693a05ca1ee9b1732ea99b7', 1152921504606846975, '0000000000000000000000000000000000000000000000000000000000000000', NULL, 'OutputLabel::Change', NULL, NULL, NULL, NULL, true, NULL, NULL, NULL, NULL, $1::bytea) ON CONFLICT(id) DO UPDATE SET id = 9615860387440682305, recipient = 'a1184d77d0d08a064e03b2bd9f50863e88faddea4693a05ca1ee9b1732ea99b7', amount = 1152921504606846975, asset_id = '0000000000000000000000000000000000000000000000000000000000000000', is_coin = NULL, label = 'OutputLabel::Change', input_index = NULL, balance_root = NULL, state_root = NULL, is_contract = NULL, is_change = true, is_variable = NULL, contract = NULL, is_contract_created = NULL, is_unknown = NULL
2023-08-04T21:14:10.174736Z ERROR fuel_indexer::executor: 160: Indexer(fuellabs.indexer_test) executor failed SqlxError(Database(PgDatabaseError { severity: Error, code: "23503", message: "update or delete on table \"block\" violates foreign key constraint \"fk_transaction_block__block_hash\" on table \"transaction\"", detail: Some("Key (hash)=(0eb0ba2def6ae83c24d640a3a9e1b1f67fcb8dde72198d009921f9879746112c) is still referenced from table \"transaction\"."), hint: None, position: None, where: None, schema: Some("fuellabs_indexer_test"), table: Some("transaction"), column: None, data_type: None, constraint: Some("fk_transaction_block__block_hash"), file: Some("ri_triggers.c"), line: Some(2553), routine: Some("ri_ReportViolation") })), retrying.
2023-08-04T21:14:10.174770Z  WARN fuel_indexer::executor: 169: Constraint violation. Continuing...
2023-08-04T21:14:10.191891Z  INFO fuel_indexer::database: 128: SELECT object from fuel_explorer.transaction where id = 6424023719303352911
thread 'tokio-runtime-worker' panicked at 'Array length exceeds maximum allowed length.', packages/fuel-indexer-schema/src/lib.rs:237:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2023-08-04T21:14:10.221130Z  INFO fuel_indexer::ffi: 79: Processing Block#70199. (>'.')>
2023-08-04T21:14:10.221191Z  INFO fuel_indexer::database: 175: INSERT INTO fuellabs_indexer_test.block (id, height, hash, object) VALUES (3847871990353508193, 70199, '80fe7d0dc261c69cc31ee0c57db840e7c1857ab299bc192ad0352badc242dbf4', $1::bytea) ON CONFLICT(id) DO UPDATE SET id = 3847871990353508193, height = 70199, hash = '80fe7d0dc261c69cc31ee0c57db840e7c1857ab299bc192ad0352badc242dbf4'
```

### Testing steps

- N/A

### Changelog

- fix: bump array max size


