### PR TITLE
log message for start block when resumable not set

### DIFF
--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -381,6 +381,10 @@ async fn get_start_block(
             info!("{action} Indexer({}) from block {block}", manifest.uid());
             Ok(block)
         }
-        None => Ok(manifest.start_block().unwrap_or(1)),
+        None => {
+            let block = manifest.start_block().unwrap_or(1);
+            info!("Starting Indexer({}) from block {block}", manifest.uid());
+            Ok(block)
+        }
     }
 }


### PR DESCRIPTION
### Description

For consistency, add a log message for the start block when the resumable flag is not set.

I ran into this recently deploying hello_indexer. I was surprised not to see anything. Meanwhile, resuming fuel-explorer showed up in the logs. 

### Testing steps

Please provide the _exact_ testing steps for the reviewer(s) if this PR requires testing.

### Changelog

* add a log message



