### PR TITLE
chore: improve `--embedded-database` messaging

### DIFF
--- a/packages/fuel-indexer/src/commands/run.rs
+++ b/packages/fuel-indexer/src/commands/run.rs
@@ -88,6 +88,19 @@ pub async fn exec(args: IndexerArgs) -> anyhow::Result<()> {
             ..Default::default()
         };
 
+        println!(
+            r#"
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+Warning: Using the --embedded-database flag is experimental and should only be used for local development.
+
+If the --embedded-database flag demonstrates flaky behavior on your machine, or doesn't work altogether, we recommend that you simply use the provided docker compose file here:
+    https://github.com/FuelLabs/fuel-indexer/blob/develop/scripts/docker-compose.yaml.
+
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+"#
+        );
+
         forc_postgres::commands::create::exec(create_db_cmd).await?;
     }
 

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -1,6 +1,9 @@
 use crate::cli::StartCommand;
 use fuel_indexer_lib::defaults;
-use std::{ffi::OsStr, process::Command};
+use std::{
+    ffi::OsStr,
+    process::{Command, Stdio},
+};
 use tracing::info;
 
 pub async fn init(command: StartCommand) -> anyhow::Result<()> {
@@ -120,7 +123,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
                     ("--postgres-user", postgres_user),
                     ("--postgres-password", postgres_password),
                     ("--postgres-host", postgres_host),
-                    ("--postgres-port", postgres_port),
+                    ("--postgres-port", postgres_port.clone()),
                     ("--postgres-database", postgres_database),
                 ];
 
@@ -144,6 +147,29 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         Ok(child) => {
             let pid = child.id();
             info!("✅ Successfully started the indexer service at PID {pid}");
+
+            // Ensure that the DB actually was created if we passed --embedded-database
+            if embedded_database {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+                let port = postgres_port.unwrap_or(defaults::POSTGRES_PORT.to_string());
+                let mut cmd = Command::new("lsof");
+                cmd.arg(&format!("-ti:{}", port))
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped());
+
+                if verbose {
+                    info!("{cmd:?}");
+                }
+
+                match cmd.spawn() {
+                    Ok(child) => {
+                        let output = child.wait_with_output().unwrap();
+                        let pid = String::from_utf8(output.stdout).unwrap();
+                        info!("✅ Successfully confirmed the embedded database process at PID(s) {pid}");
+                    }
+                    Err(e) => panic!("❌ Failed to confirm that --embedded-database was started: {e:?}."),
+                }
+            }
         }
         Err(e) => panic!("❌ Failed to spawn fuel-indexer child process: {e:?}."),
     }


### PR DESCRIPTION
Thanks for opening a PR with the Fuel Indexer project. Please review the **Checklist** below and ensure you've completed all of the necessary steps to make this PR review as painless as possible.


### Checklist
- [ ] Ensure your top-level commit message is in line with our [contributor guidelines](./CONTRIBUTING.md).
- [ ] Please add proper labels.
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)
- [ ] Please allow Codeowners at least 24 hours to do a first-pass review.
- [ ] Please add thoroughly detailed testing steps below.
- [ ] Please keep your Changelog message short and sweet.

### Description

- This PR does not detect auto-failure of `--embedded-database` - that would be pretty hard to do. But it does improve messaging when using `--embedded-database`

### Testing steps

- [ ] Update `forc index start` with local binary path ` let mut cmd = Command::new("./target/release/fuel-indexer");`
- [ ] Build binaries locally `cargo build -p forc-index -p fuel-indexer -p fuel-indexer-api-server --release --locked`
- [ ] Run `forc index` `cargo run --bin forc-index -- start --embedded-database --run-migrations  --verbose`
- [ ] Should see more informative messaging related to `--embedded-database` flag

### Changelog

- chore: improve `--embedded-database` messaging
