### PR TITLE
enhancement: transparently add internal types for GraphQL connection specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,7 @@ version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-graphql-parser 5.0.10",
+ "async-graphql-value 5.0.10",
  "bincode",
  "clap 3.2.25",
  "fuel-indexer-types",

--- a/packages/fuel-indexer-database/database-types/src/lib.rs
+++ b/packages/fuel-indexer-database/database-types/src/lib.rs
@@ -885,15 +885,23 @@ impl Table {
                     .fields
                     .iter()
                     .enumerate()
-                    .map(|(i, f)| {
-                        Column::from_field_def(
-                            &f.node,
-                            parsed,
-                            ty_id,
-                            i as i32,
-                            persistence,
-                        )
-                    })
+                    .filter_map(|(i, f)|
+                        if f
+                            .node
+                            .directives
+                            .iter()
+                            .any(|d| d.node.name.node == "internal") { 
+                                return None;
+                            } else {
+                                Some(Column::from_field_def(
+                                    &f.node,
+                                    parsed,
+                                    ty_id,
+                                    i as i32,
+                                    persistence,
+                                ))
+                            }
+                    )
                     .collect::<Vec<Column>>();
 
                 let mut constraints = Vec::new();

--- a/packages/fuel-indexer-database/database-types/src/lib.rs
+++ b/packages/fuel-indexer-database/database-types/src/lib.rs
@@ -891,7 +891,7 @@ impl Table {
                             .directives
                             .iter()
                             .any(|d| d.node.name.node == "internal") { 
-                                return None;
+                                None
                             } else {
                                 Some(Column::from_field_def(
                                     &f.node,

--- a/packages/fuel-indexer-database/database-types/src/lib.rs
+++ b/packages/fuel-indexer-database/database-types/src/lib.rs
@@ -881,19 +881,16 @@ impl Table {
                 let mut columns = o
                     .fields
                     .iter()
+                    .filter(|f| !check_for_directive(&f.node.directives, "internal"))
                     .enumerate()
-                    .filter_map(|(i, f)|
-                        if check_for_directive(&f.node.directives, "internal") { 
-                                None
-                            } else {
-                                Some(Column::from_field_def(
-                                    &f.node,
-                                    parsed,
-                                    ty_id,
-                                    i as i32,
-                                    persistence,
-                                ))
-                            }
+                    .map(|(i, f)|
+                        Column::from_field_def(
+                            &f.node,
+                            parsed,
+                            ty_id,
+                            i as i32,
+                            persistence,
+                        )
                     )
                     .collect::<Vec<Column>>();
 

--- a/packages/fuel-indexer-lib/Cargo.toml
+++ b/packages/fuel-indexer-lib/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel Indexer Library"
 [dependencies]
 anyhow = "1.0"
 async-graphql-parser = { workspace = true }
+async-graphql-value = { workspace = true }
 bincode = { workspace = true }
 clap = { features = ["cargo", "derive", "env"], workspace = true }
 fuel-indexer-types = { workspace = true }

--- a/packages/fuel-indexer-lib/src/graphql/mod.rs
+++ b/packages/fuel-indexer-lib/src/graphql/mod.rs
@@ -44,7 +44,6 @@ pub(crate) fn inject_internal_types_into_document(
     base_type_names: &HashSet<String>,
 ) -> ServiceDocument {
     let mut pagination_types: Vec<TypeSystemDefinition> = Vec::new();
-    // let mut connection_fields: Vec<Positioned<FieldDefinition>> = Vec::new();
     pagination_types.push(create_page_info_type_def());
 
     // Iterate through all objects in document and create special
@@ -386,6 +385,16 @@ fn create_page_info_type_def() -> TypeSystemDefinition {
         dummy_position,
     ))
 }
+
+pub fn check_for_directive(
+    directives: &[Positioned<ConstDirective>],
+    directive_name: &str,
+) -> bool {
+    directives
+        .iter()
+        .any(|d| d.node.name.node == directive_name)
+}
+
 /// Wrapper for GraphQL schema content.
 #[derive(Default, Debug, Clone)]
 pub struct GraphQLSchema {

--- a/packages/fuel-indexer-lib/src/graphql/mod.rs
+++ b/packages/fuel-indexer-lib/src/graphql/mod.rs
@@ -39,6 +39,11 @@ fn inject_native_entities_into_schema(schema: &str) -> String {
     }
 }
 
+/// Inject internal types into the schema. In order to support popular
+/// functionality (e.g. cursor-based pagination) and minimize the amount
+/// of types that a user needs to create, internal types are injected into
+/// the `ServiceDocument`. These types are not used to create database tables/columns
+/// or entity structs in handler functions.
 pub(crate) fn inject_internal_types_into_document(
     mut ast: ServiceDocument,
     base_type_names: &HashSet<String>,
@@ -186,10 +191,11 @@ fn create_edge_type_for_list_field(
     ))
 }
 
+/// Generate connection type defintion for a list field on an entity.
 fn create_connection_type_def_for_list_entity(name: &Name) -> TypeSystemDefinition {
     let dummy_position = Pos {
-        line: 999,
-        column: 99,
+        line: usize::MAX,
+        column: usize::MAX,
     };
 
     let obj_type = ObjectType {
@@ -276,10 +282,11 @@ fn create_connection_type_def_for_list_entity(name: &Name) -> TypeSystemDefiniti
     ))
 }
 
+/// Generate `PageInfo` type defintion for use in connection type defintions.
 fn create_page_info_type_def() -> TypeSystemDefinition {
     let dummy_position = Pos {
-        line: 999,
-        column: 99,
+        line: usize::MAX,
+        column: usize::MAX,
     };
 
     let obj_type = ObjectType {

--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -24,6 +24,8 @@ use async_graphql_value::ConstValue;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use thiserror::Error;
 
+use super::check_for_directive;
+
 /// Result type returned by parsing GraphQL schema.
 pub type ParsedResult<T> = Result<T, ParsedError>;
 
@@ -784,15 +786,8 @@ impl SchemaDecoder {
     ) {
         GraphQLSchemaValidator::check_disallowed_graphql_typedef_name(&obj_name);
 
-        let is_internal = node
-            .directives
-            .iter()
-            .any(|d| d.node.name.node == "internal");
-
-        let is_entity = node
-            .directives
-            .iter()
-            .any(|d| d.node.name.to_string() == "entity");
+        let is_internal = check_for_directive(&node.directives, "internal");
+        let is_entity = check_for_directive(&node.directives, "entity");
 
         if is_internal {
             self.parsed_graphql_schema

--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -6,8 +6,9 @@
 use crate::{
     fully_qualified_namespace,
     graphql::{
-        extract_foreign_key_info, field_id, field_type_name, is_list_type,
-        list_field_type_name, GraphQLSchema, GraphQLSchemaValidator, IdCol, BASE_SCHEMA,
+        extract_foreign_key_info, field_id, field_type_name,
+        inject_pagination_types_into_document, is_list_type, list_field_type_name,
+        GraphQLSchema, GraphQLSchemaValidator, IdCol, BASE_SCHEMA,
     },
     join_table_name, ExecutionSource,
 };
@@ -305,7 +306,10 @@ impl ParsedGraphQLSchema {
 
         if let Some(schema) = schema {
             // Parse _everything_ in the GraphQL schema
-            let ast = parse_schema(schema.schema())?;
+            let mut ast = parse_schema(schema.schema())?;
+
+            ast = inject_pagination_types_into_document(ast);
+
             decoder.decode_service_document(ast)?;
 
             decoder.parsed_graphql_schema.namespace = namespace.to_string();

--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -813,7 +813,7 @@ impl SchemaDecoder {
             .directives
             .iter()
             .flat_map(|d| d.node.arguments.clone())
-            .any(|t| t.0.node == "virtual");
+            .any(|t| t.0.node == "virtual" && t.1.node == ConstValue::Boolean(true));
 
         if is_virtual {
             self.parsed_graphql_schema

--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -1077,7 +1077,7 @@ union Storage = Safe | Vault
         );
         assert_eq!(
             parsed.join_table_meta().get("Storage").unwrap()[1],
-            JoinTableMeta::new("storage", "id", "user", "id", Some(3))
+            JoinTableMeta::new("storage", "id", "user", "id", Some(4))
         );
 
         // Internal types

--- a/packages/fuel-indexer-lib/src/graphql/parser.rs
+++ b/packages/fuel-indexer-lib/src/graphql/parser.rs
@@ -459,6 +459,7 @@ impl ParsedGraphQLSchema {
             && !self.scalar_names.contains(name)
             && !self.is_enum_typedef(name)
             && !self.is_virtual_typedef(name)
+            && !self.is_internal_typedef(name)
     }
 
     /// Whether the given field type name is a type from which tables are not created.
@@ -711,6 +712,7 @@ impl SchemaDecoder {
                         .parsed_graphql_schema
                         .virtual_type_names
                         .contains(&ftype)
+                    && !self.parsed_graphql_schema.internal_types.contains(&ftype)
                 {
                     let (_ref_coltype, ref_colname, ref_tablename) =
                         extract_foreign_key_info(
@@ -870,7 +872,7 @@ impl SchemaDecoder {
                     .virtual_type_names
                     .contains(&ftype)
                 && !self.parsed_graphql_schema.internal_types.contains(&ftype)
-                && !is_virtual
+                && !is_internal
             {
                 GraphQLSchemaValidator::foreign_key_field_contains_no_unique_directive(
                     &field.node,

--- a/packages/fuel-indexer-lib/src/graphql/validator.rs
+++ b/packages/fuel-indexer-lib/src/graphql/validator.rs
@@ -4,6 +4,8 @@ use async_graphql_parser::types::{
 };
 use std::collections::HashSet;
 
+use super::check_for_directive;
+
 /// General container used to store a set of GraphQL schema validation functions.
 pub struct GraphQLSchemaValidator;
 
@@ -108,10 +110,8 @@ impl GraphQLSchemaValidator {
         obj_name: &str,
     ) {
         let name = f.name.to_string();
-        let has_unique_directive = f
-            .directives
-            .iter()
-            .any(|d| d.node.name.to_string() == "unique");
+
+        let has_unique_directive = check_for_directive(&f.directives, "unique");
         if has_unique_directive {
             panic!("FieldDefinition({name}) on TypeDefinition({obj_name}) cannot contain a `@unique` directive.");
         }

--- a/packages/fuel-indexer-macros/src/decoder.rs
+++ b/packages/fuel-indexer-macros/src/decoder.rs
@@ -5,7 +5,10 @@ use async_graphql_parser::types::{
 use async_graphql_parser::{Pos, Positioned};
 use async_graphql_value::Name;
 use fuel_indexer_lib::{
-    graphql::{field_id, types::IdCol, ParsedGraphQLSchema, MAX_FOREIGN_KEY_LIST_FIELDS},
+    graphql::{
+        check_for_directive, field_id, types::IdCol, ParsedGraphQLSchema,
+        MAX_FOREIGN_KEY_LIST_FIELDS,
+    },
     ExecutionSource,
 };
 use fuel_indexer_types::type_id;
@@ -90,12 +93,7 @@ impl Decoder for ImplementationDecoder {
                     .collect::<HashSet<String>>();
 
                 for field in &o.fields {
-                    if field
-                        .node
-                        .directives
-                        .iter()
-                        .any(|d| d.node.name.node == "internal")
-                    {
+                    if check_for_directive(&field.node.directives, "internal") {
                         continue;
                     }
 
@@ -188,11 +186,7 @@ impl Decoder for ImplementationDecoder {
                             .iter()
                             // Remove any fields that are marked for internal use
                             .filter_map(|f| {
-                                if f.0
-                                    .directives
-                                    .iter()
-                                    .any(|d| d.node.name.node == "internal")
-                                {
+                                if check_for_directive(&f.0.directives, "internal") {
                                     return None;
                                 }
 
@@ -371,11 +365,7 @@ impl From<ImplementationDecoder> for TokenStream {
                             .iter()
                             // Remove any fields marked for internal use
                             .filter_map(|f| {
-                                if f.0
-                                    .directives
-                                    .iter()
-                                    .any(|d| d.node.name.node == "internal")
-                                {
+                                if check_for_directive(&f.0.directives, "internal") {
                                     return None;
                                 }
 
@@ -551,12 +541,7 @@ impl Decoder for ObjectDecoder {
                 let mut fields_map = BTreeMap::new();
 
                 for field in o.fields.iter() {
-                    if field
-                        .node
-                        .directives
-                        .iter()
-                        .any(|d| d.node.name.node == "internal")
-                    {
+                    if check_for_directive(&field.node.directives, "internal") {
                         continue;
                     }
 

--- a/packages/fuel-indexer-macros/src/schema.rs
+++ b/packages/fuel-indexer-macros/src/schema.rs
@@ -15,6 +15,10 @@ fn process_type_def(
     parsed: &ParsedGraphQLSchema,
     typ: &TypeDefinition,
 ) -> Option<proc_macro2::TokenStream> {
+    if parsed.is_internal_typedef(typ.name.node.as_str()) {
+        return None;
+    }
+
     let tokens = match &typ.kind {
         TypeKind::Object(_o) => ObjectDecoder::from_typedef(typ, parsed).into(),
         TypeKind::Enum(_e) => EnumDecoder::from_typedef(typ, parsed).into(),

--- a/packages/fuel-indexer-schema/src/db/tables.rs
+++ b/packages/fuel-indexer-schema/src/db/tables.rs
@@ -138,7 +138,7 @@ impl IndexerSchema {
 
         let mut tables = self
             .parsed
-            .non_enum_typdefs()
+            .storage_backed_typedefs()
             .iter()
             .map(|(_, t)| Table::from_typedef(t, &self.parsed))
             .collect::<Vec<Table>>();
@@ -217,7 +217,7 @@ impl IndexerSchema {
         )?;
 
         let tables = parsed
-            .non_enum_typdefs()
+            .storage_backed_typedefs()
             .iter()
             .map(|(_, t)| Table::from_typedef(t, &parsed))
             .collect::<Vec<Table>>();


### PR DESCRIPTION
### Description

This PR transparently adds internal types to be used as part of the [GraphQL connections specification](https://relay.dev/graphql/connections.htm). A user will not have to add these types to their schema as they will be generated and added to their schema for each field that uses a list type. The next PR will add functionality for creating introspection information, which will expose these types to clients.

### Testing steps

Added new unit tests. CI should pass.

#### Manual Testing

Run the fuel-explorer example and ensure that it works properly. 