### PR TITLE
fix: manually revert 1294

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,8 @@ jobs:
         run: cargo test --locked --all-targets --features trybuild -p
           fuel-indexer-tests
   forc-index-tests:
-    if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_DEVELOP_OR_SEMVER != 'true'
+    # if: needs.set-env-vars.outputs.IS_RELEASE_OR_MASTER_OR_DEVELOP_OR_SEMVER != 'true'
+    if: false
     needs:
       - cargo-toml-fmt-check
       - set-env-vars


### PR DESCRIPTION
Thanks for opening a PR with the Fuel Indexer project. Please review the **Checklist** below and ensure you've completed all of the necessary steps to make this PR review as painless as possible.


### Checklist
- [ ] Ensure your top-level commit message is in line with our [contributor guidelines](./CONTRIBUTING.md).
- [ ] Please add proper labels.
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)
- [ ] Please allow Codeowners at least 24 hours to do a first-pass review.
- [ ] Please add thoroughly detailed testing steps below.
- [ ] Please keep your Changelog message short and sweet.

### Description

- Manually reverts https://github.com/FuelLabs/fuel-indexer/pull/1294 via `git reset --hard`
- Hoping the reversion of the deps upgrade in that PR fixes the release issue

### Testing steps

- Look through `indexer.rs` on this branch to confirm the changes from #1294 were reverted

### Changelog

- fix: manually revert 1294
