### PR TITLE
chore: remove indexer asset versioning logic

### DIFF
--- a/packages/fuel-indexer-database/database-types/src/lib.rs
+++ b/packages/fuel-indexer-database/database-types/src/lib.rs
@@ -566,9 +566,6 @@ pub struct IndexerAsset {
     /// Database ID of the indexer.
     pub index_id: i64,
 
-    /// Version associated with this indexer asset.
-    pub version: i32,
-
     /// Digest of the asset's bytes.
     pub digest: String,
 

--- a/packages/fuel-indexer-database/postgres/migrations/20230911123600_remove_versions.down.sql
+++ b/packages/fuel-indexer-database/postgres/migrations/20230911123600_remove_versions.down.sql
@@ -1,0 +1,4 @@
+-- Active: 1693382282533@@127.0.0.1@5432@postgres
+ALTER TABLE index_asset_registry_manifest ADD COLUMN version integer not null;
+ALTER TABLE index_asset_registry_schema ADD COLUMN version integer not null;
+ALTER TABLE index_asset_registry_wasm ADD COLUMN version integer not null;

--- a/packages/fuel-indexer-database/postgres/migrations/20230911123600_remove_versions.up.sql
+++ b/packages/fuel-indexer-database/postgres/migrations/20230911123600_remove_versions.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE index_asset_registry_manifest DROP COLUMN version;
+ALTER TABLE index_asset_registry_schema DROP COLUMN version;
+ALTER TABLE index_asset_registry_wasm DROP COLUMN version;

--- a/packages/fuel-indexer-database/src/queries.rs
+++ b/packages/fuel-indexer-database/src/queries.rs
@@ -230,18 +230,6 @@ pub async fn all_registered_indexers(
     }
 }
 
-pub async fn indexer_asset_version(
-    conn: &mut IndexerConnection,
-    index_id: &i64,
-    asset_type: &IndexerAssetType,
-) -> sqlx::Result<i64> {
-    match conn {
-        IndexerConnection::Postgres(ref mut c) => {
-            postgres::indexer_asset_version(c, index_id, asset_type).await
-        }
-    }
-}
-
 /// Register a single indexer asset.
 pub async fn register_indexer_asset(
     conn: &mut IndexerConnection,
@@ -261,27 +249,27 @@ pub async fn register_indexer_asset(
     }
 }
 
-/// Return the latest version for a given indexer asset type.
-pub async fn latest_asset_for_indexer(
+/// Returns the requested asset for an indexer with the given id.
+pub async fn indexer_asset(
     conn: &mut IndexerConnection,
     index_id: &i64,
     asset_type: IndexerAssetType,
 ) -> sqlx::Result<IndexerAsset> {
     match conn {
         IndexerConnection::Postgres(ref mut c) => {
-            postgres::latest_asset_for_indexer(c, index_id, asset_type).await
+            postgres::indexer_asset(c, index_id, asset_type).await
         }
     }
 }
 
-/// Return the latest version for every indexer asset type.
-pub async fn latest_assets_for_indexer(
+/// Return every indexer asset type for an indexer with the give id.
+pub async fn indexer_assets(
     conn: &mut IndexerConnection,
     index_id: &i64,
 ) -> sqlx::Result<IndexerAssetBundle> {
     match conn {
         IndexerConnection::Postgres(ref mut c) => {
-            postgres::latest_assets_for_indexer(c, index_id).await
+            postgres::indexer_assets(c, index_id).await
         }
     }
 }

--- a/packages/fuel-indexer-schema/src/db/tables.rs
+++ b/packages/fuel-indexer-schema/src/db/tables.rs
@@ -203,12 +203,9 @@ impl IndexerSchema {
 
         let indexer_id =
             queries::get_indexer_id(&mut conn, namespace, identifier).await?;
-        let IndexerAsset { bytes, .. } = queries::latest_asset_for_indexer(
-            &mut conn,
-            &indexer_id,
-            IndexerAssetType::Manifest,
-        )
-        .await?;
+        let IndexerAsset { bytes, .. } =
+            queries::indexer_asset(&mut conn, &indexer_id, IndexerAssetType::Manifest)
+                .await?;
         let manifest = Manifest::try_from(&bytes)?;
 
         let schema = GraphQLSchema::new(root.schema.clone());

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -177,7 +177,7 @@ impl IndexerService {
         let mut conn = self.pool.acquire().await?;
         let indices = queries::all_registered_indexers(&mut conn).await?;
         for index in indices {
-            let assets = queries::latest_assets_for_indexer(&mut conn, &index.id).await?;
+            let assets = queries::indexer_assets(&mut conn, &index.id).await?;
             let mut manifest = Manifest::try_from(&assets.manifest.bytes)?;
 
             let start_block = get_start_block(&mut conn, &manifest).await.unwrap_or(1);
@@ -306,9 +306,7 @@ async fn create_service_task(
                     .await
                     {
                         Ok(id) => {
-                            let assets =
-                                queries::latest_assets_for_indexer(&mut conn, &id)
-                                    .await?;
+                            let assets = queries::indexer_assets(&mut conn, &id).await?;
                             let mut manifest =
                                 Manifest::try_from(&assets.manifest.bytes)?;
 


### PR DESCRIPTION
### Description

Closes #1227.

This PR removes the vestiges of indexer asset versions.

### Testing steps

CI tests should pass.

### Changelog

* remove appearances of indexer asset version
* rename `laset_asset_for_indexer` query to `indexer_asset`
* rename `laset_assets_for_indexer` query to `indexer_assets`
