### PR TITLE
devx: move extern crate alloc to prelude

### DIFF
--- a/examples/fuel-explorer/fuel-explorer/src/lib.rs
+++ b/examples/fuel-explorer/fuel-explorer/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 // TODO: We use a lot of manual type conversion below due to https://github.com/FuelLabs/fuel-indexer/issues/286

--- a/examples/hello-world-native/hello-indexer-native/src/main.rs
+++ b/examples/hello-world-native/hello-indexer-native/src/main.rs
@@ -20,7 +20,6 @@
 //! ```bash
 //! cargo run -p hello-world-data --bin hello-world-data
 //! ```
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(

--- a/examples/hello-world/hello-indexer/src/lib.rs
+++ b/examples/hello-world/hello-indexer/src/lib.rs
@@ -26,7 +26,6 @@
 //! cargo run -p hello-world-data --bin hello-world-data
 //! ```
 
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(manifest = "examples/hello-world/hello-indexer/hello_indexer.manifest.yaml")]

--- a/packages/fuel-indexer-macros/src/native.rs
+++ b/packages/fuel-indexer-macros/src/native.rs
@@ -37,6 +37,7 @@ fn native_prelude() -> proc_macro2::TokenStream {
 
         static mut db: Option<Arc<Mutex<Database>>> = None;
 
+        extern crate alloc;
         use fuel_indexer_utils::plugin::types::*;
         use fuel_indexer_utils::plugin::native::*;
         use fuel_indexer_utils::plugin::{serde_json, serialize, deserialize, bincode};

--- a/packages/fuel-indexer-macros/src/wasm.rs
+++ b/packages/fuel-indexer-macros/src/wasm.rs
@@ -37,6 +37,7 @@ pub fn handler_block_wasm(
 /// indexer module, not within the scope of the entire lib module.
 fn wasm_prelude() -> proc_macro2::TokenStream {
     quote! {
+        extern crate alloc;
         use alloc::{format, vec, vec::Vec};
         use std::str::FromStr;
 

--- a/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(

--- a/packages/fuel-indexer-tests/indexers/simple-wasm/simple-wasm/src/lib.rs
+++ b/packages/fuel-indexer-tests/indexers/simple-wasm/simple-wasm/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(manifest = "packages/fuel-indexer-tests/indexers/simple-wasm/simple_wasm.yaml")]

--- a/packages/fuel-indexer-tests/trybuild/fail_if_abi_contains_reserved_fuel_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_abi_contains_reserved_fuel_type.rs
@@ -1,7 +1,8 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
-#[indexer(manifest = "packages/fuel-indexer-tests/trybuild/invalid_abi_type_simple_wasm.yaml")]
+#[indexer(
+    manifest = "packages/fuel-indexer-tests/trybuild/invalid_abi_type_simple_wasm.yaml"
+)]
 mod indexer {
     fn function_one(event: BlockHeight) {
         let BlockHeight { id, account } = event;

--- a/packages/fuel-indexer-tests/trybuild/fail_if_arg_not_passed_to_handler_function.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_arg_not_passed_to_handler_function.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[no_mangle]
@@ -13,7 +12,10 @@ fn ff_put_many_to_many_record(_inp: ()) {}
 #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
 mod indexer {
     fn function_one() {
-        let t1 = Thing1 { id: uid([1]), account: Address::default() };
+        let t1 = Thing1 {
+            id: uid([1]),
+            account: Address::default(),
+        };
         t1.save();
     }
 }

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_abi_arg_includes_invalid_type.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::indexer;
 
 #[no_mangle]

--- a/packages/fuel-indexer-tests/trybuild/fail_if_attribute_manifest_schema_arg_is_invalid.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_attribute_manifest_schema_arg_is_invalid.rs
@@ -1,10 +1,11 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[no_mangle]
 fn ff_log_data(_inp: ()) {}
 
-#[indexer(manifest = "packages/fuel-indexer-tests/trybuild/invalid_schema_simple_wasm.yaml")]
+#[indexer(
+    manifest = "packages/fuel-indexer-tests/trybuild/invalid_schema_simple_wasm.yaml"
+)]
 mod indexer {
     fn function_one(event: SomeEvent) {
         let SomeEvent { id, account } = event;

--- a/packages/fuel-indexer-tests/trybuild/fail_if_ident_not_defined_in_abi.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_ident_not_defined_in_abi.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]

--- a/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_indexer_module_is_empty.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[no_mangle]

--- a/packages/fuel-indexer-tests/trybuild/fail_if_non_function_patterns_included_in_module.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_non_function_patterns_included_in_module.rs
@@ -1,13 +1,10 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]
 mod indexer {
 
-    mod some_disallowed_module {
+    mod some_disallowed_module {}
 
-    }
-    
     fn function_one(event: SomeEvent) {
         let SomeEvent { id, account } = event;
 

--- a/packages/fuel-indexer-tests/trybuild/fail_if_unsupported_type_used_in_handler_args.rs
+++ b/packages/fuel-indexer-tests/trybuild/fail_if_unsupported_type_used_in_handler_args.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[indexer(manifest = "packages/fuel-indexer-tests/trybuild/simple_wasm.yaml")]

--- a/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_multi_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_multi_type.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[no_mangle]

--- a/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_single_type.rs
+++ b/packages/fuel-indexer-tests/trybuild/pass_if_indexer_is_valid_single_type.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[no_mangle]

--- a/packages/fuel-indexer-tests/trybuild/pass_if_unsupported_types_are_used.rs
+++ b/packages/fuel-indexer-tests/trybuild/pass_if_unsupported_types_are_used.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use fuel_indexer_utils::prelude::*;
 
 #[no_mangle]

--- a/plugins/forc-index/src/defaults.rs
+++ b/plugins/forc-index/src/defaults.rs
@@ -148,8 +148,7 @@ pub fn default_indexer_lib(
     let manifest_path = manifest_path.display();
 
     format!(
-        r#"extern crate alloc;
-use fuel_indexer_utils::prelude::*;
+        r#"use fuel_indexer_utils::prelude::*;
 
 #[indexer(manifest = "{manifest_path}")]
 pub mod {indexer_name}_index_mod {{
@@ -186,8 +185,7 @@ pub fn default_indexer_binary(
     let manifest_path = manifest_path.display();
 
     format!(
-        r#"extern crate alloc;
-use fuel_indexer_utils::prelude::*;
+        r#"use fuel_indexer_utils::prelude::*;
 
 #[indexer(manifest = "{manifest_path}")]
 pub mod {indexer_name}_index_mod {{


### PR DESCRIPTION
### Description

While improving the documentation for indexer modules, I wondered why we had `extern crate alloc` in the modules and not in the preludes. I moved it and everything appears to work.

### Testing steps

CI should pass and examples should build and function correctly when deployed.
