### PR TITLE
fix: add `OPTIONS` to allowed CORS methods

### DIFF
--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -317,8 +317,14 @@ impl WebApi {
             )
             .layer(
                 CorsLayer::new()
-                    .allow_methods(vec![Method::GET, Method::OPTIONS, Method::POST])
-                    .allow_origin(Any {}),
+                    .allow_methods(vec![
+                        Method::GET,
+                        Method::POST,
+                        Method::OPTIONS,
+                        Method::DELETE,
+                    ])
+                    .allow_origin(Any {})
+                    .allow_headers(Any {}),
             );
 
         Ok(app)

--- a/packages/fuel-indexer-api-server/src/api.rs
+++ b/packages/fuel-indexer-api-server/src/api.rs
@@ -317,7 +317,7 @@ impl WebApi {
             )
             .layer(
                 CorsLayer::new()
-                    .allow_methods(vec![Method::GET, Method::POST])
+                    .allow_methods(vec![Method::GET, Method::OPTIONS, Method::POST])
                     .allow_origin(Any {}),
             );
 


### PR DESCRIPTION
Closes #1265.

### Description

Adds `OPTIONS` to the allowed CORS methods.

### Testing steps

CI should pass.

### Manual Testing

Run the indexer service from one system. Then, attempt to make a query from a separate system that is not at the same address.



