### PR TITLE
fix: temporarily skip bad ids

### DIFF
--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -167,8 +167,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                             // Just bump the cursor and keep going
                             warn!("Constraint violation. Continuing...");
 
-                            // Try to fetch the page again using same cursor.
-                            continue;
+                            next_cursor = cursor;
                         } else {
                             error!("Database error: {inner}.");
                             sleep(Duration::from_secs(DELAY_FOR_SERVICE_ERROR)).await;


### PR DESCRIPTION
Thanks for opening a PR with the Fuel Indexer project, please review the **Checklist** below and ensure you've completed all of the necessary steps to make this PR review as painless as possible.


### Checklist
- [ ] Ensure your top-level commit message is inline with our [contributor guidelines](./CONTRIBUTING.md).
- [ ] Please add proper labels.
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)
- [ ] Please allow Codeowners at least 24 hours to do a first-pass review.
- [ ] Please add thorougly detailed testing steps below.
- [ ] Please keep your Changelog message short and sweet.

### Description

- Reverts back to the logic we had: skipping blocks that produce errors due to https://github.com/FuelLabs/fuel-indexer/issues/1093 until https://github.com/FuelLabs/fuel-indexer/issues/1208 is in 
- [Confirmed fix shown in "Test 7 Fix" in this doc](https://docs.google.com/spreadsheets/d/1RV_AWAhknxkgvA0I-A8WTZE8ZOu0Jv-azAn3-2LVC0o/edit#gid=649003433)

### Testing steps

- [ ] Deploy a default indexer to the service
- [ ] Should index with no memory leak around block ~67000
- [ ] Use the little script mentioned in https://github.com/FuelLabs/fuel-indexer/issues/1218 to record memory usage

### Changelog

- fix: temporarily skip bad ids



