### PR TITLE
fix: consecutive blocks trigger existence check

### DIFF
--- a/packages/fuel-indexer-database/postgres/src/lib.rs
+++ b/packages/fuel-indexer-database/postgres/src/lib.rs
@@ -943,6 +943,7 @@ pub async fn create_ensure_block_height_consecutive_trigger(
                 SELECT 1
                 FROM pg_trigger
                 WHERE tgname = 'trigger_ensure_block_height_consecutive'
+                AND tgrelid = '{namespace}_{identifier}.indexmetadataentity'::regclass
             ) THEN
                 CREATE TRIGGER trigger_ensure_block_height_consecutive
                 BEFORE INSERT OR UPDATE ON {namespace}_{identifier}.indexmetadataentity


### PR DESCRIPTION
### Description

#1373 PR, which made the trigger configurable, introduced a bug where only one trigger to ensure blocks are consecutive can ever be created. Since `postgresql` does not have a built-in syntax to check for the existence of a trigger, `SQL` statement that does it is a bit tricky.

This PR fixes the issue.

### Testing steps

1. Start `fuel-indexer` and deploy an indexer:

```
cargo run --bin fuel-indexer -- run --fuel-node-host beta-4.fuel.network --fuel-node-port 80 --run-migrations --replace-indexer --manifest examples/fuel-explorer/fuel-explorer/fuel_explorer.manifest.yaml
```

2. Deploy another indexer.

```
cargo run -p forc-index -- deploy --path /tmp/some-indexer/ --replace-indexer
```

On `develop`, when more than one indexer is deployed, only one of them has the trigger installed:

```
postgres=> \d fuellabs_explorer.indexmetadataentity
             Table "fuellabs_explorer.indexmetadataentity"
    Column    |         Type          | Collation | Nullable | Default
--------------+-----------------------+-----------+----------+---------
 id           | character varying(64) |           | not null |
 time         | numeric(20,0)         |           | not null |
 block_height | integer               |           | not null |
 block_id     | character varying(64) |           | not null |
 object       | bytea                 |           | not null |
Indexes:
    "indexmetadataentity_pkey" PRIMARY KEY, btree (id)
Triggers:
    trigger_ensure_block_height_consecutive BEFORE INSERT OR UPDATE ON fuellabs_explorer.indexmetadataentity FOR EACH ROW EXECUTE FUNCTION ensure_block_height_consecutive()
```

```
postgres=> \d fuellabs_hello_indexer.indexmetadataentity
          Table "fuellabs_hello_indexer.indexmetadataentity"
    Column    |         Type          | Collation | Nullable | Default
--------------+-----------------------+-----------+----------+---------
 id           | character varying(64) |           | not null |
 time         | numeric(20,0)         |           | not null |
 block_height | integer               |           | not null |
 block_id     | character varying(64) |           | not null |
 object       | bytea                 |           | not null |
Indexes:
    "indexmetadataentity_pkey" PRIMARY KEY, btree (id)
```

On this branch, both:

```
postgres=> \d fuellabs_explorer.indexmetadataentity
             Table "fuellabs_explorer.indexmetadataentity"
    Column    |         Type          | Collation | Nullable | Default
--------------+-----------------------+-----------+----------+---------
 id           | character varying(64) |           | not null |
 time         | numeric(20,0)         |           | not null |
 block_height | integer               |           | not null |
 block_id     | character varying(64) |           | not null |
 object       | bytea                 |           | not null |
Indexes:
    "indexmetadataentity_pkey" PRIMARY KEY, btree (id)
Triggers:
    trigger_ensure_block_height_consecutive BEFORE INSERT OR UPDATE ON fuellabs_explorer.indexmetadataentity FOR EACH ROW EXECUTE FUNCTION ensure_block_height_consecutive()
```

```
postgres=> \d fuellabs_hello_indexer.indexmetadataentity
          Table "fuellabs_hello_indexer.indexmetadataentity"
    Column    |         Type          | Collation | Nullable | Default
--------------+-----------------------+-----------+----------+---------
 id           | character varying(64) |           | not null |
 time         | numeric(20,0)         |           | not null |
 block_height | integer               |           | not null |
 block_id     | character varying(64) |           | not null |
 object       | bytea                 |           | not null |
Indexes:
    "indexmetadataentity_pkey" PRIMARY KEY, btree (id)
Triggers:
    trigger_ensure_block_height_consecutive BEFORE INSERT OR UPDATE ON fuellabs_hello_indexer.indexmetadataentity FOR EACH ROW EXECUTE FUNCTION ensure_block_height_consecutive()
```

### Changelog

* fix consecutive blocks trigger existence check
