### PR TITLE
fix: trigger kill switch when end block is met

### DIFF
--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -255,6 +255,21 @@ pub async fn retrieve_blocks_from_node(
     end_block: Option<u32>,
     indexer_uid: &str,
 ) -> IndexerResult<(Vec<BlockData>, Option<String>, bool)> {
+    // Let's check if we need less blocks than block_page_size.
+    let page_size = if let (Some(start), Some(end)) = (cursor, end_block) {
+        if let Ok(start) = start.parse::<u32>() {
+            if start >= end {
+                return Err(IndexerError::EndBlockMet);
+            }
+
+            std::cmp::min((end - start) as usize, block_page_size)
+        } else {
+            block_page_size
+        }
+    } else {
+        block_page_size
+    };
+
     debug!("Fetching paginated results from {cursor:?}");
 
     let PaginatedResult {
@@ -265,7 +280,7 @@ pub async fn retrieve_blocks_from_node(
     } = client
         .full_blocks(PaginationRequest {
             cursor: cursor.clone(),
-            results: block_page_size,
+            results: page_size,
             direction: PageDirection::Forward,
         })
         .await
@@ -284,12 +299,6 @@ pub async fn retrieve_blocks_from_node(
 
     let mut block_info = Vec::new();
     for block in results.into_iter() {
-        if let Some(end_block) = end_block {
-            if block.header.height.0 > end_block {
-                return Err(IndexerError::EndBlockMet);
-            }
-        }
-
         let producer: Option<Bytes32> = block.block_producer().map(|pk| pk.hash());
 
         let mut transactions = Vec::new();


### PR DESCRIPTION
Closes #1352.

### Description

Ensure that indexers are shutdown when the end block is met.

### Testing steps

Change the `end_block` field of the `fuel-explorer` manifest to an arbitrary block height. Run the indexer on beta-4 with the explorer and ensure that you see a message similar to the following when the end block is met:
```
2023-09-13T18:41:34.577587Z  INFO fuel_indexer::executor: 157: Indexer(fuellabs.explorer) has met its end block; beginning indexer shutdown process.
2023-09-13T18:41:34.577608Z  INFO fuel_indexer::executor: 137: Kill switch flipped, stopping Indexer(fuellabs.explorer). <('.')>
```
