### PR TITLE
enhancement: Added message to compiler error when on Apple M1

### DIFF
--- a/plugins/forc-index/src/ops/forc_index_build.rs
+++ b/plugins/forc-index/src/ops/forc_index_build.rs
@@ -127,7 +127,7 @@ pub fn init(command: BuildCommand) -> anyhow::Result<()> {
                     if s.success() {
                         info!("✅ Build succeeded.");
                     } else {
-                        anyhow::bail!("❌ Build failed.");
+                        anyhow::bail!(verbose_error_message());
                     }
                 }
                 Err(e) => {
@@ -167,18 +167,18 @@ pub fn init(command: BuildCommand) -> anyhow::Result<()> {
                         if s.success() {
                             pb.finish_with_message("✅ Build succeeded.");
                         } else {
-                            pb.finish_with_message(error_message());
+                            pb.finish_with_message("❌ Build failed.");
                             anyhow::bail!("❌ Failed to build index.");
                         }
                     }
                     Err(e) => {
-                        pb.finish_with_message(error_message());
+                        pb.finish_with_message("❌ Build failed.");
                         anyhow::bail!("❌ Failed to determine process exit status: {e}.",);
                     }
                 }
             }
             Err(e) => {
-                pb.finish_with_message(error_message());
+                pb.finish_with_message("❌ Build failed.");
                 anyhow::bail!(format!("❌ Error: {e}",));
             }
         }
@@ -229,7 +229,7 @@ pub fn init(command: BuildCommand) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn error_message() -> String {
+fn verbose_error_message() -> String {
     let mut error = "❌ Build failed.".to_string();
 
     if cfg!(target_arch = "aarch64") {

--- a/plugins/forc-index/src/ops/forc_index_build.rs
+++ b/plugins/forc-index/src/ops/forc_index_build.rs
@@ -2,6 +2,7 @@ use crate::{cli::BuildCommand, defaults, utils::project_dir_info};
 use fuel_indexer_lib::manifest::{Manifest, Module};
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::{
     env,
     fs::File,
@@ -10,7 +11,6 @@ use std::{
     process::{Command, Stdio},
     time::Duration,
 };
-use std::collections::HashSet;
 use tracing::info;
 
 #[derive(Deserialize)]

--- a/plugins/forc-index/src/ops/forc_index_build.rs
+++ b/plugins/forc-index/src/ops/forc_index_build.rs
@@ -253,9 +253,9 @@ fn verbose_error_message() -> String {
             extra_msg.insert_str(
                 0,
                 r#"
-For Apple Silicon macOS users the preinstalled llvm has limited WASM targets,
-please install a binary with better support from Homebrew (brew install llvm)
-and configuring rustc with necessary environment variables:
+For Apple Silicon macOS users, the preinstalled llvm has limited WASM targets.
+Please install a binary with better support from Homebrew (brew install llvm)
+and configure rustc with the necessary environment variables:
             "#,
             );
         }


### PR DESCRIPTION
Currently opening as draft:
- To get feedback on the wording of the error message.
- @ra0x3 You left a comment [here](https://github.com/FuelLabs/fuel-indexer/issues/889#issuecomment-1543790207) stating:

> I might even go as far to say we maybe should read the output of a failed forc index build and look for wasm-related output in order to present this message their as well

Not sure I totally understand the requirement here and whether the changes in this PR already satisfies this.

### Description

When compilation fails and host is Apple M1, print out error message Informing user about possible missing environment vars.

Closes #889

Currently the message printed is

```

▪▪▪▪▪ ❌ Build failed.
For Apple Silicon macOS users the preinstalled llvm has limited WASM targets,
please install a binary with better support from Homebrew (brew install llvm)
and configuring rustc with necessary environment variables:
            
export LIBCLANG_PATH='/opt/homebrew/opt/llvm/lib'
export LDFLAGS='-L/opt/homebrew/opt/llvm/lib'
export CPPFLAGS='-I/opt/homebrew/opt/llvm/include'                                                                                                                                   Error: ❌ Failed to build index.
```

### Changelog

- Added a private `error_message` function that, on compilation error, includes information about setting env variables if compilation fails on Apple M1s.
