### PR TITLE
fix: move `client.chain_info()` call outside of loop

### DIFF
--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -277,6 +277,8 @@ pub async fn retrieve_blocks_from_node(
             }
         });
 
+    let chain_id = client.chain_info().await?.consensus_parameters.chain_id;
+
     let mut block_info = Vec::new();
     for block in results.into_iter() {
         if let Some(end_block) = end_block {
@@ -377,7 +379,6 @@ pub async fn retrieve_blocks_from_node(
                 fuel_tx::Transaction::from_bytes(trans.raw_payload.0 .0.as_slice())
                     .expect("Bad transaction.");
 
-            let chain_id = client.chain_info().await?.consensus_parameters.chain_id;
             let id = transaction.id(&chain_id);
 
             let transaction = match transaction {


### PR DESCRIPTION
### Description

`client.chain_info()` is used to get the necessary chain information to identify a transaction. When doing the beta-4 upgrade, I didn't realize that I could have placed the method call outside of the loop. This ensures that the call only happens once instead of every transaction.

### Testing steps

CI should pass.

#### Manual testing

There should be a significant speed up in block retrieval and processing in comparison to `develop`.
