### PR TITLE
enhancement: use panic_hook to retrieve message from a failed WASM execution

### DIFF
--- a/packages/fuel-indexer-lib/src/lib.rs
+++ b/packages/fuel-indexer-lib/src/lib.rs
@@ -51,6 +51,7 @@ pub enum WasmIndexerError {
     GetStringFailed,
     AllocMissing,
     AllocFailed,
+    Panic,
     GeneralError,
 }
 
@@ -70,6 +71,7 @@ impl From<u32> for WasmIndexerError {
             10 => Self::GetStringFailed,
             11 => Self::AllocMissing,
             12 => Self::AllocFailed,
+            13 => Self::Panic,
             _ => Self::GeneralError,
         }
     }
@@ -79,10 +81,10 @@ impl std::fmt::Display for WasmIndexerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::SerializationError => {
-                write!(f, "Failed to serialize object.")
+                write!(f, "Failed to serialize object")
             }
             Self::DeserializationError => {
-                write!(f, "Failed to deserialize object.")
+                write!(f, "Failed to deserialize object")
             }
             Self::UnableToSaveListType => {
                 write!(f, "Failed to save list")
@@ -96,7 +98,7 @@ impl std::fmt::Display for WasmIndexerError {
             Self::KillSwitch => {
                 write!(
                     f,
-                    "Indexer kill switch has been triggered. Indexer will halt."
+                    "Indexer kill switch has been triggered. Indexer will halt"
                 )
             }
             Self::DatabaseError => {
@@ -106,21 +108,24 @@ impl std::fmt::Display for WasmIndexerError {
                 write!(f, "Some blocks are missing")
             }
             Self::InvalidLogLevel => {
-                write!(f, "Invalid log level.")
+                write!(f, "Invalid log level")
             }
             Self::GetObjectIdFailed => {
-                write!(f, "get_object_id failed.")
+                write!(f, "get_object_id failed")
             }
             Self::GetStringFailed => {
-                write!(f, "get_string failed.")
+                write!(f, "get_string failed")
             }
             Self::AllocMissing => {
-                write!(f, "alloc is missing.")
+                write!(f, "alloc is missing")
             }
             Self::AllocFailed => {
-                write!(f, "alloc failed.")
+                write!(f, "alloc failed")
             }
-            Self::GeneralError => write!(f, "Some unspecified WASM error occurred."),
+            Self::Panic => {
+                write!(f, "Panic")
+            }
+            Self::GeneralError => write!(f, "Some unspecified WASM error occurred"),
         }
     }
 }


### PR DESCRIPTION
### Description

Closes #1402.


This PR adds `WasmIndexerError::Panic` variant and registers a `panic` hook in the `WASM` indexer.

The panic message is stored in a `static mut` `String`, and an `early_exit` is triggered. The message is then retrieved by thy indexer service and logged.

### Testing steps

CI tests should pass.

For manual testing, deploy an indexer that causes `panic` (for instance, by calling `unwrap()` on the `None` value in the handler function), and observe the panic error message in the logs of `fuel-indexer`.

### Changelog

* Add `WasmIndexerError::Panic`
* Generate code to store and retrieve `panic` messages in the `WASM`.
* Add `get_panic_message` function to `Executor` trait. For native executor, it always returns an error.