### PR TITLE
chore: update rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUSTC_VERSION }}
       - uses: buildjet/cache@v3
         with:
           path: |
@@ -97,8 +99,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUSTC_VERSION }}
           components: rustfmt
       - name: cargo fmt --all --verbose -- --check
         run: cargo fmt --all --verbose -- --check
@@ -113,8 +116,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUSTC_VERSION }}
           components: clippy, rustfmt
       - name: cargo clippy --locked --no-default-features
         run: cargo clippy --locked --no-default-features
@@ -129,8 +133,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUSTC_VERSION }}
           components: clippy, rustfmt
       - name: cargo clippy --locked --all-targets --all-features
         run: cargo clippy --locked --all-targets --all-features
@@ -159,7 +164,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUSTC_VERSION }}
       - name: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests
           --exclude plugin-tests --exclude fuel-indexer-benchmarks
         run: cargo test --locked --all-targets --workspace --exclude fuel-indexer-tests
@@ -188,8 +195,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUSTC_VERSION }}
           targets: wasm32-unknown-unknown
       - uses: buildjet/cache@v3
         with:
@@ -335,8 +343,9 @@ jobs:
           ci/macos-install-packages.sh
       - uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUSTC_VERSION }}
           targets: ${{ matrix.job.target }}
       - name: Install cross
         uses: baptiste0928/cargo-install@v1
@@ -521,8 +530,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUSTC_VERSION }}
           targets: wasm32-unknown-unknown
       - name: Verify tag version
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   REGISTRY: ghcr.io
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
   SQLX_OFFLINE: true
-  RUSTC_VERSION: 1.72.1
+  RUSTC_VERSION: 1.73.0
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   IS_MASTER: ${{ github.head_ref == 'master' || github.ref_name == 'master' }}
   IS_DEVELOP: ${{ github.head_ref == 'develop' || github.ref_name == 'develop' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-indexer"
-rust-version = "1.72.1"
+rust-version = "1.73.0"
 version = "0.21.0"
 
 [workspace.dependencies]

--- a/ci/Dockerfile.fuel-node
+++ b/ci/Dockerfile.fuel-node
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.72.1 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.73.0 AS chef
 
 WORKDIR /build/
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
-FROM --platform=$BUILDPLATFORM rust:1.72.1 AS chef
+FROM --platform=$BUILDPLATFORM rust:1.73.0 AS chef
 
 ARG TARGETPLATFORM
 RUN cargo install cargo-chef

--- a/examples/fuel-explorer/fuel-explorer/Cargo.toml
+++ b/examples/fuel-explorer/fuel-explorer/Cargo.toml
@@ -3,7 +3,7 @@ name = "fuel_explorer"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.72.1"
+rust-version = "1.73.0"
 
 [lib]
 crate-type = ['cdylib']

--- a/examples/hello-world-native/hello-indexer-native/Cargo.toml
+++ b/examples/hello-world-native/hello-indexer-native/Cargo.toml
@@ -3,7 +3,7 @@ name = "hello_indexer_native"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.72.1"
+rust-version = "1.73.0"
 
 [dependencies]
 async-trait = { version = "0.1" }

--- a/examples/hello-world/hello-indexer/Cargo.toml
+++ b/examples/hello-world/hello-indexer/Cargo.toml
@@ -3,7 +3,7 @@ name = "hello_indexer"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.72.1"
+rust-version = "1.73.0"
 
 [lib]
 crate-type = ['cdylib']

--- a/plugins/forc-index/src/defaults.rs
+++ b/plugins/forc-index/src/defaults.rs
@@ -23,7 +23,7 @@ name = "{indexer_name}"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.72.1"
+rust-version = "1.73.0"
 
 [[bin]]
 name = "{indexer_name}"
@@ -48,7 +48,7 @@ name = "{indexer_name}"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.72.1"
+rust-version = "1.73.0"
 
 [lib]
 crate-type = ['cdylib']


### PR DESCRIPTION
### Description

I ran into this on CI:

```
failures:

---- config::test_rustc_version_in_default_indexer_cargo_manifest_matches_project_rustc_version stdout ----
thread 'config::test_rustc_version_in_default_indexer_cargo_manifest_matches_project_rustc_version' panicked at packages/fuel-indexer-tests/tests/config.rs:28:5:
assertion `left == right` failed
  left: "1.72.1"
 right: "1.73.0"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The stable toolchain moved to `1.73.0`
```
Run rustup toolchain install stable --target wasm32-unknown-unknown --profile minimal --no-self-update
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: latest update on 2023-10-05, rust version 1.73.0 (cc66ad468 2023-10-03)
```

### Testing steps

CI should pass.

### Changelog

* Update `rust` version to `1.73.0`
