### PR TITLE
enhancement: rebuild when manifest changed

### DIFF
--- a/plugins/forc-index/src/ops/forc_index_build.rs
+++ b/plugins/forc-index/src/ops/forc_index_build.rs
@@ -85,9 +85,10 @@ pub fn init(command: BuildCommand) -> anyhow::Result<()> {
     };
 
     // Rebuild the WASM module even if only the schema has changed.
-    crate::utils::ensure_rebuild_if_schema_changed(
+    crate::utils::ensure_rebuild_if_schema_or_manifest_changed(
         root_dir.as_path(),
         Path::new(manifest_schema_file.as_path()),
+        indexer_manifest_path.as_path(),
         manifest.execution_source(),
     )?;
 


### PR DESCRIPTION
### Description

Closes #1314.

Update the indexer's main file when the manifest has changed, thus ensuring the indexer is rebuilt.

### Testing steps

1. Start `fuel-indexer`:

```
cargo run -p fuel-indexer -- run --fuel-node-host beta-4.fuel.network --fuel-node-port 80 --replace-indexer
```

2. Deploy an indexer:

```
cargo run -p forc-index -- deploy --path examples/fuel-explorer/fuel-explorer --replace-indexer --remove-data
```

3. Modify the manifest, e.g., change the namespace from `fuellabs` to `fuellabss`.

On `develop`, the indexer won't be rebuilt, and after deployment, it will error out:

```
2023-09-08T12:51:27.319752Z ERROR fuel_indexer::database: 139: TypeId(2415430278514146675) not found in tables: {5273039706591452776: "fuellabss_explorer.returnreceipt", 7475756035792124495: "fuellabss_explorer.header", 190081141759730074: "fuellabss_explorer.inputcoin", 1248756222114133960: "fuellabss_explorer.transferoutreceipt", -6228762953672972224: "fuellabss_explorer.coin", 6671396917556899066: "fuellabss_explorer.messagecoin", -3686111346759416169: "fuellabss_explorer.indexmetadataentity", -8791287207532562824: "fuellabss_explorer.logdatareceipt", 1204734681933021643: "fuellabss_explorer.input", 4122088370919413417: "fuellabss_explorer.transactions_inputs", 4318209886670111554: "fuellabss_explorer.block", 1083385359712899285: "fuellabss_explorer.storageslot", 5126984583546503304: "fuellabss_explorer.transferreceipt", 2512928291820126734: "fuellabss_explorer.inputcontract", -369908973665499865: "fuellabss_explorer.dryrun", 6075042093519011672: "fuellabss_explorer.output", -3830814071307429389: "fuellabss_explorer.submittedstatus", -3011039217246718922: "fuellabss_explorer.scripttransaction", -4417345847117790356: "fuellabss_explorer.failurestatus", -5383500092020256774: "fuellabss_explorer.logreceipt", 8376820390310112500: "fuellabss_explorer.unknownoutput", 4211961993554749929: "fuellabss_explorer.blocks_transactionidfragments", 4912135489741891794: "fuellabss_explorer.transactionidfragment", -4075885122172009087: "fuellabss_explorer.genesis", 5252423379060728106: "fuellabss_explorer.transactions_storageslots", 3523589469813171908: "fuellabss_explorer.transaction", 4434790272062654902: "fuellabss_explorer.unknownstatus", 702734144208282657: "fuellabss_explorer.scriptresultreceipt", 1065197761806324164: "fuellabss_explorer.panicreceipt", -3007313251137444475: "fuellabss_explorer.callreceipt", -1983231777461251552: "fuellabss_explorer.nodeinfo", 790830012356320987: "fuellabss_explorer.contractoutput", 1319965943463023716: "fuellabss_explorer.coinoutput", -6548981058107120243: "fuellabss_explorer.poa", 4097987661502837639: "fuellabss_explorer.txpointer", 2116564885524775658: "fuellabss_explorer.transactions_outputs", 3358996397087988402: "fuellabss_explorer.contract", 4883693151124385526: "fuellabss_explorer.blockidfragment", 3970108180319142259: "fuellabss_explorer.createtransaction", 772495386088098518: "fuellabss_explorer.unknown", 6590287182399271055: "fuellabss_explorer.consensus", 1445246135380242938: "fuellabss_explorer.programstate", 5457264983079858996: "fuellabss_explorer.revertreceipt", 1057154041689470010: "fuellabss_explorer.consensusparameters", -989573080930581567: "fuellabss_explorer.contractidfragment", -1334110055354161296: "fuellabss_explorer.transactionstatus", 4262888917438162002: "fuellabss_explorer.contractcreated", -6131479977252120024: "fuellabss_explorer.messageoutput", -7060752975673823074: "fuellabss_explorer.minttransaction", 4287532035648295657: "fuellabss_explorer.receipt", -7625221669356720962: "fuellabss_explorer.utxoid", -7643239317216586174: "fuellabss_explorer.variableoutput", 2815042521442911309: "fuellabss_explorer.witness", -3931343836074999714: "fuellabss_explorer.changeoutput", -5383465022378694356: "fuellabss_explorer.inputmessage", 698961292638158374: "fuellabss_explorer.returndatareceipt", 3476699237632627858: "fuellabss_explorer.chaininfo", 6746764393379001107: "fuellabss_explorer.instructionresult", -4881663347953249136: "fuellabss_explorer.squeezedoutstatus", -5998043377717280767: "fuellabss_explorer.successstatus", 2175593355850797510: "fuellabss_explorer.messageoutreceipt"}.

Does the schema version in SchemaManager::new_schema match the schema version in Database::load_schema?

Do your WASM modules need to be rebuilt?
```

On this branch, deploying the indexer should succeed, and the indexer should start without errors.

### Changelog

* Update the indexer's main file when the manifest has changed, thus ensuring the indexer is rebuilt.
