### PR TITLE
enhancement: make sequential blocks trigger configurable

### DIFF
--- a/packages/fuel-indexer-benchmarks/src/bin/qa.rs
+++ b/packages/fuel-indexer-benchmarks/src/bin/qa.rs
@@ -498,6 +498,7 @@ async fn main() {
         .arg("--fuel-node-port")
         .arg("80")
         .arg("--replace-indexer")
+        .arg("--allow-non-sequential-blocks")
         .spawn()
         .unwrap();
 

--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -936,10 +936,35 @@ pub async fn create_ensure_block_height_consecutive_trigger(
     execute_query(conn, trigger_function).await.unwrap();
 
     let trigger = format!(
-        "CREATE TRIGGER trigger_ensure_block_height_consecutive
-        BEFORE INSERT OR UPDATE ON {namespace}_{identifier}.indexmetadataentity
-        FOR EACH ROW
-        EXECUTE FUNCTION ensure_block_height_consecutive();"
+        "DO
+        $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_trigger
+                WHERE tgname = 'trigger_ensure_block_height_consecutive'
+            ) THEN
+                CREATE TRIGGER trigger_ensure_block_height_consecutive
+                BEFORE INSERT OR UPDATE ON {namespace}_{identifier}.indexmetadataentity
+                FOR EACH ROW
+                EXECUTE FUNCTION ensure_block_height_consecutive();
+            END IF;
+        END;
+        $$;"
+    );
+
+    execute_query(conn, trigger).await?;
+
+    Ok(())
+}
+
+pub async fn remove_ensure_block_height_consecutive_trigger(
+    conn: &mut PoolConnection<Postgres>,
+    namespace: &str,
+    identifier: &str,
+) -> sqlx::Result<()> {
+    let trigger = format!(
+        "DROP TRIGGER IF EXISTS trigger_ensure_block_height_consecutive ON {namespace}_{identifier}.indexmetadataentity;"
     );
 
     execute_query(conn, trigger).await?;

--- a/packages/fuel-indexer-database/src/queries.rs
+++ b/packages/fuel-indexer-database/src/queries.rs
@@ -424,3 +424,18 @@ pub async fn create_ensure_block_height_consecutive_trigger(
         }
     }
 }
+
+pub async fn remove_ensure_block_height_consecutive_trigger(
+    conn: &mut IndexerConnection,
+    namespace: &str,
+    identifier: &str,
+) -> sqlx::Result<()> {
+    match conn {
+        IndexerConnection::Postgres(ref mut c) => {
+            postgres::remove_ensure_block_height_consecutive_trigger(
+                c, namespace, identifier,
+            )
+            .await
+        }
+    }
+}

--- a/packages/fuel-indexer-lib/src/config/cli.rs
+++ b/packages/fuel-indexer-lib/src/config/cli.rs
@@ -191,6 +191,13 @@ pub struct IndexerArgs {
     /// Amount of blocks to return in a request to a Fuel node.
     #[clap(long, help = "Amount of blocks to return in a request to a Fuel node.", default_value_t = defaults::NODE_BLOCK_PAGE_SIZE)]
     pub block_page_size: usize,
+
+    /// Allow missing blocks or non-sequential block processing.
+    #[clap(
+        long,
+        help = "Allow missing blocks or non-sequential block processing."
+    )]
+    pub allow_non_sequential_blocks: bool,
 }
 
 #[derive(Debug, Parser, Clone)]

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -107,6 +107,7 @@ impl Default for IndexerArgs {
             remove_data: defaults::REMOVE_DATA,
             accept_sql_queries: defaults::ACCEPT_SQL,
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
+            allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
         }
     }
 }
@@ -136,6 +137,7 @@ pub struct IndexerConfig {
     pub replace_indexer: bool,
     pub accept_sql_queries: bool,
     pub block_page_size: usize,
+    pub allow_non_sequential_blocks: bool,
 }
 
 impl Default for IndexerConfig {
@@ -157,6 +159,7 @@ impl Default for IndexerConfig {
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: defaults::ACCEPT_SQL,
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
+            allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
         }
     }
 }
@@ -238,6 +241,7 @@ impl From<IndexerArgs> for IndexerConfig {
             replace_indexer: args.replace_indexer,
             accept_sql_queries: args.accept_sql_queries,
             block_page_size: args.block_page_size,
+            allow_non_sequential_blocks: args.allow_non_sequential_blocks,
         };
 
         config
@@ -325,6 +329,7 @@ impl From<ApiServerArgs> for IndexerConfig {
             replace_indexer: defaults::REPLACE_INDEXER,
             accept_sql_queries: args.accept_sql_queries,
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
+            allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
         };
 
         config

--- a/packages/fuel-indexer-lib/src/defaults.rs
+++ b/packages/fuel-indexer-lib/src/defaults.rs
@@ -134,3 +134,6 @@ pub const REMOVE_DATA: bool = false;
 
 /// Allow the web server to accept raw SQL queries.
 pub const ACCEPT_SQL: bool = false;
+
+/// Allow missing blocks or non-sequential block processing.
+pub const ALLOW_NON_SEQUENTIAL_BLOCKS: bool = false;

--- a/packages/fuel-indexer-schema/src/db/tables.rs
+++ b/packages/fuel-indexer-schema/src/db/tables.rs
@@ -187,13 +187,6 @@ impl IndexerSchema {
             queries::execute_query(conn, stmnt.to_owned()).await?;
         }
 
-        queries::create_ensure_block_height_consecutive_trigger(
-            conn,
-            &self.namespace,
-            &self.identifier,
-        )
-        .await?;
-
         self.tables = tables;
 
         Ok(self)

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
@@ -39,4 +39,5 @@ rate_limit:
 replace_indexer: false
 accept_sql_queries: false
 block_page_size: 20
+allow_non_sequential_blocks: false
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
@@ -11,6 +11,9 @@ OPTIONS:
         --accept-sql-queries
             Allow the web server to accept raw SQL queries.
 
+        --allow-non-sequential-blocks
+            Allow missing blocks or non-sequential block processing.
+
         --auth-enabled
             Require users to authenticate for some operations.
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
@@ -11,6 +11,9 @@ OPTIONS:
         --accept-sql-queries
             Allow the web server to accept raw SQL queries.
 
+        --allow-non-sequential-blocks
+            Allow missing blocks or non-sequential block processing.
+
         --auth-enabled
             Require users to authenticate for some operations.
 

--- a/packages/fuel-indexer/src/service.rs
+++ b/packages/fuel-indexer/src/service.rs
@@ -356,8 +356,11 @@ impl IndexerService {
         self.killers
             .insert(uid.clone(), executor.kill_switch().clone());
 
-        self.tasks
-            .spawn(crate::executor::run_executor(&self.config, executor));
+        self.tasks.spawn(crate::executor::run_executor(
+            &self.config,
+            self.pool.clone(),
+            executor,
+        ));
     }
 }
 

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -39,6 +39,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         remove_data,
         accept_sql_queries,
         block_page_size,
+        allow_non_sequential_blocks,
     } = command;
 
     let mut cmd = Command::new("fuel-indexer");
@@ -91,6 +92,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
             ("--auth-enabled", auth_enabled),
             ("--verbose", verbose),
             ("--local-fuel-node", local_fuel_node),
+            ("--allow-non-sequential-blocks", allow_non_sequential_blocks),
         ];
         for (opt, value) in options.iter() {
             if *value {


### PR DESCRIPTION
### Description

This PR adds an option to relax the requirement that indexed blocks must be consecutive and that there can be no gaps. This is done by specifying `--allow-non-sequential-blocks` flag when starting the indexer service. 

### Testing steps

1. Run `fuel-indexer` with `--allow-non-sequential-blocks` and confirm with `psql` that the trigger has been removed:

```
cargo run -p fuel-indexer -- run --fuel-node-host beta-4.fuel.network --fuel-node-port 80 --replace-indexer --run-migrations --manifest examples/fuel-explorer/fuel-explorer/fuel_explorer.manifest.yaml --allow-non-sequential-blocks
```

```
postgres=> \d fuellabs_explorer.indexmetadataentity;
             Table "fuellabs_explorer.indexmetadataentity"
    Column    |         Type          | Collation | Nullable | Default
--------------+-----------------------+-----------+----------+---------
 id           | character varying(64) |           | not null |
 time         | numeric(20,0)         |           | not null |
 block_height | integer               |           | not null |
 block_id     | character varying(64) |           | not null |
 object       | bytea                 |           | not null |
Indexes:
    "indexmetadataentity_pkey" PRIMARY KEY, btree (id)
```

2. Run `fuel-indexer` with `--allow-non-sequential-blocks` and confirm with `psql` that the trigger has been added:

```
cargo run -p fuel-indexer -- run --fuel-node-host beta-4.fuel.network --fuel-node-port 80 --replace-indexer --run-migrations --manifest examples/fuel-explorer/fuel-explorer/fuel_explorer.manifest.yaml
```

```
postgres=> \d fuellabs_explorer.indexmetadataentity;
             Table "fuellabs_explorer.indexmetadataentity"
    Column    |         Type          | Collation | Nullable | Default
--------------+-----------------------+-----------+----------+---------
 id           | character varying(64) |           | not null |
 time         | numeric(20,0)         |           | not null |
 block_height | integer               |           | not null |
 block_id     | character varying(64) |           | not null |
 object       | bytea                 |           | not null |
Indexes:
    "indexmetadataentity_pkey" PRIMARY KEY, btree (id)
Triggers:
    trigger_ensure_block_height_consecutive BEFORE INSERT OR UPDATE ON fuellabs_explorer.indexmetadataentity FOR EACH ROW EXECUTE FUNCTION ensure_block_height_consecutive()
```

### Changelog

* add `remove_ensure_block_height_consecutive_trigger` query
* change where `create_ensure_block_height_consecutive_trigger` is called: previously when the table was created; currently: when the indexer executor starts
