### PR TITLE
fix: bring forc index start up-to-date

### DIFF
--- a/examples/fuel-explorer/fuel-explorer/src/lib.rs
+++ b/examples/fuel-explorer/fuel-explorer/src/lib.rs
@@ -144,49 +144,29 @@ impl From<fuel::UtxoId> for UtxoId {
 
 impl From<Bytes32> for ContractIdFragment {
     fn from(hash: Bytes32) -> Self {
-        // Since the ID will just be derived from the hash, rather than using `::new()`,
-        // just manaully derived the ID, then use `::get_or_create()`.
-        Self {
-            id: uid(hash),
-            hash,
-        }
-        .get_or_create()
+        let hash = Bytes32::from(<[u8; 32]>::from(hash));
+        Self::new(hash).get_or_create()
     }
 }
 
 impl From<ContractId> for ContractIdFragment {
     fn from(hash: ContractId) -> Self {
-        // Since the ID will just be derived from the hash, rather than using `::new()`,
-        // just manaully derived the ID, then use `::get_or_create()`.
-        Self {
-            id: uid(hash),
-            hash: Bytes32::from(<[u8; 32]>::from(hash)),
-        }
-        .get_or_create()
+        let hash = Bytes32::from(<[u8; 32]>::from(hash));
+        Self::new(hash).get_or_create()
     }
 }
 
 impl From<Bytes32> for BlockIdFragment {
     fn from(hash: Bytes32) -> Self {
-        // Since the ID will just be derived from the hash, rather than using `::new()`,
-        // just manaully derived the ID, then use `::get_or_create()`.
-        Self {
-            id: uid(hash),
-            hash,
-        }
-        .get_or_create()
+        let hash = Bytes32::from(<[u8; 32]>::from(hash));
+        Self::new(hash).get_or_create()
     }
 }
 
 impl From<Bytes32> for TransactionIdFragment {
     fn from(hash: Bytes32) -> Self {
-        // Since the ID will just be derived from the hash, rather than using `::new()`,
-        // just manaully derived the ID, then use `::get_or_create()`.
-        Self {
-            id: uid(hash),
-            hash,
-        }
-        .get_or_create()
+        let hash = Bytes32::from(<[u8; 32]>::from(hash));
+        Self::new(hash).get_or_create()
     }
 }
 
@@ -249,15 +229,14 @@ impl From<fuel::Input> for Input {
 
                 let utxo_id = UtxoId::from(utxo_id);
                 let tx_pointer = TxPointer::from(tx_pointer);
+                let contract = ContractIdFragment::from(contract_id);
 
                 let input = InputContract::new(
                     utxo_id.id,
                     balance_root,
                     state_root,
                     tx_pointer.id,
-                    // Don't need to load the object here since the `ContractIdFragment.id` is
-                    // just `uid(ContractId)`
-                    uid(contract_id),
+                    contract.id,
                     InputLabel::Contract.into(),
                     true,
                 );
@@ -420,13 +399,11 @@ impl From<fuel::TransactionStatus> for TransactionStatus {
                 reason,
                 program_state,
             } => {
-                // Don't need to load the object here since the `BlockFragment.id` is
-                // just `uid(hash)
-                let block_id = uid(block);
+                let block_id = BlockIdFragment::from(block);
                 let program_state = program_state.map(|p| p.into());
 
                 let status = FailureStatus::new(
-                    block_id,
+                    block_id.id,
                     time,
                     reason,
                     program_state,
@@ -441,14 +418,12 @@ impl From<fuel::TransactionStatus> for TransactionStatus {
                 time,
                 program_state,
             } => {
-                // Don't need to load the object here since the `BlockFragment.id` is
-                // just `uid(hash)
-                let block_id = uid(block);
+                let block_id = BlockIdFragment::from(block);
                 let program_state = program_state.map(|p| p.into());
 
                 let status = SuccessStatus::new(
                     time,
-                    block_id,
+                    block_id.id,
                     program_state,
                     TransactionStatusLabel::Success.into(),
                     true,
@@ -920,7 +895,7 @@ pub mod explorer_index {
         );
         header.save();
 
-        let _block_frag = BlockIdFragment::from(block_data.header.id);
+        let block_frag = BlockIdFragment::from(block_data.header.id);
 
         let consensus = Consensus::from(block_data.consensus);
         consensus.save();
@@ -933,7 +908,7 @@ pub mod explorer_index {
             .collect::<Vec<UID>>();
 
         let block = Block {
-            id: uid(block_data.header.id),
+            id: block_frag.id,
             block_id: block_data.header.id,
             header: header.id,
             consensus: consensus.id,

--- a/packages/fuel-indexer-benchmarks/src/bin/qa.rs
+++ b/packages/fuel-indexer-benchmarks/src/bin/qa.rs
@@ -490,9 +490,8 @@ async fn main() {
 
     let mani_path = explorer_root.join("fuel_explorer.manifest.yaml");
 
-    // TODO: replace this with forc-index start after/during https://github.com/FuelLabs/fuel-indexer/pull/1348
-    let _proc = Command::new("fuel-indexer")
-        .arg("run")
+    let _proc = Command::new("forc-index")
+        .arg("start")
         .arg("--run-migrations")
         .arg("--fuel-node-host")
         .arg("beta-4.fuel.network")

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -135,7 +135,7 @@ pub struct IndexerConfig {
     pub rate_limit: RateLimitConfig,
     pub replace_indexer: bool,
     pub accept_sql_queries: bool,
-    pub node_block_page_size: usize,
+    pub block_page_size: usize,
 }
 
 impl Default for IndexerConfig {
@@ -156,7 +156,7 @@ impl Default for IndexerConfig {
             rate_limit: RateLimitConfig::default(),
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: defaults::ACCEPT_SQL,
-            node_block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
+            block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
         }
     }
 }
@@ -237,7 +237,7 @@ impl From<IndexerArgs> for IndexerConfig {
             },
             replace_indexer: args.replace_indexer,
             accept_sql_queries: args.accept_sql_queries,
-            node_block_page_size: args.block_page_size,
+            block_page_size: args.block_page_size,
         };
 
         config
@@ -324,7 +324,7 @@ impl From<ApiServerArgs> for IndexerConfig {
             },
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: args.accept_sql_queries,
-            node_block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
+            block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
         };
 
         config
@@ -361,8 +361,7 @@ impl IndexerConfig {
         let accept_sql_config_key =
             serde_yaml::Value::String("accept_sql_queries".into());
 
-        let node_block_page_size_key =
-            serde_yaml::Value::String("block_page_size".into());
+        let block_page_size_key = serde_yaml::Value::String("block_page_size".into());
 
         if let Some(accept_sql_queries) = content.get(accept_sql_config_key) {
             config.accept_sql_queries = accept_sql_queries.as_bool().unwrap();
@@ -404,8 +403,8 @@ impl IndexerConfig {
             config.indexer_net_config = indexer_net_config.as_bool().unwrap();
         }
 
-        if let Some(node_block_page_size) = content.get(node_block_page_size_key) {
-            config.node_block_page_size = node_block_page_size.as_u64().unwrap() as usize;
+        if let Some(block_page_size) = content.get(block_page_size_key) {
+            config.block_page_size = block_page_size.as_u64().unwrap() as usize;
         }
 
         let fuel_config_key = serde_yaml::Value::String("fuel_node".into());

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
@@ -38,5 +38,5 @@ rate_limit:
   window_size: 5
 replace_indexer: false
 accept_sql_queries: false
-node_block_page_size: 20
+block_page_size: 20
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__default_indexer_config.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__default_indexer_config.snap
@@ -38,5 +38,5 @@ rate_limit:
   window_size: 5
 replace_indexer: false
 accept_sql_queries: false
-node_block_page_size: 20
+block_page_size: 20
 

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -83,7 +83,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
     let end_block = executor.manifest().end_block();
     let stop_idle_indexers = config.stop_idle_indexers;
     let indexer_uid = executor.manifest().uid();
-    let node_block_page_size = config.node_block_page_size;
+    let block_page_size = config.block_page_size;
 
     let fuel_node_addr = executor
         .manifest()
@@ -146,7 +146,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
             let (block_info, next_cursor, _has_next_page) =
                 match retrieve_blocks_from_node(
                     &client,
-                    node_block_page_size,
+                    block_page_size,
                     &cursor,
                     end_block,
                     &indexer_uid,
@@ -217,7 +217,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                     // TODO: https://github.com/FuelLabs/fuel-indexer/issues/1093
                     if inner.constraint().is_some() {
                         // Just bump the cursor and keep going. These errors do not count towards `INDEXER_FAILED_CALLS`
-                        warn!("Constraint violation. This is not a retry-able error. Continuing...");
+                        warn!("Constraint violation: {inner:?}. This is not a retry-able error. Continuing...");
                         cursor = next_cursor;
                         continue;
                     }


### PR DESCRIPTION
Thanks for opening a PR with the Fuel Indexer project. Please review the **Checklist** below and ensure you've completed all of the necessary steps to make this PR review as painless as possible.


### Checklist
- [ ] Ensure your top-level commit message is in line with our [contributor guidelines](./CONTRIBUTING.md).
- [ ] Please add proper labels.
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)
- [ ] Please allow Codeowners at least 24 hours to do a first-pass review.
- [ ] Please add thoroughly detailed testing steps below.
- [ ] Please keep your Changelog message short and sweet.

### Description

- PR does a few small things:
  - Fixes a bug in the explorer related to not deriving ID's for types properly
  - Brings `forc index start` up to date
  - Renames `node_block_page_size` to `block_page_size` for consistency 
  - Updates the QA script to use `forc-index`

### Testing steps

- [ ] Update `forc index start` to use local `fuel-indexer` at `./target/release/fuel-indexer`
- [ ] Update the QA script `qa.rs` to use local local `forc-index` at `./target/release/forc-index`
- [ ] Build binaries locally `cargo build -p forc-index -p fuel-indexer -p fuel-indexer-api-server --release --locked
- [ ] Refresh DB `bash scripts/utils/refresh_test_db.bash`
- [ ] Run QA script `cargo run -p fuel-indexer-benchmarks --bin qa -- --network beta-4.fuel.network --runs 10 --blocks 10000`


### Changelog

- fix: bring forc index start up-to-date
