### PR TITLE
chore: fuel-indexer: refactor run, service, and executor to take advantage of tokio::task::JoinSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,6 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
- "tokio-util",
  "tracing",
  "wasmer",
  "wasmer-middlewares",

--- a/packages/fuel-indexer-benchmarks/src/lib.rs
+++ b/packages/fuel-indexer-benchmarks/src/lib.rs
@@ -7,7 +7,7 @@ use fuel_indexer::{
 use fuel_indexer_database::IndexerConnectionPool;
 use fuel_indexer_lib::config::DatabaseConfig;
 use fuel_indexer_tests::fixtures::TestPostgresDb;
-use std::{str::FromStr, sync::atomic::AtomicBool};
+use std::str::FromStr;
 
 /// Location of Fuel node to be used for block retrieval.
 pub const NODE_URL: &str = "beta-4.fuel.network:80";
@@ -73,7 +73,6 @@ pub fn create_wasm_indexer_benchmark(
             .unwrap();
         let blocks = rt.block_on(get_blocks(start_block, num_blocks)).unwrap();
         c.bench_function(name, move |b| {
-            let kill_switch = std::sync::Arc::new(AtomicBool::new(false));
             b.iter_batched(
                 // This setup function is run prior to each iteration of
                 // the benchmark; this ensures that there is a fresh WASM
@@ -92,9 +91,7 @@ pub fn create_wasm_indexer_benchmark(
                         (executor, blocks.clone())
                     })
                 },
-                |(mut ex, blocks)| {
-                    rt.block_on(ex.handle_events(kill_switch.clone(), blocks))
-                },
+                |(mut ex, blocks)| rt.block_on(ex.handle_events(blocks)),
                 criterion::BatchSize::SmallInput,
             )
         });

--- a/packages/fuel-indexer-database/postgres/migrations/20230911123600_remove_versions.down.sql
+++ b/packages/fuel-indexer-database/postgres/migrations/20230911123600_remove_versions.down.sql
@@ -1,4 +1,3 @@
--- Active: 1693382282533@@127.0.0.1@5432@postgres
 ALTER TABLE index_asset_registry_manifest ADD COLUMN version integer not null;
 ALTER TABLE index_asset_registry_schema ADD COLUMN version integer not null;
 ALTER TABLE index_asset_registry_wasm ADD COLUMN version integer not null;

--- a/packages/fuel-indexer-tests/tests/service.rs
+++ b/packages/fuel-indexer-tests/tests/service.rs
@@ -3,7 +3,6 @@ use fuel_indexer::{Executor, IndexerConfig, WasmIndexExecutor};
 use fuel_indexer_lib::{config::DatabaseConfig, manifest::Manifest};
 use fuel_indexer_tests::fixtures::TestPostgresDb;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
 
 #[tokio::test]
 async fn test_wasm_executor_can_meter_execution() {
@@ -58,11 +57,9 @@ async fn test_wasm_executor_can_meter_execution() {
             .await
             .unwrap();
 
-            let kill_switch = std::sync::Arc::new(AtomicBool::new(false));
-
             let blocks: Vec<fuel_indexer_types::fuel::BlockData> = vec![];
 
-            if let Err(e) = executor.handle_events(kill_switch, blocks.clone()).await {
+            if let Err(e) = executor.handle_events(blocks.clone()).await {
                 if let fuel_indexer::IndexerError::RuntimeError(e) = e {
                     if let Some(e) = e.to_trap() {
                         assert_eq!(e, wasmer_types::TrapCode::UnreachableCodeReached);

--- a/packages/fuel-indexer/Cargo.toml
+++ b/packages/fuel-indexer/Cargo.toml
@@ -36,7 +36,6 @@ itertools = "0.10"
 sqlx = { version = "0.6", features = ["bigdecimal"] }
 thiserror = { workspace = true }
 tokio = { features = ["macros", "rt-multi-thread", "sync", "process"], workspace = true }
-tokio-util = { workspace = true }
 tracing = { workspace = true }
 wasmer = "4"
 wasmer-middlewares = "4"

--- a/packages/fuel-indexer/src/commands/run.rs
+++ b/packages/fuel-indexer/src/commands/run.rs
@@ -130,7 +130,12 @@ pub async fn exec(args: IndexerArgs) -> anyhow::Result<()> {
         }
     }
 
-    subsystems.spawn(service.run());
+    subsystems.spawn(async {
+        let result = service.run().await;
+        if let Err(e) = result {
+            tracing::error!("Indexer Service failed: {e}");
+        }
+    });
 
     #[cfg(feature = "api-server")]
     subsystems.spawn({

--- a/packages/fuel-indexer/src/commands/run.rs
+++ b/packages/fuel-indexer/src/commands/run.rs
@@ -168,7 +168,7 @@ pub async fn exec(args: IndexerArgs) -> anyhow::Result<()> {
     // Each subsystem runs its own loop, and we require all subsystems for the
     // Indexer service to operate correctly. If any of the subsystems stops
     // running, the entire Indexer Service exits.
-    if let Some(_) = subsystems.join_next().await {
+    if subsystems.join_next().await.is_some() {
         subsystems.shutdown().await;
     }
 

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -751,9 +751,7 @@ impl WasmIndexExecutor {
         {
             Ok(executor) => Ok(executor),
             Err(e) => {
-                error!(
-                    "Could not instantiate WasmIndexExecutor({uid}): {e:?}."
-                );
+                error!("Could not instantiate WasmIndexExecutor({uid}): {e:?}.");
                 Err(IndexerError::WasmExecutionInstantiationError)
             }
         }

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -752,7 +752,7 @@ impl WasmIndexExecutor {
             Ok(executor) => Ok(executor),
             Err(e) => {
                 error!(
-                    "Could not instantiate WasmIndexExecutor({uid}) from ExecutorSource::Manifest: {e:?}."
+                    "Could not instantiate WasmIndexExecutor({uid}): {e:?}."
                 );
                 Err(IndexerError::WasmExecutionInstantiationError)
             }

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -3,11 +3,7 @@ use crate::{
     database::Database, ffi, queries::ClientExt, IndexerConfig, IndexerError,
     IndexerResult,
 };
-use async_std::{
-    fs::File,
-    io::ReadExt,
-    sync::{Arc, Mutex},
-};
+use async_std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use fuel_core_client::client::{
     pagination::{PageDirection, PaginatedResult, PaginationRequest},
@@ -33,7 +29,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 use tokio::{
-    task::{spawn_blocking, JoinHandle},
+    task::spawn_blocking,
     time::{sleep, Duration},
 };
 use tracing::{debug, error, info, warn};
@@ -78,24 +74,23 @@ impl From<ExecutorSource> for Vec<u8> {
 // types in `fuel_core_client` don't compile to WASM.
 pub fn run_executor<T: 'static + Executor + Send + Sync>(
     config: &IndexerConfig,
-    manifest: &Manifest,
     mut executor: T,
-    kill_switch: Arc<AtomicBool>,
 ) -> impl Future<Output = ()> {
     // TODO: https://github.com/FuelLabs/fuel-indexer/issues/286
 
-    let end_block = manifest.end_block();
+    let end_block = executor.manifest().end_block();
     let stop_idle_indexers = config.stop_idle_indexers;
-    let indexer_uid = manifest.uid();
+    let indexer_uid = executor.manifest().uid();
     let node_block_page_size = config.node_block_page_size;
 
-    let fuel_node_addr = manifest
+    let fuel_node_addr = executor
+        .manifest()
         .fuel_client()
         .map(|x| x.to_string())
         .unwrap_or(config.fuel_node.to_string());
 
     // Where should we initially start when fetching blocks from the client?
-    let mut cursor = manifest.start_block().map(|x| {
+    let mut cursor = executor.manifest().start_block().map(|x| {
         if x > 1 {
             let decremented = x - 1;
             decremented.to_string()
@@ -138,7 +133,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
 
         loop {
             // If something else has signaled that this indexer should stop, then stop.
-            if kill_switch.load(Ordering::SeqCst) {
+            if executor.kill_switch().load(Ordering::SeqCst) {
                 info!("Kill switch flipped, stopping Indexer({indexer_uid}). <('.')>");
                 break;
             }
@@ -183,9 +178,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
             }
 
             // The client responded with actual blocks, so attempt to index them.
-            let result = executor
-                .handle_events(kill_switch.clone(), block_info)
-                .await;
+            let result = executor.handle_events(block_info).await;
 
             if let Err(e) = result {
                 // Run time metering is deterministic. There is no point in retrying.
@@ -229,7 +222,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
             cursor = next_cursor;
 
             // Again, check if something else has signaled that this indexer should stop, then stop.
-            if kill_switch.load(Ordering::SeqCst) {
+            if executor.kill_switch().load(Ordering::SeqCst) {
                 info!("Kill switch flipped, stopping Indexer({indexer_uid}). <('.')>");
                 break;
             }
@@ -480,11 +473,11 @@ pub trait Executor
 where
     Self: Sized,
 {
-    async fn handle_events(
-        &mut self,
-        kill_switch: Arc<AtomicBool>,
-        blocks: Vec<BlockData>,
-    ) -> IndexerResult<()>;
+    async fn handle_events(&mut self, blocks: Vec<BlockData>) -> IndexerResult<()>;
+
+    fn manifest(&self) -> &Manifest;
+
+    fn kill_switch(&self) -> &Arc<AtomicBool>;
 }
 
 /// WASM indexer runtime environment responsible for fetching/saving data to and from the database.
@@ -535,6 +528,9 @@ where
 
     /// Function that handles events.
     handle_events_fn: fn(Vec<BlockData>, Arc<Mutex<Database>>) -> F,
+
+    /// Kill switch. When set to true, the indexer must stop execution.
+    kill_switch: Arc<AtomicBool>,
 }
 
 impl<F> NativeIndexExecutor<F>
@@ -557,31 +553,23 @@ where
         )
         .await?;
         db.load_schema(version).await?;
+        let kill_switch = Arc::new(AtomicBool::new(false));
         Ok(Self {
             db: Arc::new(Mutex::new(db)),
             manifest: manifest.to_owned(),
             handle_events_fn,
+            kill_switch,
         })
     }
 
     /// Create a new `NativeIndexExecutor`.
-    pub async fn create<T: Future<Output = IndexerResult<()>> + Send + 'static>(
+    pub async fn create(
         config: &IndexerConfig,
         manifest: &Manifest,
         pool: IndexerConnectionPool,
-        handle_events: fn(Vec<BlockData>, Arc<Mutex<Database>>) -> T,
-    ) -> IndexerResult<(JoinHandle<()>, ExecutorSource, Arc<AtomicBool>)> {
-        let executor =
-            NativeIndexExecutor::new(manifest, pool.clone(), config, handle_events)
-                .await?;
-        let kill_switch = Arc::new(AtomicBool::new(false));
-        let handle = tokio::spawn(run_executor(
-            config,
-            manifest,
-            executor,
-            kill_switch.clone(),
-        ));
-        Ok((handle, ExecutorSource::Manifest, kill_switch))
+        handle_events: fn(Vec<BlockData>, Arc<Mutex<Database>>) -> F,
+    ) -> IndexerResult<Self> {
+        NativeIndexExecutor::new(manifest, pool.clone(), config, handle_events).await
     }
 }
 
@@ -591,11 +579,7 @@ where
     F: Future<Output = IndexerResult<()>> + Send,
 {
     /// Handle events for  native executor.
-    async fn handle_events(
-        &mut self,
-        kill_switch: Arc<AtomicBool>,
-        blocks: Vec<BlockData>,
-    ) -> IndexerResult<()> {
+    async fn handle_events(&mut self, blocks: Vec<BlockData>) -> IndexerResult<()> {
         self.db.lock().await.start_transaction().await?;
         let res = (self.handle_events_fn)(blocks, self.db.clone()).await;
         let uid = self.manifest.uid();
@@ -605,13 +589,21 @@ where
             return Err(IndexerError::NativeExecutionRuntimeError);
         } else {
             // Do not commit if kill switch has been triggered.
-            if kill_switch.load(Ordering::SeqCst) {
+            if self.kill_switch.load(Ordering::SeqCst) {
                 self.db.lock().await.revert_transaction().await?;
             } else {
                 self.db.lock().await.commit_transaction().await?;
             }
         }
         Ok(())
+    }
+
+    fn kill_switch(&self) -> &Arc<AtomicBool> {
+        &self.kill_switch
+    }
+
+    fn manifest(&self) -> &Manifest {
+        &self.manifest
     }
 }
 
@@ -639,6 +631,9 @@ pub struct WasmIndexExecutor {
 
     /// Manifest of the indexer.
     manifest: Manifest,
+
+    /// Kill switch. When set to true, the indexer must stop execution.
+    kill_switch: Arc<AtomicBool>,
 }
 
 impl WasmIndexExecutor {
@@ -715,6 +710,8 @@ impl WasmIndexExecutor {
 
         db.lock().await.load_schema(schema_version).await?;
 
+        let kill_switch = Arc::new(AtomicBool::new(false));
+
         Ok(WasmIndexExecutor {
             instance,
             _module: module,
@@ -722,6 +719,7 @@ impl WasmIndexExecutor {
             db: db.clone(),
             metering_points: config.metering_points,
             manifest: manifest.clone(),
+            kill_switch,
         })
     }
 
@@ -742,76 +740,21 @@ impl WasmIndexExecutor {
     pub async fn create(
         config: &IndexerConfig,
         manifest: &Manifest,
-        exec_source: ExecutorSource,
         pool: IndexerConnectionPool,
         schema_version: String,
-    ) -> IndexerResult<(JoinHandle<()>, ExecutorSource, Arc<AtomicBool>)> {
-        let killer = Arc::new(AtomicBool::new(false));
+        wasm_bytes: impl AsRef<[u8]>,
+    ) -> IndexerResult<Self> {
         let uid = manifest.uid();
 
-        match &exec_source {
-            ExecutorSource::Manifest => match manifest.module() {
-                crate::Module::Wasm(ref module) => {
-                    let mut bytes = Vec::<u8>::new();
-                    let mut file = File::open(module).await?;
-                    file.read_to_end(&mut bytes).await?;
-
-                    match WasmIndexExecutor::new(
-                        config,
-                        manifest,
-                        bytes.clone(),
-                        pool,
-                        schema_version,
-                    )
-                    .await
-                    {
-                        Ok(executor) => {
-                            let handle = tokio::spawn(run_executor(
-                                config,
-                                manifest,
-                                executor,
-                                killer.clone(),
-                            ));
-
-                            Ok((handle, ExecutorSource::Registry(bytes), killer))
-                        }
-                        Err(e) => {
-                            error!(
-                                "Could not instantiate WasmIndexExecutor({uid}) from ExecutorSource::Manifest: {e:?}."
-                            );
-                            Err(IndexerError::WasmExecutionInstantiationError)
-                        }
-                    }
-                }
-                crate::Module::Native => {
-                    Err(IndexerError::NativeExecutionInstantiationError)
-                }
-            },
-            ExecutorSource::Registry(bytes) => {
-                match WasmIndexExecutor::new(
-                    config,
-                    manifest,
-                    bytes,
-                    pool,
-                    schema_version,
-                )
-                .await
-                {
-                    Ok(executor) => {
-                        let handle = tokio::spawn(run_executor(
-                            config,
-                            manifest,
-                            executor,
-                            killer.clone(),
-                        ));
-
-                        Ok((handle, exec_source, killer))
-                    }
-                    Err(e) => {
-                        error!("Could not instantiate WasmIndexExecutor({uid}) from ExecutorSource::Registry: {e:?}.");
-                        Err(IndexerError::WasmExecutionInstantiationError)
-                    }
-                }
+        match WasmIndexExecutor::new(config, manifest, wasm_bytes, pool, schema_version)
+            .await
+        {
+            Ok(executor) => Ok(executor),
+            Err(e) => {
+                error!(
+                    "Could not instantiate WasmIndexExecutor({uid}) from ExecutorSource::Manifest: {e:?}."
+                );
+                Err(IndexerError::WasmExecutionInstantiationError)
             }
         }
     }
@@ -868,11 +811,7 @@ impl WasmIndexExecutor {
 #[async_trait]
 impl Executor for WasmIndexExecutor {
     /// Trigger a WASM event handler, passing in a serialized event struct.
-    async fn handle_events(
-        &mut self,
-        kill_switch: Arc<AtomicBool>,
-        blocks: Vec<BlockData>,
-    ) -> IndexerResult<()> {
+    async fn handle_events(&mut self, blocks: Vec<BlockData>) -> IndexerResult<()> {
         if blocks.is_empty() {
             return Ok(());
         }
@@ -923,7 +862,7 @@ impl Executor for WasmIndexExecutor {
             }
         } else {
             // Do not commit if kill switch has been triggered.
-            if kill_switch.load(Ordering::SeqCst) {
+            if self.kill_switch.load(Ordering::SeqCst) {
                 self.db.lock().await.revert_transaction().await?;
             } else {
                 self.db.lock().await.commit_transaction().await?;
@@ -931,5 +870,13 @@ impl Executor for WasmIndexExecutor {
         }
 
         Ok(())
+    }
+
+    fn kill_switch(&self) -> &Arc<AtomicBool> {
+        &self.kill_switch
+    }
+
+    fn manifest(&self) -> &Manifest {
+        &self.manifest
     }
 }

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -345,7 +345,7 @@ impl IndexerService {
     }
 
     // Spawn and register a tokio::task running the Executor loop, as well as
-    // the kill switch and the abort handle.ß
+    // the kill switch and the abort handle.
     fn start_executor<T: 'static + Executor + Send + Sync>(&mut self, executor: T) {
         let uid = executor.manifest().uid();
 

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -7,18 +7,15 @@ use async_std::{fs::File, io::ReadExt};
 use fuel_indexer_database::{
     queries, types::IndexerAssetType, IndexerConnection, IndexerConnectionPool,
 };
-use fuel_indexer_lib::{defaults, utils::ServiceRequest};
+use fuel_indexer_lib::utils::ServiceRequest;
 use fuel_indexer_schema::db::manager::SchemaManager;
 use fuel_indexer_types::fuel::BlockData;
 use futures::Future;
 use std::collections::HashMap;
 use std::marker::Send;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::{
-    sync::mpsc::Receiver,
-    time::{sleep, Duration},
-};
-use tracing::{debug, error, info, warn};
+use tokio::sync::mpsc::Receiver;
+use tracing::{error, info, warn};
 
 /// Primary service used to run one or many indexers.
 pub struct IndexerService {


### PR DESCRIPTION
### Description

This PR cleans up parts of `IndexerService`, `Executor`, and `fuel-indexer`'s `run.rs`.

There is a slight change of semantics due to the replacement of `FuturesUnordered` with `JoinSet`: `JoinSet` aborts all tasks when it is dropped. This appeared in `web-api` tests that dropped the `IndexerService` object before the tests' completion. Tasks added to `FuturesUnordered` would've been running anyway (since `task::spawn` detaches the future). Tasks spawned into the task set of `IndexerService` are aborted. This required a small change to the tests to keep the `IndexerService` alive.

### Testing steps

CI tests should pass.

### Changelog

* Replace `FuturesUnordered` with `tokio::task::JoinSet`
* Clean up code in `service.rs` and `executor.rs`: move the kill switch into `Executor` implementations and expose through the trait interface; expose the manifest the same way. This allows cleaning up some functions that now only need the executor and no other parameters.
* Simplify fuel-indexer's `run.rs` to use the `JoinSet` for all subsystems (node, web-api, signal-handler, etc.).
* `WasmIndexExecutor::new()` takes WASM bytes and not `ExecSource`: we were passing `ExecSource::Manifest` and returning `ExecSource::Registry(wasm_bytes)`. Instead, the WASM bytes are loaded before `new()` is called, and everything is simpler this way.
* `IndexerService::run` removes completed tasks from the `JoinSet` and runs the service loop: `loop { tokio::select! ... }`. This way, we don't need two separate tasks for it.

### Measuring resource usage:

Changes in this PR have no adverse effect on the resource usage:

<img width="1446" alt="Screenshot 2023-09-08 at 12 55 33 PM" src="https://github.com/FuelLabs/fuel-indexer/assets/1270689/f12843b0-5efb-4756-8534-ed37a3044a5e">

