### PR TITLE
fix: re-enable docker publish on master + re-enable plugin tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,8 +270,7 @@ jobs:
         run: cargo test --locked --all-targets --features trybuild -p
           fuel-indexer-tests
   forc-index-tests:
-    # if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_DEVELOP_OR_SEMVER != 'true'
-    if: false
+    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_DEVELOP_OR_SEMVER != 'true'
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
@@ -322,8 +321,7 @@ jobs:
           cd ..
           rm -rfv indexer-test
   build-and-test-examples:
-    # if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_DEVELOP_OR_SEMVER != 'true'
-    if: false
+    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_DEVELOP_OR_SEMVER != 'true'
     needs:
       - cargo-toml-fmt-check
       - set-env-vars
@@ -373,7 +371,7 @@ jobs:
   publish-docker-image:
     needs:
       - set-env-vars
-    if: needs.set-env-vars.outputs.IS_RELEASE == 'true'
+    if: needs.set-env-vars.outputs.IS_RELEASE == 'true' || needs.set-env-vars.outputs.IS_MASTER == 'true'
     runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       contents: read


### PR DESCRIPTION
Thanks for opening a PR with the Fuel Indexer project. Please review the **Checklist** below and ensure you've completed all of the necessary steps to make this PR review as painless as possible.


### Checklist
- [ ] Ensure your top-level commit message is in line with our [contributor guidelines](./CONTRIBUTING.md).
- [ ] Please add proper labels.
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)
- [ ] Please allow Codeowners at least 24 hours to do a first-pass review.
- [ ] Please add thoroughly detailed testing steps below.
- [ ] Please keep your Changelog message short and sweet.

### Description

- Re-enables docker publish on master (not sure why `env.IS_RELEASE` is not being set on release event, but can investigate later)
  - `latest` docker tag hasn't been published for 10 days (stopped after https://github.com/FuelLabs/fuel-indexer/pull/1224)
  - Originally disabled docker publishing on `IS_MASTER` because the image might contain unpublished changes
    - Still need to ideally have this ☝🏽 
- Doesn't require another release
  - New `latest is [here](https://github.com/FuelLabs/fuel-indexer/pkgs/container/fuel-indexer/versions)

### Testing steps

- N/A

### Changelog

- fix: re-enable docker publish on master + re-enable plugin tests
