### PR TITLE
fix: update MessageOut data parsing due to API change

### DIFF
--- a/packages/fuel-indexer-macros/src/indexer.rs
+++ b/packages/fuel-indexer-macros/src/indexer.rs
@@ -540,16 +540,21 @@ fn process_fn_items(
 
                                 // It's possible that the data field was generated from an empty Sway `Bytes` array
                                 // in the send_message() instruction in which case the data field in the receipt will
-                                // have no type information or data to decode, so we decode an empty vector to a unit struct
+                                // have no type information or data to decode. Thus, we check for a None value or
+                                // an empty byte vector; if either condition is present, then we decode to a unit struct instead.
                                 let (type_id, data) = data
                                     .map_or((u64::MAX, Vec::<u8>::new()), |buffer| {
-                                        let (type_id_bytes, data_bytes) = buffer.split_at(8);
-                                        let type_id = u64::from_be_bytes(
-                                            <[u8; 8]>::try_from(type_id_bytes)
-                                            .expect("Could not get type ID for data in MessageOut receipt")
-                                        );
-                                        let data = data_bytes.to_vec();
-                                        (type_id, data)
+                                        if buffer.is_empty() {
+                                            (u64::MAX, Vec::<u8>::new())
+                                        } else {
+                                            let (type_id_bytes, data_bytes) = buffer.split_at(8);
+                                            let type_id = u64::from_be_bytes(
+                                                <[u8; 8]>::try_from(type_id_bytes)
+                                                .expect("Could not get type ID for data in MessageOut receipt")
+                                            );
+                                            let data = data_bytes.to_vec();
+                                            (type_id, data)
+                                        }
                                     });
 
                                 decoder.decode_messagedata(type_id, data.clone());


### PR DESCRIPTION
### Description

Due to [a change in how the `data` field in a `MessageOut` receipt is formed](https://github.com/FuelLabs/fuel-vm/commit/18a2e4a13094448068e378baf3b89e448ec356d6), our type ID and data parsing did not cover each case. This PR adjusts the parsing to check for a `None` value as well as an empty byte array as well.

### Testing steps

On `develop`: Clear database, build any indexer (`fuel-explorer` is probably best) and run indexer on internal beta-4 test network. You should see a failure at or near block 364788.

On this branch: Repeat above steps. You should see no failure.
