### PR TITLE
enhancement: remove panics and expects

### DIFF
--- a/packages/fuel-indexer-lib/src/lib.rs
+++ b/packages/fuel-indexer-lib/src/lib.rs
@@ -46,6 +46,11 @@ pub enum WasmIndexerError {
     KillSwitch,
     DatabaseError,
     MissingBlocksError,
+    InvalidLogLevel,
+    GetObjectIdFailed,
+    GetStringFailed,
+    AllocMissing,
+    AllocFailed,
     GeneralError,
 }
 
@@ -60,6 +65,11 @@ impl From<u32> for WasmIndexerError {
             5 => Self::KillSwitch,
             6 => Self::DatabaseError,
             7 => Self::MissingBlocksError,
+            8 => Self::InvalidLogLevel,
+            9 => Self::GetObjectIdFailed,
+            10 => Self::GetStringFailed,
+            11 => Self::AllocMissing,
+            12 => Self::AllocFailed,
             _ => Self::GeneralError,
         }
     }
@@ -94,6 +104,21 @@ impl std::fmt::Display for WasmIndexerError {
             }
             Self::MissingBlocksError => {
                 write!(f, "Some blocks are missing")
+            }
+            Self::InvalidLogLevel => {
+                write!(f, "Invalid log level.")
+            }
+            Self::GetObjectIdFailed => {
+                write!(f, "get_object_id failed.")
+            }
+            Self::GetStringFailed => {
+                write!(f, "get_string failed.")
+            }
+            Self::AllocMissing => {
+                write!(f, "alloc is missing.")
+            }
+            Self::AllocFailed => {
+                write!(f, "alloc failed.")
             }
             Self::GeneralError => write!(f, "Some unspecified WASM error occurred."),
         }

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -3,6 +3,7 @@ use crate::{
     database::Database, ffi, queries::ClientExt, IndexerConfig, IndexerError,
     IndexerResult,
 };
+use anyhow::Context;
 use async_std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use fuel_core_client::client::{
@@ -78,7 +79,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
     config: &IndexerConfig,
     pool: IndexerConnectionPool,
     mut executor: T,
-) -> impl Future<Output = ()> {
+) -> anyhow::Result<impl Future<Output = IndexerResult<()>>> {
     // TODO: https://github.com/FuelLabs/fuel-indexer/issues/286
 
     let end_block = executor.manifest().end_block();
@@ -104,9 +105,9 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
 
     info!("Indexer({indexer_uid}) subscribing to Fuel node at {fuel_node_addr}");
 
-    let client = FuelClient::from_str(&fuel_node_addr).unwrap_or_else(|e| {
-        panic!("Indexer({indexer_uid}) client node connection failed: {e}.")
-    });
+    let client = FuelClient::from_str(&fuel_node_addr).with_context(|| {
+        format!("Indexer({indexer_uid}) client node connection failed.")
+    })?;
 
     if let Some(end_block) = end_block {
         info!("Indexer({indexer_uid}) will stop at block #{end_block}.");
@@ -116,10 +117,10 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
 
     let allow_non_sequential_blocks = config.allow_non_sequential_blocks;
 
-    async move {
-        let mut conn = pool.acquire().await.unwrap_or_else(|_| {
-            panic!("Indexer({indexer_uid}) was unable to acquire a database connection.")
-        });
+    let task = async move {
+        let mut conn = pool.acquire().await.with_context(|| {
+            format!("Indexer({indexer_uid}) was unable to acquire a database connection.")
+        })?;
 
         if allow_non_sequential_blocks {
             queries::remove_ensure_block_height_consecutive_trigger(
@@ -127,8 +128,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                 executor.manifest().namespace(),
                 executor.manifest().identifier(),
             )
-            .await
-            .unwrap_or_else(|_| panic!("Unable to remove the sequential blocks trigger for Indexer({indexer_uid})"));
+            .await.with_context(|| format!("Unable to remove the sequential blocks trigger for Indexer({indexer_uid})"))?;
         } else {
             queries::create_ensure_block_height_consecutive_trigger(
                 &mut conn,
@@ -136,7 +136,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                 executor.manifest().identifier(),
             )
             .await
-            .unwrap_or_else(|_| panic!("Unable to create the sequential blocks trigger for Indexer({indexer_uid})"));
+            .with_context(|| format!("Unable to create the sequential blocks trigger for Indexer({indexer_uid})"))?;
         }
 
         // If we reach an issue that continues to fail, we'll retry a few times before giving up, as
@@ -163,8 +163,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
         loop {
             // If something else has signaled that this indexer should stop, then stop.
             if executor.kill_switch().load(Ordering::SeqCst) {
-                info!("Kill switch flipped, stopping Indexer({indexer_uid}). <('.')>");
-                break;
+                return Err(IndexerError::KillSwitch(indexer_uid));
             }
 
             // Fetch the next page of blocks, and the starting cursor for the subsequent page
@@ -205,8 +204,9 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                 );
 
                 if num_empty_block_reqs == max_empty_block_reqs {
-                    error!("No blocks being produced after {num_empty_block_reqs} empty responses. Indexer({indexer_uid}) giving up. <('.')>");
-                    break;
+                    return Err(anyhow::format_err!(
+                        "No blocks being produced after {num_empty_block_reqs} empty responses. Indexer({indexer_uid}) giving up. <('.')>"
+                    ).into());
                 }
 
                 // There is no work to do, so we sleep for a bit, then continue without updating our cursor.
@@ -219,8 +219,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
 
             // If the kill switch has been triggered, the executor exits early.
             if executor.kill_switch().load(Ordering::SeqCst) {
-                info!("Kill switch flipped, stopping Indexer({indexer_uid}). <('.')>");
-                break;
+                return Err(IndexerError::KillSwitch(indexer_uid));
             }
 
             if let Err(e) = result {
@@ -228,24 +227,24 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
                     if let Some(&WasmIndexerError::MissingBlocksError) =
                         e.downcast_ref::<WasmIndexerError>()
                     {
-                        error!(
+                        return Err(anyhow::format_err!(
                             "Indexer({indexer_uid}) terminating due to missing blocks."
-                        );
-                        break;
+                        )
+                        .into());
                     }
                 }
                 // Run time metering is deterministic. There is no point in retrying.
                 if let IndexerError::RunTimeLimitExceededError = e {
-                    error!("Indexer({indexer_uid}) executor run time limit exceeded. Giving up. <('.')>. Consider increasing metering points");
-                    break;
+                    return Err(anyhow::format_err!(
+                        "Indexer({indexer_uid}) executor run time limit exceeded. Giving up. <('.')>. Consider increasing metering points"
+                    ).into());
                 }
 
                 // We don't want to retry forever as that eats resources.
                 if consecutive_retries >= INDEXER_FAILED_CALLS {
-                    error!(
+                    return Err(anyhow::format_err!(
                         "Indexer({indexer_uid}) failed after too many retries, giving up. <('.')>"
-                    );
-                    break;
+                    ).into());
                 }
 
                 if let IndexerError::SqlxError(sqlx::Error::Database(inner)) = e {
@@ -276,14 +275,15 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
 
             // Again, check if something else has signaled that this indexer should stop, then stop.
             if executor.kill_switch().load(Ordering::SeqCst) {
-                info!("Kill switch flipped, stopping Indexer({indexer_uid}). <('.')>");
-                break;
+                return Err(IndexerError::KillSwitch(indexer_uid));
             }
 
             // Since we had successful call, we reset the retry count.
             consecutive_retries = 0;
         }
-    }
+    };
+
+    Ok(task)
 }
 
 /// Retrieve blocks from a client node.

--- a/packages/fuel-indexer/src/lib.rs
+++ b/packages/fuel-indexer/src/lib.rs
@@ -88,4 +88,8 @@ pub enum IndexerError {
     EndBlockMet,
     #[error("Invalid schema: {0:?}")]
     SchemaVersionMismatch(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+    #[error("Indexer({0}) kill switch flipped. <('.')>")]
+    KillSwitch(String),
 }


### PR DESCRIPTION
### Description

Closes #1098.

This PR cleans up remaining `expect`s, `unwrap`s and `panic`s in the executor and service.

The only place where `expect`s are still present is the `Drop` implementation of `WasmArg`. However, since `WasmArg` is created (and destroyed) in a `spawn_blocking` task, it will not affect the indexer service. If `Drop` were to `panic!`, the individual indexer would shut down (and would not be restarted automatically). The indexer service would be unaffected.

### Testing steps

CI test should pass.

### Changelog

* Added more error variants to WasmIndexerError. Changed `expect`s and `unwrap`s to returning `Err` variant which also triggers the early exit.
* Instead of `panic!`-ing or printing `error!` and `break`-ing the loop, the executor now returns an `IndexerResult`. The `Err` variant is printed when it reaches `IndexerService` `run` loop.