### PR TITLE
Add Mint and Burn receipts to fuel-explorer

### DIFF
--- a/examples/fuel-explorer/fuel-explorer/schema/fuel_explorer.schema.graphql
+++ b/examples/fuel-explorer/fuel-explorer/schema/fuel_explorer.schema.graphql
@@ -358,6 +358,23 @@ type MessageOutReceipt @entity(virtual: true) {
   is_message_out: Boolean!
 }
 
+type MintReceipt @entity(virtual: true) {
+  sub_id: Bytes32!
+  contract_id: ContractId!
+  val: UInt8!
+  pc: UInt8!
+  isr: UInt8!
+}
+
+
+type BurnReceipt @entity(virtual: true) {
+  sub_id: Bytes32!
+  contract_id: ContractId!
+  val: UInt8!
+  pc: UInt8!
+  isr: UInt8!
+}
+
 union Receipt =
     CallReceipt
   | ReturnReceipt
@@ -370,6 +387,8 @@ union Receipt =
   | TransferOutReceipt
   | ScriptResultReceipt
   | MessageOutReceipt
+  | MintReceipt
+  | BurnReceipt
 
 type VariableOutput @entity {
   id: ID!

--- a/examples/fuel-explorer/fuel-explorer/src/lib.rs
+++ b/examples/fuel-explorer/fuel-explorer/src/lib.rs
@@ -714,7 +714,40 @@ impl From<fuel::Receipt> for Receipt {
 
                 Self::from(receipt)
             }
-            fuel::Receipt::Mint { .. } | fuel::Receipt::Burn { .. } => todo!(),
+            fuel::Receipt::Mint {
+                sub_id,
+                contract_id,
+                val,
+                pc,
+                is,
+            } => {
+                let receipt = MintReceipt {
+                    sub_id,
+                    contract_id,
+                    val,
+                    pc,
+                    isr: is,
+                };
+
+                Self::from(receipt)
+            }
+            fuel::Receipt::Burn {
+                sub_id,
+                contract_id,
+                val,
+                pc,
+                is,
+            } => {
+                let receipt = BurnReceipt {
+                    sub_id,
+                    contract_id,
+                    val,
+                    pc,
+                    isr: is,
+                };
+
+                Self::from(receipt)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #1339.

### Description

Adds `Mint` and `Burn` receipt parsing to the Fuel explorer example.

### Testing steps

Build the fuel-explorer example module and then run the indexer with a start block before 1455679 (the block causing the panic). You should see that the indexer processes the block with no issues.
