### PR TITLE
Add library for dynamic GraphQL schema building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,10 +504,13 @@ dependencies = [
  "bytes",
  "fast_chemail",
  "fnv",
+ "futures-channel",
+ "futures-timer",
  "futures-util",
  "handlebars",
  "http",
  "indexmap 1.9.3",
+ "lru",
  "mime",
  "multer",
  "num-traits",
@@ -609,6 +618,18 @@ checksum = "d461325bfb04058070712296601dfe5e5bd6cdff84780a0a8c569ffb15c87eb3"
 dependencies = [
  "bytes",
  "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "6.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ae89db8cdd72492b16a487649405296eee4e40e25620d17720656816c4503a"
+dependencies = [
+ "bytes",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
 ]
@@ -3334,6 +3355,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuel-indexer-graphql-lib"
+version = "0.20.1"
+dependencies = [
+ "assert_matches",
+ "async-graphql 5.0.10",
+ "async-graphql-parser 5.0.10",
+ "async-graphql-value 6.0.4",
+ "async-trait",
+ "extension-trait",
+ "graphql-parser",
+ "indexmap 2.0.0",
+ "insta",
+ "serde_json",
+ "strum 0.25.0",
+ "tokio",
+ "velcro",
+]
+
+[[package]]
 name = "fuel-indexer-lib"
 version = "0.20.1"
 dependencies = [
@@ -3970,6 +4010,12 @@ name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -4613,6 +4659,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -4907,6 +4954,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -7095,6 +7151,9 @@ name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.2",
+]
 
 [[package]]
 name = "strum_macros"
@@ -7983,6 +8042,36 @@ name = "vec1"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bda7c41ca331fe9a1c278a9e7ee055f4be7f5eb1c2b72f079b4ff8b5fce9d5c"
+
+[[package]]
+name = "velcro"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c6a51883ba1034757307e06dc4856cd5439ecf6804ce6c90d13d49496196fc"
+dependencies = [
+ "velcro_macros",
+]
+
+[[package]]
+name = "velcro_core"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "742cf45d07989b7614877e083602a8973890c75a81f47216b238d2f326ec916c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "velcro_macros"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b23c806d7b49977e6e12ee6d120ac01dcab702b51c652fdf1a6709ab5b8868c"
+dependencies = [
+ "syn 1.0.109",
+ "velcro_core",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
    "packages/fuel-indexer-database/database-types",
    "packages/fuel-indexer-database/postgres",
    "packages/fuel-indexer-graphql",
+   "packages/fuel-indexer-graphql-lib",
    "packages/fuel-indexer-lib",
    "packages/fuel-indexer-macros",
    "packages/fuel-indexer-macros/macro-utils",
@@ -38,6 +39,7 @@ default-members = [
    "packages/fuel-indexer-database/database-types",
    "packages/fuel-indexer-database/postgres",
    "packages/fuel-indexer-graphql",
+   "packages/fuel-indexer-graphql-lib",
    "packages/fuel-indexer-lib",
    "packages/fuel-indexer-macros",
    "packages/fuel-indexer-metrics",
@@ -75,6 +77,7 @@ fuel-indexer-api-server = { version = "0.20.1", path = "./packages/fuel-indexer-
 fuel-indexer-database = { version = "0.20.1", path = "./packages/fuel-indexer-database" }
 fuel-indexer-database-types = { version = "0.20.1", path = "./packages/fuel-indexer-database/database-types" }
 fuel-indexer-graphql = { version = "0.20.1", path = "./packages/fuel-indexer-graphql" }
+fuel-indexer-graphql-lib = { version = "0.20.1", path = "./packages/fuel-indexer-graphql-lib" }
 fuel-indexer-lib = { version = "0.20.1", path = "./packages/fuel-indexer-lib" }
 fuel-indexer-macro-utils = { version = "0.20.1", path = "./packages/fuel-indexer-macros/macro-utils" }
 fuel-indexer-macros = { version = "0.20.1", path = "./packages/fuel-indexer-macros", default-features = false }

--- a/packages/fuel-indexer-graphql-lib/Cargo.toml
+++ b/packages/fuel-indexer-graphql-lib/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "fuel-indexer-graphql-lib"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "Fuel Indexer GraphQL Library"
+
+[features]
+default = ["json"]
+json = ["dep:serde_json"]
+
+[dependencies]
+async-graphql = { version = "5.0", features = ["dynamic-schema", "dataloader"] }
+async-graphql-value = "6.0.3"
+async-trait = "0.1.73"
+extension-trait = "1.0.2"
+indexmap = "2.0.0"
+serde_json = { workspace = true, optional = true }
+strum = { version = "0.25.0", features = ["derive"] }
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+async-graphql-parser = "5.0"
+graphql-parser = "0.4.0"
+insta = { version = "1.31.0", features = ["json"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt", "macros"] }
+velcro = "0.5.4"

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/connection.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/connection.rs
@@ -1,0 +1,19 @@
+//! `async_graphql::dynamic` extensions for handling GraphQL connections.
+//! See: https://graphql.org/learn/pagination/#end-of-list-counts-and-connections
+//! See: https://relay.dev/graphql/connections.htm#sec-Connection-Types
+
+use super::node::*;
+use super::paging::*;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DynamicConnectionEdge {
+    pub node_id: DynamicNodeId,
+    pub cursor: DynamicCursor,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DynamicConnection {
+    pub total_count: usize,
+    pub edges: Vec<DynamicConnectionEdge>,
+    pub page_info: DynamicPageInfo,
+}

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/data.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/data.rs
@@ -1,0 +1,51 @@
+use super::prelude::*;
+
+#[derive(Clone, Hash, PartialEq, Eq, Debug, EnumString, strum::Display)]
+pub enum DynamicDataType {
+    Int,
+    String,
+    // TODO: Implement remaining types
+}
+
+pub type DynamicData = serde_json::Value;
+
+pub type DynamicFieldId = String;
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub struct DynamicDataField(DynamicFieldId, DynamicDataType);
+impl DynamicDataField {
+    pub fn new(name: impl Into<String>, data_type: impl Into<DynamicDataType>) -> Self {
+        Self(name.into(), data_type.into())
+    }
+
+    pub fn id(&self) -> &DynamicFieldId {
+        &self.0
+    }
+    pub fn data_type(&self) -> &DynamicDataType {
+        &self.1
+    }
+}
+
+#[derive(Clone)]
+pub struct DynamicDataFieldResolver {
+    pub data_field: DynamicDataField,
+}
+impl DynamicDataFieldResolver {
+    pub fn new(data_field: DynamicDataField) -> Self {
+        Self { data_field }
+    }
+
+    pub fn resolve(self, data: &DynamicData) -> Option<FieldValue> {
+        let value = data.get(self.data_field.id()).unwrap();
+        match self.data_field.data_type() {
+            DynamicDataType::String => {
+                let value: String = value.as_str().unwrap().to_string();
+                Some(FieldValue::value(value))
+            }
+            DynamicDataType::Int => {
+                let value: i32 = value.as_i64().unwrap() as i32;
+                Some(FieldValue::value(value))
+            }
+        }
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/edge.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/edge.rs
@@ -1,0 +1,63 @@
+//! `async_graphql::dynamic` extensions for handling GraphQL connections.
+//! See: https://graphql.org/learn/pagination/#end-of-list-counts-and-connections
+//! See: https://relay.dev/graphql/connections.htm#sec-Connection-Types
+
+use super::node::*;
+use super::prelude::*;
+
+pub type DynamicEdgeTypeId = String;
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub struct DynamicEdgeId(DynamicEdgeTypeId, DynamicNodeLocalId, DynamicNodeLocalId);
+impl DynamicEdgeId {
+    pub fn new(
+        type_id: impl Into<DynamicEdgeTypeId>,
+        tail_local_id: impl Into<DynamicNodeLocalId>,
+        head_local_id: impl Into<DynamicNodeLocalId>,
+    ) -> Self {
+        Self(type_id.into(), tail_local_id.into(), head_local_id.into())
+    }
+}
+impl From<DynamicEdgeId> for String {
+    fn from(id: DynamicEdgeId) -> String {
+        format!("{}:{}:{}", id.0, id.1, id.2)
+    }
+}
+
+pub type DynamicEdgeData = serde_json::Value;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DynamicEdge(
+    DynamicEdgeTypeId,
+    DynamicNodeLocalId,
+    DynamicNodeLocalId,
+    DynamicEdgeData,
+);
+impl DynamicEdge {
+    pub fn new(
+        id: impl Into<DynamicEdgeTypeId>,
+        tail_local_id: impl Into<DynamicNodeLocalId>,
+        head_local_id: impl Into<DynamicNodeLocalId>,
+        data: impl Into<DynamicEdgeData>,
+    ) -> Self {
+        Self(
+            id.into(),
+            tail_local_id.into(),
+            head_local_id.into(),
+            data.into(),
+        )
+    }
+
+    pub fn type_id(&self) -> &DynamicEdgeTypeId {
+        &self.0
+    }
+    pub fn tail_local_id(&self) -> &DynamicNodeLocalId {
+        &self.1
+    }
+    pub fn head_local_id(&self) -> &DynamicNodeLocalId {
+        &self.2
+    }
+    pub fn data(&self) -> &DynamicEdgeData {
+        &self.3
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/loader.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/loader.rs
@@ -1,0 +1,76 @@
+use super::edge::*;
+use super::node::*;
+use super::prelude::*;
+
+#[async_trait]
+pub trait DynamicLoader: Send + Sync + 'static {
+    async fn load_node_by_id(
+        &self,
+        id: &DynamicNodeId,
+    ) -> Result<Option<DynamicNode>, ()>;
+    async fn load_nodes_by_id(
+        &self,
+        ids: &[DynamicNodeId],
+    ) -> Result<Vec<Option<DynamicNode>>, ()>;
+    async fn load_edges(
+        &self,
+        type_id: &DynamicEdgeTypeId,
+        tail_local_id: &DynamicNodeLocalId,
+    ) -> Result<Vec<DynamicEdge>, ()>;
+}
+
+pub struct TestLoader {
+    pub nodes: HashMap<DynamicNodeId, DynamicNode>,
+    pub edges: HashMap<(DynamicEdgeTypeId, DynamicNodeLocalId), DynamicEdge>,
+}
+impl TestLoader {
+    pub fn new(nodes: Vec<DynamicNode>, edges: Vec<DynamicEdge>) -> Self {
+        let nodes = nodes
+            .into_iter()
+            .map(|node| (node.id(), node))
+            .collect::<HashMap<_, _>>();
+        let edges = edges
+            .into_iter()
+            .map(|edge| ((edge.type_id().clone(), edge.tail_local_id().clone()), edge))
+            .collect::<HashMap<_, _>>();
+        Self { nodes, edges }
+    }
+}
+
+#[async_trait]
+impl DynamicLoader for TestLoader {
+    async fn load_node_by_id(
+        &self,
+        id: &DynamicNodeId,
+    ) -> Result<Option<DynamicNode>, ()> {
+        let node = self.nodes.get(id);
+        Ok(node.cloned())
+    }
+
+    async fn load_nodes_by_id(
+        &self,
+        ids: &[DynamicNodeId],
+    ) -> Result<Vec<Option<DynamicNode>>, ()> {
+        let mut nodes = Vec::new();
+        for id in ids {
+            let node = self.load_node_by_id(id).await?;
+            nodes.push(node);
+        }
+        Ok(nodes)
+    }
+
+    async fn load_edges(
+        &self,
+        type_id: &DynamicEdgeTypeId,
+        tail_local_id: &DynamicNodeLocalId,
+    ) -> Result<Vec<DynamicEdge>, ()> {
+        let edges = self
+            .edges
+            .iter()
+            .filter(|(id, _edge)| id.0 == *type_id && id.1 == *tail_local_id)
+            .map(|(_, edge)| edge)
+            .cloned()
+            .collect();
+        Ok(edges)
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/mod.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/mod.rs
@@ -1,0 +1,27 @@
+pub mod connection;
+pub mod data;
+pub mod edge;
+pub mod loader;
+pub mod node;
+pub mod paging;
+pub mod resolver;
+
+pub use connection::*;
+pub use data::*;
+pub use edge::*;
+pub use loader::*;
+pub use node::*;
+pub use paging::*;
+pub use resolver::*;
+
+pub(self) mod prelude {
+    pub use crate::prelude::*;
+    pub use crate::spec::*;
+    pub use crate::util::*;
+    pub use async_graphql::dynamic::*;
+    pub use std::collections::HashMap;
+    pub use std::hash::Hash;
+    pub use std::str::FromStr;
+    pub use std::sync::Arc;
+    pub use strum::EnumString;
+}

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/node.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/node.rs
@@ -1,0 +1,128 @@
+//! `async_graphql::dynamic` extensions for handling GraphQL nodes.
+//! See: https://graphql.org/learn/global-object-identification/#node-interface
+
+use super::data::*;
+use super::prelude::*;
+use super::resolver::*;
+
+pub type DynamicNodeLocalId = String;
+
+pub type DynamicNodeTypeId = String;
+
+#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+pub struct DynamicNodeId(DynamicNodeTypeId, DynamicNodeLocalId);
+impl DynamicNodeId {
+    pub fn new(
+        type_id: impl Into<DynamicNodeTypeId>,
+        local_id: impl Into<DynamicNodeLocalId>,
+    ) -> Self {
+        Self(type_id.into(), local_id.into())
+    }
+}
+impl DynamicNodeId {
+    pub fn type_id(&self) -> &DynamicNodeTypeId {
+        &self.0
+    }
+    pub fn local_id(&self) -> &DynamicNodeLocalId {
+        &self.1
+    }
+}
+impl FromStr for DynamicNodeId {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut split = s.splitn(2, ':');
+        let type_id = split.next().unwrap().parse().unwrap();
+        let local_id = split.next().unwrap().to_string();
+        Ok(Self(type_id, local_id))
+    }
+}
+impl From<DynamicNodeId> for String {
+    fn from(id: DynamicNodeId) -> String {
+        format!("{}:{}", id.type_id(), id.local_id())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DynamicNode(DynamicNodeTypeId, DynamicNodeLocalId, DynamicData);
+impl DynamicNode {
+    pub fn new(
+        type_id: impl Into<DynamicNodeTypeId>,
+        local_id: impl Into<DynamicNodeLocalId>,
+        data: impl Into<DynamicData>,
+    ) -> Self {
+        Self(type_id.into(), local_id.into(), data.into())
+    }
+
+    pub fn id(&self) -> DynamicNodeId {
+        DynamicNodeId::new(self.type_id(), self.local_id())
+    }
+    pub fn type_id(&self) -> &DynamicNodeTypeId {
+        &self.0
+    }
+    pub fn local_id(&self) -> &DynamicNodeLocalId {
+        &self.1
+    }
+    pub fn data(&self) -> &DynamicData {
+        &self.2
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub struct DynamicConnectionField {
+    pub id: DynamicFieldId,
+    pub ref_node_type_id: DynamicNodeTypeId,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub struct DynamicRefField {
+    pub id: DynamicFieldId,
+    pub data_field_id: DynamicFieldId,
+    pub ref_node_type_id: DynamicNodeTypeId,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DynamicNodeType {
+    pub id: DynamicNodeTypeId,
+    pub data_fields: Vec<DynamicDataField>,
+    pub ref_fields: Vec<DynamicRefField>,
+    pub connection_fields: Vec<DynamicConnectionField>,
+}
+
+impl From<DynamicNodeType> for Object {
+    fn from(value: DynamicNodeType) -> Self {
+        let name = TypeRef::node(value.id.clone());
+
+        let mut object = <Object as NodeObject<DynamicResolver>>::new_node(&name);
+
+        // Add data fields
+        for data_field in &value.data_fields {
+            object = <Object as NodeObject<DynamicResolver>>::data_field(
+                object,
+                data_field.id(),
+                TypeRef::named_nn(data_field.data_type().to_string()),
+            );
+        }
+
+        // Add ref fields
+        for ref_field in &value.ref_fields {
+            object = <Object as NodeObject<DynamicResolver>>::ref_field(
+                object,
+                ref_field.id.clone(),
+                TypeRef::named_nn(ref_field.ref_node_type_id.to_string()),
+            );
+        }
+
+        // Add connection fields
+        for connection_field in &value.connection_fields {
+            object = <Object as NodeObject<DynamicResolver>>::connection_field(
+                object,
+                connection_field.id.clone(),
+                TypeRef::named_nn(TypeRef::connection(
+                    connection_field.ref_node_type_id.clone(),
+                )),
+            );
+        }
+
+        object
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/paging.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/paging.rs
@@ -1,0 +1,11 @@
+use super::prelude::*;
+
+pub type DynamicCursor = Cursor;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DynamicPageInfo {
+    pub has_next_page: bool,
+    pub has_previous_page: bool,
+    pub start_cursor: Option<DynamicCursor>,
+    pub end_cursor: Option<DynamicCursor>,
+}

--- a/packages/fuel-indexer-graphql-lib/src/dynamic/resolver.rs
+++ b/packages/fuel-indexer-graphql-lib/src/dynamic/resolver.rs
@@ -1,0 +1,310 @@
+use super::connection::*;
+use super::data::*;
+use super::loader::*;
+use super::node::*;
+use super::paging::*;
+use super::prelude::*;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+pub struct DynamicResolver {
+    pub node_types: HashMap<DynamicNodeTypeId, DynamicNodeType>,
+    pub loader: Arc<Mutex<dyn DynamicLoader>>,
+}
+impl DynamicResolver {
+    pub fn new(
+        node_types: Vec<DynamicNodeType>,
+        loader: Arc<Mutex<dyn DynamicLoader>>,
+    ) -> Self {
+        let node_types = node_types
+            .into_iter()
+            .map(|node_type| (node_type.id.clone(), node_type))
+            .collect::<HashMap<_, _>>();
+        Self { node_types, loader }
+    }
+}
+
+impl QueryResolver for DynamicResolver {
+    fn resolve_node_by_id(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let resolver = ctx.data_unchecked::<Self>();
+            let id = ctx.args.get("id").unwrap();
+            let id = id.string().unwrap();
+            let id: DynamicNodeId = id.parse().unwrap();
+            let loader = resolver.loader.lock().await;
+            let node = loader.load_node_by_id(&id).await.unwrap();
+            if let Some(node) = node {
+                let type_id = node.type_id().clone();
+                Ok(Some(FieldValue::owned_any(node.clone()).with_type(type_id)))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+    fn resolve_node_by_ids(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let resolver = ctx.data_unchecked::<Self>();
+            let ids = ctx.args.get("ids").unwrap();
+            let ids = ids.list().unwrap();
+            let ids = ids
+                .iter()
+                .map(|id| id.string().unwrap().parse())
+                .collect::<Result<Vec<DynamicNodeId>, _>>()
+                .unwrap();
+            let loader = resolver.loader.lock().await;
+            let nodes = loader.load_nodes_by_id(ids.as_slice()).await.unwrap();
+            let nodes = nodes
+                .into_iter()
+                .map(|node| {
+                    if let Some(node) = node {
+                        let type_id = node.type_id().clone();
+                        FieldValue::owned_any(node.clone()).with_type(type_id)
+                    } else {
+                        FieldValue::NULL
+                    }
+                })
+                .collect::<Vec<_>>();
+            Ok(Some(FieldValue::list(nodes)))
+        })
+    }
+}
+
+impl NodeResolver for DynamicResolver {
+    fn resolve_id(
+        ctx: async_graphql::dynamic::ResolverContext,
+    ) -> async_graphql::dynamic::FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicNode>()?;
+            let value: String = parent.id().into();
+            Ok(Some(FieldValue::value(value)))
+        })
+    }
+    fn resolve_data(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicNode>()?;
+            let path_node = ctx.path_node.unwrap();
+            let field_name = path_node.field_name();
+            let resolver = ctx.data_unchecked::<Self>();
+            let node_type = resolver.node_types.get(parent.type_id()).unwrap();
+            let field_type = node_type
+                .data_fields
+                .iter()
+                .find(|field_type| field_type.id() == field_name)
+                .unwrap();
+            match field_type.data_type() {
+                DynamicDataType::String => {
+                    let value = parent.data()[field_name].as_str().unwrap();
+                    Ok(Some(FieldValue::value(value)))
+                }
+                DynamicDataType::Int => {
+                    let value = parent.data()[field_name].as_i64().unwrap();
+                    Ok(Some(FieldValue::value(value)))
+                }
+            }
+        })
+    }
+    fn resolve_ref(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicNode>()?;
+            let path_node = ctx.path_node.unwrap();
+            let field_name = path_node.field_name();
+            let resolver = ctx.data_unchecked::<Self>();
+            let node_type = resolver.node_types.get(parent.type_id()).unwrap();
+            let field_type = node_type
+                .ref_fields
+                .iter()
+                .find(|field_type| field_type.id == field_name)
+                .unwrap();
+            let data_field_id = &field_type.data_field_id;
+            let local_id = parent.data()[data_field_id].as_str().unwrap();
+            let id = DynamicNodeId::new(field_type.ref_node_type_id.clone(), local_id);
+            let resolver = ctx.data_unchecked::<Self>();
+            let loader = resolver.loader.lock().await;
+            let node = loader.load_node_by_id(&id).await.unwrap().unwrap();
+            Ok(Some(FieldValue::owned_any(node.clone())))
+        })
+    }
+    fn resolve_connection(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicNode>()?;
+            let path_node = ctx.path_node.unwrap();
+            let field_name = path_node.field_name();
+            let resolver = ctx.data_unchecked::<Self>();
+            let node_type = resolver.node_types.get(parent.type_id()).unwrap();
+            let field_type = node_type
+                .connection_fields
+                .iter()
+                .find(|field_type| field_type.id == field_name)
+                .unwrap();
+            let resolver = ctx.data_unchecked::<Self>();
+            match (node_type.id.as_str(), field_type.ref_node_type_id.as_str()) {
+                ("Chain", "Block") => {
+                    let loader = resolver.loader.lock().await;
+                    let edges = loader
+                        .load_edges(&"ChainHasBlock".to_string(), parent.local_id())
+                        .await
+                        .unwrap();
+                    let edges = edges
+                        .iter()
+                        .map(|edge| DynamicConnectionEdge {
+                            node_id: DynamicNodeId::new("Block", edge.head_local_id()),
+                            cursor: "".to_string(),
+                        })
+                        .collect::<Vec<_>>();
+                    let total_count = edges.len();
+                    let connection = DynamicConnection {
+                        edges,
+                        total_count,
+                        page_info: DynamicPageInfo {
+                            has_next_page: false,
+                            has_previous_page: false,
+                            start_cursor: None,
+                            end_cursor: None,
+                        },
+                    };
+                    Ok(Some(FieldValue::owned_any(connection)))
+                }
+                ("Chain", "Transaction") => {
+                    let loader = resolver.loader.lock().await;
+                    let edges = loader
+                        .load_edges(&"ChainHasTransaction".to_string(), parent.local_id())
+                        .await
+                        .unwrap();
+                    let edges = edges
+                        .iter()
+                        .map(|edge| DynamicConnectionEdge {
+                            node_id: DynamicNodeId::new(
+                                "Transaction",
+                                edge.head_local_id(),
+                            ),
+                            cursor: "".to_string(),
+                        })
+                        .collect::<Vec<_>>();
+                    let total_count = edges.len();
+                    let connection = DynamicConnection {
+                        edges,
+                        total_count,
+                        page_info: DynamicPageInfo {
+                            has_next_page: false,
+                            has_previous_page: false,
+                            start_cursor: None,
+                            end_cursor: None,
+                        },
+                    };
+                    Ok(Some(FieldValue::owned_any(connection)))
+                }
+                _ => unreachable!(),
+            }
+        })
+    }
+}
+
+impl ConnectionResolver for DynamicResolver {
+    fn resolve_total_count(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicConnection>()?;
+            Ok(Some(FieldValue::value(parent.total_count)))
+        })
+    }
+    fn resolve_nodes(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicConnection>()?;
+            let node_ids = parent
+                .edges
+                .iter()
+                .map(|edge| edge.node_id.clone())
+                .collect::<Vec<_>>();
+            let resolver = ctx.data_unchecked::<Self>();
+            let loader = resolver.loader.lock().await;
+            let nodes = loader.load_nodes_by_id(node_ids.as_slice()).await.unwrap();
+            let nodes = nodes
+                .into_iter()
+                .map(|node| {
+                    if let Some(node) = node {
+                        FieldValue::owned_any(node.clone())
+                    } else {
+                        FieldValue::NULL
+                    }
+                })
+                .collect::<Vec<_>>();
+            Ok(Some(FieldValue::list(nodes)))
+        })
+    }
+    fn resolve_edges(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicConnection>()?;
+            let edges = parent
+                .edges
+                .iter()
+                .map(|edge| FieldValue::owned_any(edge.clone()))
+                .collect::<Vec<_>>();
+            Ok(Some(FieldValue::list(edges)))
+        })
+    }
+    fn resolve_page_info(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicConnection>()?;
+            Ok(Some(FieldValue::owned_any(parent.page_info.clone())))
+        })
+    }
+}
+
+impl EdgeResolver for DynamicResolver {
+    fn resolve_node(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx
+                .parent_value
+                .try_downcast_ref::<DynamicConnectionEdge>()?;
+            let id = &parent.node_id;
+            let resolver = ctx.data_unchecked::<Self>();
+            let loader = resolver.loader.lock().await;
+            let node = loader.load_node_by_id(id).await.unwrap().unwrap();
+            Ok(Some(FieldValue::owned_any(node.clone())))
+        })
+    }
+    fn resolve_cursor(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx
+                .parent_value
+                .try_downcast_ref::<DynamicConnectionEdge>()?;
+            Ok(Some(FieldValue::value(parent.cursor.clone())))
+        })
+    }
+}
+
+impl PageInfoResolver for DynamicResolver {
+    fn resolve_has_next_page(
+        ctx: async_graphql::dynamic::ResolverContext,
+    ) -> async_graphql::dynamic::FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicPageInfo>()?;
+            Ok(Some(FieldValue::value(parent.has_next_page)))
+        })
+    }
+    fn resolve_has_previous_page(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicPageInfo>()?;
+            Ok(Some(FieldValue::value(parent.has_previous_page)))
+        })
+    }
+    fn resolve_start_cursor(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicPageInfo>()?;
+            if let Some(start_cursor) = &parent.start_cursor {
+                Ok(Some(FieldValue::value(start_cursor.clone())))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+    fn resolve_end_cursor(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<DynamicPageInfo>()?;
+            if let Some(end_cursor) = &parent.end_cursor {
+                Ok(Some(FieldValue::value(end_cursor.clone())))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/json_resolver.rs
+++ b/packages/fuel-indexer-graphql-lib/src/json_resolver.rs
@@ -1,0 +1,180 @@
+use std::collections::HashMap;
+
+pub use crate::spec::*;
+
+use crate::spec::PageInfoResolver;
+
+pub(self) mod prelude {
+    pub use crate::spec::*;
+    pub use async_graphql::dynamic::*;
+    pub use serde_json::Value as JsonValue;
+}
+
+use prelude::*;
+
+pub struct Node(pub String, pub JsonValue);
+impl Node {
+    pub fn id(&self) -> &str {
+        &self.0
+    }
+    pub fn type_id(&self) -> &str {
+        self.id().split(':').next().unwrap()
+    }
+    pub fn local_id(&self) -> &str {
+        self.id().split(':').nth(1).unwrap()
+    }
+    pub fn data(&self) -> &JsonValue {
+        &self.1
+    }
+
+    pub fn to_field_value(&self) -> FieldValue {
+        FieldValue::borrowed_any(self)
+    }
+    pub fn to_typed_field_value(&self) -> FieldValue {
+        let type_id = self.type_id().to_string();
+        FieldValue::borrowed_any(self).with_type(type_id)
+    }
+}
+
+pub struct JsonResolver {
+    pub nodes: HashMap<String, Node>,
+}
+impl JsonResolver {
+    pub fn new(nodes: Vec<Node>) -> Self {
+        let nodes = nodes
+            .into_iter()
+            .map(|node| (node.id().to_string(), node))
+            .collect::<HashMap<_, _>>();
+        Self { nodes }
+    }
+}
+
+impl QueryResolver for JsonResolver {
+    fn resolve_node_by_id(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let resolver = ctx.data_unchecked::<JsonResolver>();
+            let id = ctx.args.get("id").unwrap();
+            let id = id.string().unwrap();
+            let node = resolver.nodes.get(id);
+            if let Some(node) = node {
+                Ok(Some(node.to_typed_field_value()))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+    fn resolve_node_by_ids(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let resolver = ctx.data_unchecked::<JsonResolver>();
+            let ids = ctx.args.get("ids").unwrap();
+            let ids = ids.list().unwrap();
+            let ids = ids
+                .iter()
+                .map(|id| id.string().unwrap().to_string())
+                .collect::<Vec<_>>();
+            let nodes = ids
+                .iter()
+                .map(|id| {
+                    let node = resolver.nodes.get(id).unwrap();
+                    node.to_typed_field_value()
+                })
+                .collect::<Vec<_>>();
+            Ok(Some(FieldValue::list(nodes)))
+        })
+    }
+}
+
+impl NodeResolver for JsonResolver {
+    fn resolve_id(
+        ctx: async_graphql::dynamic::ResolverContext,
+    ) -> async_graphql::dynamic::FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<Node>()?;
+            Ok(Some(FieldValue::value(parent.id())))
+        })
+    }
+    fn resolve_data(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<Node>()?;
+            let path_node = ctx.path_node.unwrap();
+            let field_name = path_node.field_name();
+            let value = parent.data()[field_name].as_str().unwrap();
+            Ok(Some(FieldValue::value(value)))
+        })
+    }
+    fn resolve_ref(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<Node>()?;
+            let path_node = ctx.path_node.unwrap();
+            let field_name = path_node.field_name();
+            let id = parent.data()[field_name].as_str().unwrap();
+            let resolver = ctx.data_unchecked::<JsonResolver>();
+            let node = resolver.nodes.get(id).unwrap();
+            Ok(Some(node.to_field_value()))
+        })
+    }
+    fn resolve_connection(_ctx: ResolverContext) -> FieldFuture {
+        unimplemented!()
+    }
+}
+
+impl ConnectionResolver for JsonResolver {
+    fn resolve_total_count(_ctx: ResolverContext) -> FieldFuture {
+        unimplemented!()
+    }
+    fn resolve_nodes(_ctx: ResolverContext) -> FieldFuture {
+        unimplemented!()
+    }
+    fn resolve_edges(_ctx: ResolverContext) -> FieldFuture {
+        unimplemented!()
+    }
+    fn resolve_page_info(_ctx: ResolverContext) -> FieldFuture {
+        unimplemented!()
+    }
+}
+
+impl EdgeResolver for JsonResolver {
+    fn resolve_node(_ctx: ResolverContext) -> FieldFuture {
+        unimplemented!()
+    }
+    fn resolve_cursor(_ctx: ResolverContext) -> FieldFuture {
+        unimplemented!()
+    }
+}
+
+impl PageInfoResolver for JsonResolver {
+    fn resolve_has_next_page(
+        ctx: async_graphql::dynamic::ResolverContext,
+    ) -> async_graphql::dynamic::FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<JsonValue>()?;
+            Ok(Some(FieldValue::value(
+                parent["has_next_page"].as_bool().unwrap(),
+            )))
+        })
+    }
+    fn resolve_has_previous_page(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<JsonValue>()?;
+            Ok(Some(FieldValue::value(
+                parent["has_previous_page"].as_bool().unwrap(),
+            )))
+        })
+    }
+    fn resolve_start_cursor(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<JsonValue>()?;
+            Ok(Some(FieldValue::value(
+                parent["start_cursor"].as_str().unwrap(),
+            )))
+        })
+    }
+    fn resolve_end_cursor(ctx: ResolverContext) -> FieldFuture {
+        FieldFuture::new(async move {
+            let parent = ctx.parent_value.try_downcast_ref::<JsonValue>()?;
+            Ok(Some(FieldValue::value(
+                parent["end_cursor"].as_str().unwrap(),
+            )))
+        })
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/lib.rs
+++ b/packages/fuel-indexer-graphql-lib/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod dynamic;
+#[cfg(feature = "json")]
+pub mod json_resolver;
+pub mod spec;
+#[cfg(test)]
+pub mod test;
+pub mod util;
+
+pub(self) mod prelude {
+    pub use async_trait::async_trait;
+    pub use extension_trait::extension_trait;
+}

--- a/packages/fuel-indexer-graphql-lib/src/spec/connection.rs
+++ b/packages/fuel-indexer-graphql-lib/src/spec/connection.rs
@@ -1,0 +1,102 @@
+//! `async_graphql::dynamic` extensions for handling GraphQL connections.
+//! See: https://graphql.org/learn/pagination/#end-of-list-counts-and-connections
+//! See: https://relay.dev/graphql/connections.htm#sec-Connection-Types
+
+use super::node::*;
+use super::paging::*;
+use super::prelude::*;
+
+#[extension_trait]
+pub impl ConnectionTypeRef for TypeRef {
+    fn edge(node_name: impl Into<String>) -> String {
+        format!("{}Edge", node_name.into())
+    }
+    fn connection(node_name: impl Into<String>) -> String {
+        format!("{}Connection", node_name.into())
+    }
+}
+
+#[extension_trait]
+pub impl<Resolver: ConnectionResolver> ConnectionObject<Resolver> for Object {
+    fn new_connection(node_name: impl Into<String>) -> Self {
+        let node_name = node_name.into();
+        Self::new(TypeRef::connection(node_name.clone()))
+            .field(Field::new(
+                "totalCount",
+                TypeRef::named_nn(TypeRef::INT),
+                Resolver::resolve_total_count,
+            ))
+            .field(Field::new(
+                "nodes",
+                TypeRef::named_nn_list_nn(node_name.clone()),
+                Resolver::resolve_nodes,
+            ))
+            .field(Field::new(
+                "edges",
+                TypeRef::named_nn_list_nn(TypeRef::edge(node_name)),
+                Resolver::resolve_edges,
+            ))
+            .field(Field::new(
+                "pageInfo",
+                TypeRef::named_nn(TypeRef::PAGE_INFO),
+                Resolver::resolve_page_info,
+            ))
+    }
+}
+
+pub trait ConnectionResolver: Send + Sync + 'static {
+    fn resolve_total_count(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_nodes(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_edges(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_page_info(ctx: ResolverContext) -> FieldFuture;
+}
+
+#[extension_trait]
+pub impl<Resolver: EdgeResolver> EdgeObject<Resolver> for Object {
+    fn new_edge(name: impl Into<String>, head_name: impl Into<String>) -> Self {
+        Self::new(TypeRef::edge(name))
+            .field(Field::new(
+                "node",
+                TypeRef::named_nn(TypeRef::node(head_name)),
+                Resolver::resolve_node,
+            ))
+            .field(Field::new(
+                "cursor",
+                TypeRef::named_nn(TypeRef::CURSOR),
+                Resolver::resolve_cursor,
+            ))
+    }
+}
+
+pub trait EdgeResolver: Send + Sync + 'static {
+    fn resolve_node(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_cursor(ctx: ResolverContext) -> FieldFuture;
+}
+
+#[extension_trait]
+pub impl FieldConnectionExt for Field {
+    /// Add connection arguments to a field.
+    /// See: https://relay.dev/graphql/connections.htm#sec-Arguments
+    fn connection_arguments(self) -> Self {
+        // Forward pagination arguments
+        self.argument(
+            InputValue::new("first", TypeRef::named(TypeRef::INT)).description(
+                "Paginate forward, returning the given amount of edges at most.",
+            ),
+        )
+        .argument(
+            InputValue::new("after", TypeRef::named(TypeRef::CURSOR))
+                .description("Return edges after the given cursor."),
+        )
+        // Backward pagination arguments
+        .argument(
+            InputValue::new("last", TypeRef::named(TypeRef::INT)).description(
+                "Paginate backward, returning the given amount of edges at most.",
+            ),
+        )
+        .argument(
+            InputValue::new("before", TypeRef::named(TypeRef::CURSOR))
+                .description("Return edges before the given cursor."),
+        )
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/spec/mod.rs
+++ b/packages/fuel-indexer-graphql-lib/src/spec/mod.rs
@@ -1,0 +1,27 @@
+//! Module for GraphQL spec types.
+//!
+//! Graph Theory: https://en.wikipedia.org/wiki/Graph_theory
+//! Directed Graph: https://en.wikipedia.org/wiki/Directed_graph
+//! Glossary: https://en.wikipedia.org/wiki/Glossary_of_graph_theory
+//! GraphQL Spec: https://spec.graphql.org/draft/
+//! GraphQL Docs: https://graphql.org/learn/
+//! GraphQL Cursor Connections Spec: https://relay.dev/graphql/connections.htm
+//! TAO Article: https://engineering.fb.com/2013/06/25/core-data/tao-the-power-of-the-graph/
+//! TAO Paper: https://research.facebook.com/publications/tao-facebooks-distributed-data-store-for-the-social-graph/
+
+pub mod connection;
+pub mod node;
+pub mod paging;
+pub mod query;
+
+pub use connection::*;
+pub use node::*;
+pub use paging::*;
+pub use query::*;
+
+pub(self) mod prelude {
+    pub use crate::prelude::*;
+    pub use crate::util::*;
+    pub use async_graphql::dynamic::*;
+    pub use std::{hash::Hash, str::FromStr};
+}

--- a/packages/fuel-indexer-graphql-lib/src/spec/node.rs
+++ b/packages/fuel-indexer-graphql-lib/src/spec/node.rs
@@ -1,0 +1,53 @@
+//! `async_graphql::dynamic` extensions for handling GraphQL nodes.
+//! See: https://graphql.org/learn/global-object-identification/#node-interface
+
+use super::connection::*;
+use super::prelude::*;
+
+#[extension_trait]
+pub impl NodeTypeRef for TypeRef {
+    const NODE: &'static str = "Node";
+    fn node(node_name: impl Into<String>) -> String {
+        node_name.into()
+    }
+}
+
+#[extension_trait]
+pub impl NodeInterface for Interface {
+    fn new_node() -> Self {
+        Self::new(TypeRef::NODE)
+            .field(InterfaceField::new("id", TypeRef::named_nn(TypeRef::ID)))
+    }
+}
+
+#[extension_trait]
+pub impl<Resolver: NodeResolver> NodeObject<Resolver> for Object {
+    fn new_node(name: impl Into<String>) -> Self {
+        Self::new(TypeRef::node(name))
+            .implement(TypeRef::NODE)
+            .field(Field::new(
+                "id",
+                TypeRef::named_nn(TypeRef::ID),
+                Resolver::resolve_id,
+            ))
+    }
+
+    fn data_field(self, name: impl Into<String>, ty: impl Into<TypeRef>) -> Self {
+        self.field(Field::new(name, ty, Resolver::resolve_data))
+    }
+    fn ref_field(self, name: impl Into<String>, ty: impl Into<TypeRef>) -> Self {
+        self.field(Field::new(name, ty, Resolver::resolve_ref))
+    }
+    fn connection_field(self, name: impl Into<String>, ty: impl Into<TypeRef>) -> Self {
+        self.field(
+            Field::new(name, ty, Resolver::resolve_connection).connection_arguments(),
+        )
+    }
+}
+
+pub trait NodeResolver: Send + Sync + 'static {
+    fn resolve_id(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_data(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_ref(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_connection(ctx: ResolverContext) -> FieldFuture;
+}

--- a/packages/fuel-indexer-graphql-lib/src/spec/paging.rs
+++ b/packages/fuel-indexer-graphql-lib/src/spec/paging.rs
@@ -1,0 +1,47 @@
+//! `async_graphql::dynamic` extensions for handling pagination.
+//! See: https://graphql.org/learn/pagination/
+
+use super::prelude::*;
+
+pub type Cursor = String;
+
+#[extension_trait]
+pub impl PagingTypeRef for TypeRef {
+    const CURSOR: &'static str = "String";
+    const PAGE_INFO: &'static str = "PageInfo";
+}
+
+/// See: https://relay.dev/graphql/connections.htm#sec-PageInfo
+#[extension_trait]
+pub impl<Resolver: PageInfoResolver> PageInfoObject<Resolver> for Object {
+    fn new_page_info() -> Self {
+        Self::new(TypeRef::PAGE_INFO)
+            .field(Field::new(
+                "hasNextPage",
+                TypeRef::named_nn(TypeRef::BOOLEAN),
+                Resolver::resolve_has_next_page,
+            ))
+            .field(Field::new(
+                "hasPreviousPage",
+                TypeRef::named_nn(TypeRef::BOOLEAN),
+                Resolver::resolve_has_previous_page,
+            ))
+            .field(Field::new(
+                "startCursor",
+                TypeRef::named(TypeRef::CURSOR),
+                Resolver::resolve_start_cursor,
+            ))
+            .field(Field::new(
+                "endCursor",
+                TypeRef::named(TypeRef::CURSOR),
+                Resolver::resolve_end_cursor,
+            ))
+    }
+}
+
+pub trait PageInfoResolver: Send + Sync + 'static {
+    fn resolve_has_next_page(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_has_previous_page(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_start_cursor(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_end_cursor(ctx: ResolverContext) -> FieldFuture;
+}

--- a/packages/fuel-indexer-graphql-lib/src/spec/query.rs
+++ b/packages/fuel-indexer-graphql-lib/src/spec/query.rs
@@ -1,0 +1,70 @@
+//! `async_graphql::dynamic` extensions for handling GraphQL connections.
+//! See: https://graphql.org/learn/pagination/#end-of-list-counts-and-connections
+//! See: https://relay.dev/graphql/connections.htm#sec-Connection-Types
+
+use super::node::*;
+use super::prelude::*;
+
+#[extension_trait]
+pub impl QueryTypeRef for TypeRef {
+    const QUERY: &'static str = "Query";
+}
+
+#[extension_trait]
+pub impl<Resolver: QueryResolver> QueryObject<Resolver> for Object {
+    fn new_query() -> Self {
+        let mut object = Self::new(TypeRef::QUERY);
+        object = QueryObject::<Resolver>::node_by_id_field(object);
+        object = QueryObject::<Resolver>::node_by_ids_field(object);
+        object
+    }
+
+    /// See: https://graphql.org/learn/global-object-identification/#node-root-field
+    fn node_by_id_field(self) -> Self {
+        self.field(
+            Field::new(
+                "node",
+                TypeRef::named(TypeRef::NODE),
+                Resolver::resolve_node_by_id,
+            )
+            .node_by_id_arguments(),
+        )
+    }
+    /// See: https://graphql.org/learn/global-object-identification/#plural-identifying-root-fields
+    fn node_by_ids_field(self) -> Self {
+        self.field(
+            Field::new(
+                "nodes",
+                TypeRef::named_list_nn(TypeRef::NODE),
+                Resolver::resolve_node_by_ids,
+            )
+            .node_by_ids_arguments(),
+        )
+    }
+}
+
+pub trait QueryResolver: Send + Sync + 'static {
+    fn resolve_node_by_id(ctx: ResolverContext) -> FieldFuture;
+    fn resolve_node_by_ids(ctx: ResolverContext) -> FieldFuture;
+}
+
+#[extension_trait]
+pub impl QueryField for Field {
+    /// Add singular identifying arguments to a root field.
+    /// See: https://graphql.org/learn/global-object-identification/#node-root-field
+    fn node_by_id_arguments(self) -> Self {
+        self.argument(
+            InputValue::new("id", TypeRef::named_nn(TypeRef::ID))
+                .description("ID of the node."),
+        )
+    }
+
+    /// Add plural identifying arguments to a root field.
+    /// See: https://graphql.org/learn/global-object-identification/#plural-identifying-root-fields
+    fn node_by_ids_arguments(self) -> Self {
+        self.argument(
+            InputValue::new("ids", TypeRef::named_nn_list_nn(TypeRef::ID))
+                .description("IDs of the nodes."),
+        )
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/test.rs
+++ b/packages/fuel-indexer-graphql-lib/src/test.rs
@@ -1,0 +1,40 @@
+pub mod prelude {
+    pub use super::util::*;
+    pub use assert_matches::*;
+    pub use async_graphql::dynamic::*;
+    pub use async_graphql::{Request, Response, ServerError};
+    pub use async_trait::async_trait;
+    pub use extension_trait::extension_trait;
+    pub use graphql_parser::*;
+    pub use insta::*;
+    pub use serde_json::{json, Value as JsonValue};
+    pub use velcro::hash_map;
+}
+
+pub mod util {
+    pub use super::prelude::*;
+
+    pub async fn execute_query(
+        schema: &Schema,
+        query: impl Into<String>,
+        root_value: Option<FieldValue<'static>>,
+    ) -> Result<Response, Vec<ServerError>> {
+        let request = Request::new(query);
+        let request = if let Some(root_value) = root_value {
+            request.root_value(root_value)
+        } else {
+            request.into()
+        };
+        let response = schema.execute(request).await;
+        response.into_result()
+    }
+
+    #[extension_trait]
+    pub impl TestSchema for Schema {
+        fn pretty_sdl(&self) -> String {
+            let sdl = self.sdl();
+            let ugly = parse_schema::<&str>(&sdl).unwrap();
+            ugly.format(&Style::default())
+        }
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/src/util.rs
+++ b/packages/fuel-indexer-graphql-lib/src/util.rs
@@ -1,0 +1,21 @@
+//! Utilities for `async_graphql::dynamic`
+
+use super::prelude::*;
+use async_graphql::dynamic::*;
+
+#[extension_trait]
+pub impl<'a> ResolverContextUtilExt<'a> for ResolverContext<'a> {
+    fn parent_value<T>(&self) -> &'a T
+    where
+        T: 'static,
+    {
+        self.parent_value
+            .try_downcast_ref::<T>()
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Parent value casting failed. Expected: {}",
+                    std::any::type_name::<T>()
+                )
+            })
+    }
+}

--- a/packages/fuel-indexer-graphql-lib/tests/dynamic.rs
+++ b/packages/fuel-indexer-graphql-lib/tests/dynamic.rs
@@ -1,0 +1,222 @@
+mod test;
+
+use crate::test::prelude::*;
+use fuel_indexer_graphql_lib::dynamic::*;
+use fuel_indexer_graphql_lib::spec::*;
+use std::sync::Arc;
+use std::vec;
+use tokio::sync::Mutex;
+
+#[tokio::test]
+async fn test() {
+    let chain_type = DynamicNodeType {
+        id: DynamicNodeTypeId::from("Chain"),
+        data_fields: vec![DynamicDataField::new("dummy", DynamicDataType::Int)],
+        ref_fields: vec![],
+        connection_fields: vec![
+            DynamicConnectionField {
+                id: DynamicFieldId::from("blocks"),
+                ref_node_type_id: DynamicNodeTypeId::from("Block"),
+            },
+            DynamicConnectionField {
+                id: DynamicFieldId::from("transactions"),
+                ref_node_type_id: DynamicNodeTypeId::from("Transaction"),
+            },
+        ],
+    };
+    let block_type = DynamicNodeType {
+        id: DynamicNodeTypeId::from("Block"),
+        data_fields: vec![
+            DynamicDataField::new("number", DynamicDataType::Int),
+            DynamicDataField::new("hash", DynamicDataType::String),
+            DynamicDataField::new("parent_hash", DynamicDataType::String),
+        ],
+        ref_fields: vec![
+            DynamicRefField {
+                id: DynamicFieldId::from("chain"),
+                data_field_id: DynamicFieldId::from("chain_id"),
+                ref_node_type_id: DynamicNodeTypeId::from("Chain"),
+            },
+            DynamicRefField {
+                id: DynamicFieldId::from("parent"),
+                data_field_id: DynamicFieldId::from("parent_hash"),
+                ref_node_type_id: DynamicNodeTypeId::from("Block"),
+            },
+        ],
+        connection_fields: vec![
+            DynamicConnectionField {
+                id: DynamicFieldId::from("blocks"),
+                ref_node_type_id: DynamicNodeTypeId::from("Block"),
+            },
+            DynamicConnectionField {
+                id: DynamicFieldId::from("transactions"),
+                ref_node_type_id: DynamicNodeTypeId::from("Transaction"),
+            },
+        ],
+    };
+    let transaction_type = DynamicNodeType {
+        id: DynamicNodeTypeId::from("Transaction"),
+        data_fields: vec![
+            DynamicDataField::new("index", DynamicDataType::Int),
+            DynamicDataField::new("hash", DynamicDataType::String),
+            DynamicDataField::new("block_hash", DynamicDataType::String),
+        ],
+        ref_fields: vec![
+            DynamicRefField {
+                id: DynamicFieldId::from("chain"),
+                data_field_id: DynamicFieldId::from("chain_id"),
+                ref_node_type_id: DynamicNodeTypeId::from("Chain"),
+            },
+            DynamicRefField {
+                id: DynamicFieldId::from("block"),
+                data_field_id: DynamicFieldId::from("block_hash"),
+                ref_node_type_id: DynamicNodeTypeId::from("Block"),
+            },
+        ],
+        connection_fields: vec![],
+    };
+
+    let chain: Object = chain_type.clone().into();
+    let block: Object = block_type.clone().into();
+    let transaction: Object = transaction_type.clone().into();
+    let block_connection = <Object as ConnectionObject<DynamicResolver>>::new_connection(
+        TypeRef::node("Block"),
+    );
+    let block_edge = <Object as EdgeObject<DynamicResolver>>::new_edge(
+        "Block",
+        TypeRef::node("Block"),
+    );
+    let transaction_connection =
+        <Object as ConnectionObject<DynamicResolver>>::new_connection(TypeRef::node(
+            "Transaction",
+        ));
+    let transaction_edge = <Object as EdgeObject<DynamicResolver>>::new_edge(
+        "Transaction",
+        TypeRef::node("Transaction"),
+    );
+    let mut schema = Schema::build(TypeRef::QUERY, None, None)
+        .register(<Object as PageInfoObject<DynamicResolver>>::new_page_info())
+        .register(<Interface as NodeInterface>::new_node())
+        .register(chain)
+        .register(block)
+        .register(transaction)
+        .register(block_connection)
+        .register(block_edge)
+        .register(transaction_connection)
+        .register(transaction_edge);
+
+    let nodes = vec![
+        DynamicNode::new(
+            DynamicNodeTypeId::from("Chain"),
+            DynamicNodeLocalId::from("0"),
+            json!({
+                "id": "0",
+                "dummy": "0x00",
+            }),
+        ),
+        DynamicNode::new(
+            DynamicNodeTypeId::from("Block"),
+            DynamicNodeLocalId::from("0"),
+            json!({
+                "id": "0",
+                "chain_id": "0",
+                "number": "0x00",
+                "hash": "0x00",
+                "parent_hash": "0x00",
+            }),
+        ),
+        DynamicNode::new(
+            DynamicNodeTypeId::from("Transaction"),
+            DynamicNodeLocalId::from("0"),
+            json!({
+                "id": "0",
+                "chain_id": "0",
+                "index": 0,
+                "hash": "0x00",
+                "block_hash": "0",
+            }),
+        ),
+    ];
+    let loader = TestLoader::new(
+        nodes,
+        vec![
+            DynamicEdge::new(
+                "ChainHasBlock",
+                "0".to_string(),
+                "0".to_string(),
+                JsonValue::Null,
+            ),
+            DynamicEdge::new(
+                "ChainHasTransaction",
+                "0".to_string(),
+                "0".to_string(),
+                JsonValue::Null,
+            ),
+        ],
+    );
+    let resolver = DynamicResolver::new(
+        vec![chain_type, block_type, transaction_type],
+        Arc::new(Mutex::new(loader)),
+    );
+    schema = schema.data(resolver);
+
+    let query = <Object as QueryObject<DynamicResolver>>::new_query();
+
+    schema = schema.register(query);
+
+    let schema = schema.finish().unwrap();
+
+    // Execute a query
+    let response = execute_query(
+        &schema,
+        r#"
+            query {
+                node(id: "Transaction:0") {
+                    id
+                    ... on Transaction {
+                        transactionId: id
+                        index
+                        hash
+                        chain {
+                            id
+                            blocks(first: 1) {
+                                edges {
+                                    node {
+                                        id
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        "#,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_json_snapshot!(response.data, @r###"
+    {
+      "node": {
+        "id": "Transaction:0",
+        "transactionId": "Transaction:0",
+        "index": 0,
+        "hash": "0x00",
+        "chain": {
+          "id": "Chain:0",
+          "blocks": {
+            "edges": [
+              {
+                "node": {
+                  "id": "Block:0"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+    "###
+    );
+}

--- a/packages/fuel-indexer-graphql-lib/tests/snapshots/spec__sdl-2.snap
+++ b/packages/fuel-indexer-graphql-lib/tests/snapshots/spec__sdl-2.snap
@@ -1,0 +1,36 @@
+---
+source: packages/fuel-indexer-graphql-lib/tests/spec.rs
+expression: text
+---
+type Block implements Node {
+  id: ID!
+  number: Int!
+  hash: String!
+}
+
+interface Node {
+  id: ID!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type Query {
+  node(id: ID!): Node
+  nodes(ids: [ID!]!): [Node]!
+}
+
+type Transaction implements Node {
+  id: ID!
+  index: Int!
+  hash: String!
+}
+
+schema {
+  query: Query
+}
+

--- a/packages/fuel-indexer-graphql-lib/tests/snapshots/spec__sdl.snap
+++ b/packages/fuel-indexer-graphql-lib/tests/snapshots/spec__sdl.snap
@@ -1,0 +1,41 @@
+---
+source: packages/fuel-indexer-graphql-lib/tests/spec.rs
+expression: text
+---
+type Block implements Node {
+  id: ID!
+  number: Int!
+  hash: String!
+  chain: Chain!
+}
+
+type Chain implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type Query {
+  node(id: ID!): Node
+  nodes(ids: [ID!]!): [Node]!
+}
+
+type Transaction implements Node {
+  id: ID!
+  index: Int!
+  hash: String!
+}
+
+schema {
+  query: Query
+}
+

--- a/packages/fuel-indexer-graphql-lib/tests/spec.rs
+++ b/packages/fuel-indexer-graphql-lib/tests/spec.rs
@@ -1,0 +1,127 @@
+mod test;
+
+use crate::test::prelude::*;
+use fuel_indexer_graphql_lib::json_resolver::*;
+
+fn build_schema() -> SchemaBuilder {
+    let mut schema = Schema::build(TypeRef::QUERY, None, None)
+        .register(<Object as PageInfoObject<JsonResolver>>::new_page_info())
+        .register(<Interface as NodeInterface>::new_node());
+    let query = <Object as QueryObject<JsonResolver>>::new_query();
+
+    // Some nodes
+    let chain = <Object as NodeObject<JsonResolver>>::new_node("Chain");
+    let mut block = NodeObject::<JsonResolver>::new_node("Block");
+    block = <Object as NodeObject<JsonResolver>>::data_field(
+        block,
+        "number",
+        TypeRef::named_nn(TypeRef::INT),
+    );
+    block = <Object as NodeObject<JsonResolver>>::data_field(
+        block,
+        "hash",
+        TypeRef::named_nn(TypeRef::STRING),
+    );
+    block = <Object as NodeObject<JsonResolver>>::ref_field(
+        block,
+        "chain",
+        TypeRef::named_nn(TypeRef::node("Chain")),
+    );
+    let mut transaction = <Object as NodeObject<JsonResolver>>::new_node("Transaction");
+    transaction = <Object as NodeObject<JsonResolver>>::data_field(
+        transaction,
+        "index",
+        TypeRef::named_nn(TypeRef::INT),
+    );
+    transaction = <Object as NodeObject<JsonResolver>>::data_field(
+        transaction,
+        "hash",
+        TypeRef::named_nn(TypeRef::STRING),
+    );
+
+    schema = schema
+        .register(chain)
+        .register(block)
+        .register(transaction)
+        .register(query);
+
+    schema
+}
+
+#[tokio::test]
+async fn resolve() {
+    // Build the schema
+    let mut schema = build_schema();
+    let resolver = JsonResolver::new(vec![
+        Node(
+            "Chain:0".to_string(),
+            json!({
+                "type": "Chain",
+                "id": "Chain:0",
+                "dummy": "0x00",
+            }),
+        ),
+        Node(
+            "Block:0".to_string(),
+            json!({
+                "type": "Block",
+                "id": "Block:0",
+                "number": "0x00",
+                "hash": "0x00",
+                "chainId": "0",
+                "chain": "Chain:0",
+            }),
+        ),
+    ]);
+    schema = schema.data(resolver);
+    let schema = schema.finish();
+    assert_matches!(schema, Ok(_));
+    let schema = schema.unwrap();
+
+    // Execute a query
+    let response = execute_query(
+        &schema,
+        r#"
+          query {
+              node(id: "Block:0") {
+                  id
+                  ... on Block {
+                    hash
+                    chain {
+                        id
+                    }
+                  }
+              }
+          }
+      "#,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_json_snapshot!(response.data, @r###"
+    {
+      "node": {
+        "id": "Block:0",
+        "hash": "0x00",
+        "chain": {
+          "id": "Chain:0"
+        }
+      }
+    }
+    "###
+    );
+}
+
+#[tokio::test]
+async fn sdl() {
+    // Build the schema
+    let schema = build_schema();
+    let schema = schema.finish();
+    assert_matches!(schema, Ok(_));
+    let schema = schema.unwrap();
+
+    // Print the schema
+    let text = schema.pretty_sdl();
+    assert_snapshot!(text);
+}

--- a/packages/fuel-indexer-graphql-lib/tests/test/mod.rs
+++ b/packages/fuel-indexer-graphql-lib/tests/test/mod.rs
@@ -1,0 +1,3 @@
+#[path = "../../src/test.rs"]
+mod src_test;
+pub use src_test::*;


### PR DESCRIPTION
This PR is a step towards fixing https://github.com/FuelLabs/fuel-indexer/issues/1145.

It adds a new, well-enough-tested and dependency-light crate `fuel-indexer-graphql-lib` to help us define executable GraphQL schemas in runtime.

It improves the `spec` module introduced in https://github.com/FuelLabs/fuel-indexer/pull/1282 and adds a new `dynamic` module for defining in-spec dynamic types and resolution of those types.