### PR TITLE
chore: cargo sort the whole workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Cargo.toml linter
         run: cargo binstall --no-confirm cargo-sort
       - name: Run Cargo.toml sort check
-        run: cargo sort -w --check packages/**/Cargo.toml
+        run: cargo sort -w --check
   docs-test:
     uses: FuelLabs/github-actions/.github/workflows/mdbook-docs.yml@master
     with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
    "examples/greetings/greetings-fuel-client",
    "examples/greetings/greetings-indexer",
    "examples/hello-world/hello-world",
+   "packages/fuel-indexer",
    "packages/fuel-indexer-api-server",
    "packages/fuel-indexer-benchmarks",
    "packages/fuel-indexer-database",
@@ -27,7 +28,6 @@ members = [
    "packages/fuel-indexer-tests/indexers/simple-wasm/simple-wasm",
    "packages/fuel-indexer-types",
    "packages/fuel-indexer-utils",
-   "packages/fuel-indexer",
    "plugins/forc-index",
    "plugins/forc-postgres",
 ]


### PR DESCRIPTION
### Description

This PR changes the CI script to `cargo sort --check` the whole workspace.

Currently, we are only checking a subset of all packages using `packages/**/Cargo.toml`. 

### Testing steps

CI should pass.

### Changelog

* Change `cargo sort -w --check packages/**/Cargo.toml` to `cargo sort -w --check`
