### PR TITLE
fix: block height conversion

### DIFF
--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -6,7 +6,7 @@ use fuel_indexer_lib::utils::sha256_digest;
 use sqlx::{
     pool::PoolConnection,
     postgres::PgRow,
-    types::{BigDecimal, JsonValue},
+    types::JsonValue,
     Postgres, Row,
 };
 use std::str::FromStr;
@@ -684,7 +684,7 @@ pub async fn last_block_height_for_indexer(
     let row = sqlx::query(&query).fetch_one(conn).await?;
 
     Ok(row
-        .try_get::<BigDecimal, usize>(0)
+        .try_get::<i32, usize>(0)
         .map(|id| id.to_u32().expect("Bad block height."))
         .unwrap_or_else(|_e| 1))
 }

--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -3,12 +3,7 @@
 use bigdecimal::ToPrimitive;
 use fuel_indexer_database_types::*;
 use fuel_indexer_lib::utils::sha256_digest;
-use sqlx::{
-    pool::PoolConnection,
-    postgres::PgRow,
-    types::JsonValue,
-    Postgres, Row,
-};
+use sqlx::{pool::PoolConnection, postgres::PgRow, types::JsonValue, Postgres, Row};
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::info;

--- a/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml
+++ b/packages/fuel-indexer-tests/components/indices/fuel-indexer-test/fuel_indexer_test.yaml
@@ -9,4 +9,4 @@ identifier: index1
 module:
   wasm: target/wasm32-unknown-unknown/release/fuel_indexer_test.wasm
 report_metrics: true
-
+resumable: true

--- a/packages/fuel-indexer/src/lib.rs
+++ b/packages/fuel-indexer/src/lib.rs
@@ -15,6 +15,7 @@ pub use fuel_indexer_lib::{
     manifest::{Manifest, ManifestError, Module},
 };
 pub use fuel_indexer_schema::{db::IndexerSchemaDbError, FtColumn};
+pub use service::get_start_block;
 pub use service::IndexerService;
 use thiserror::Error;
 use wasmer::{ExportError, InstantiationError, RuntimeError};

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -357,7 +357,7 @@ async fn create_service_task(
 }
 
 /// Determine the starting block for this indexer.
-async fn get_start_block(
+pub async fn get_start_block(
     conn: &mut IndexerConnection,
     manifest: &Manifest,
 ) -> Result<u32, IndexerError> {


### PR DESCRIPTION
### Description

`block_height` is now `u32`. Attempting to get `BigDecimal` results in a silent error, and `last_block_height_for_indexer` always returns `1`. This PR fixes it. 

### Testing steps

Run `forc-index`:
```
cargo run -p fuel-indexer -- run --run-migrations --fuel-node-host beta-4.fuel.network --fuel-node-port 80 --replace-indexer --manifest examples/hello-world/hello-indexer/hello_indexer.manifest.yaml 
```
And restart:
```
cargo run -p fuel-indexer -- run --run-migrations --fuel-node-host beta-4.fuel.network --fuel-node-port 80
```

On `develop,` `hello_indexer` starts from `1`. With this fix, it resumes where it left off.

### Changelog

* fix `block_height` conversion: from `BigDecimal` to `i32`.
