### PR TITLE
enhancement: add option for delaying requests to Fuel node

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,9 @@ accept_sql_queries: false
 # Amount of blocks to return in a request to a Fuel node.
 block_page_size: 20
 
+# Make the service wait for the given duration between block requests to a Fuel client
+client_request_delay: ~
+
 # ***********************
 # Fuel Node configuration
 # ************************

--- a/packages/fuel-indexer-lib/src/config/cli.rs
+++ b/packages/fuel-indexer-lib/src/config/cli.rs
@@ -206,12 +206,12 @@ pub struct IndexerArgs {
     )]
     pub disable_toolchain_version_check: bool,
 
-    /// If present, the Fuel indexer service will wait for this particular duration between requests to a Fuel node.
+    /// Make the service wait for the given duration between block requests to a Fuel client.
     #[clap(
         long,
-        help = "If present, the Fuel indexer service will wait for this particular duration between requests to a Fuel node"
+        help = "Make the service wait for the given duration between block requests to a Fuel client."
     )]
-    pub node_request_delay: Option<u64>,
+    pub client_request_delay: Option<u64>,
 }
 
 #[derive(Debug, Parser, Clone)]

--- a/packages/fuel-indexer-lib/src/config/cli.rs
+++ b/packages/fuel-indexer-lib/src/config/cli.rs
@@ -205,6 +205,13 @@ pub struct IndexerArgs {
         help = "By default, Fuel Indexer will only accept WASM indexer modules compiled with the same toolchain version as the version of Fuel Indexer."
     )]
     pub disable_toolchain_version_check: bool,
+
+    /// If present, the Fuel indexer service will wait for this particular duration between requests to a Fuel node.
+    #[clap(
+        long,
+        help = "If present, the Fuel indexer service will wait for this particular duration between requests to a Fuel node"
+    )]
+    pub node_request_delay: Option<u64>,
 }
 
 #[derive(Debug, Parser, Clone)]

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -109,6 +109,7 @@ impl Default for IndexerArgs {
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
             allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
             disable_toolchain_version_check: defaults::DISABLE_TOOLCHAIN_VERSION_CHECK,
+            node_request_delay: None,
         }
     }
 }
@@ -140,6 +141,7 @@ pub struct IndexerConfig {
     pub block_page_size: usize,
     pub allow_non_sequential_blocks: bool,
     pub disable_toolchain_version_check: bool,
+    pub node_request_delay: Option<u64>,
 }
 
 impl Default for IndexerConfig {
@@ -163,6 +165,7 @@ impl Default for IndexerConfig {
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
             allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
             disable_toolchain_version_check: defaults::DISABLE_TOOLCHAIN_VERSION_CHECK,
+            node_request_delay: None,
         }
     }
 }
@@ -246,6 +249,7 @@ impl From<IndexerArgs> for IndexerConfig {
             block_page_size: args.block_page_size,
             allow_non_sequential_blocks: args.allow_non_sequential_blocks,
             disable_toolchain_version_check: args.disable_toolchain_version_check,
+            node_request_delay: args.node_request_delay,
         };
 
         config
@@ -335,6 +339,7 @@ impl From<ApiServerArgs> for IndexerConfig {
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
             allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
             disable_toolchain_version_check: args.disable_toolchain_version_check,
+            node_request_delay: None,
         };
 
         config
@@ -372,6 +377,8 @@ impl IndexerConfig {
             serde_yaml::Value::String("accept_sql_queries".into());
 
         let block_page_size_key = serde_yaml::Value::String("block_page_size".into());
+        let node_request_delay_key =
+            serde_yaml::Value::String("node_request_delay".into());
 
         if let Some(accept_sql_queries) = content.get(accept_sql_config_key) {
             config.accept_sql_queries = accept_sql_queries.as_bool().unwrap();
@@ -415,6 +422,10 @@ impl IndexerConfig {
 
         if let Some(block_page_size) = content.get(block_page_size_key) {
             config.block_page_size = block_page_size.as_u64().unwrap() as usize;
+        }
+
+        if let Some(node_request_delay) = content.get(node_request_delay_key) {
+            config.node_request_delay = node_request_delay.as_u64();
         }
 
         let fuel_config_key = serde_yaml::Value::String("fuel_node".into());

--- a/packages/fuel-indexer-lib/src/config/mod.rs
+++ b/packages/fuel-indexer-lib/src/config/mod.rs
@@ -109,7 +109,7 @@ impl Default for IndexerArgs {
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
             allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
             disable_toolchain_version_check: defaults::DISABLE_TOOLCHAIN_VERSION_CHECK,
-            node_request_delay: None,
+            client_request_delay: None,
         }
     }
 }
@@ -141,7 +141,7 @@ pub struct IndexerConfig {
     pub block_page_size: usize,
     pub allow_non_sequential_blocks: bool,
     pub disable_toolchain_version_check: bool,
-    pub node_request_delay: Option<u64>,
+    pub client_request_delay: Option<u64>,
 }
 
 impl Default for IndexerConfig {
@@ -165,7 +165,7 @@ impl Default for IndexerConfig {
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
             allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
             disable_toolchain_version_check: defaults::DISABLE_TOOLCHAIN_VERSION_CHECK,
-            node_request_delay: None,
+            client_request_delay: None,
         }
     }
 }
@@ -249,7 +249,7 @@ impl From<IndexerArgs> for IndexerConfig {
             block_page_size: args.block_page_size,
             allow_non_sequential_blocks: args.allow_non_sequential_blocks,
             disable_toolchain_version_check: args.disable_toolchain_version_check,
-            node_request_delay: args.node_request_delay,
+            client_request_delay: args.client_request_delay,
         };
 
         config
@@ -339,7 +339,7 @@ impl From<ApiServerArgs> for IndexerConfig {
             block_page_size: defaults::NODE_BLOCK_PAGE_SIZE,
             allow_non_sequential_blocks: defaults::ALLOW_NON_SEQUENTIAL_BLOCKS,
             disable_toolchain_version_check: args.disable_toolchain_version_check,
-            node_request_delay: None,
+            client_request_delay: None,
         };
 
         config
@@ -377,8 +377,8 @@ impl IndexerConfig {
             serde_yaml::Value::String("accept_sql_queries".into());
 
         let block_page_size_key = serde_yaml::Value::String("block_page_size".into());
-        let node_request_delay_key =
-            serde_yaml::Value::String("node_request_delay".into());
+        let client_request_delay_key =
+            serde_yaml::Value::String("client_request_delay".into());
 
         if let Some(accept_sql_queries) = content.get(accept_sql_config_key) {
             config.accept_sql_queries = accept_sql_queries.as_bool().unwrap();
@@ -424,8 +424,8 @@ impl IndexerConfig {
             config.block_page_size = block_page_size.as_u64().unwrap() as usize;
         }
 
-        if let Some(node_request_delay) = content.get(node_request_delay_key) {
-            config.node_request_delay = node_request_delay.as_u64();
+        if let Some(client_request_delay) = content.get(client_request_delay_key) {
+            config.client_request_delay = client_request_delay.as_u64();
         }
 
         let fuel_config_key = serde_yaml::Value::String("fuel_node".into());

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
@@ -41,4 +41,5 @@ accept_sql_queries: false
 block_page_size: 20
 allow_non_sequential_blocks: false
 disable_toolchain_version_check: false
+node_request_delay: ~
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__default_indexer_config.snap
@@ -41,5 +41,5 @@ accept_sql_queries: false
 block_page_size: 20
 allow_non_sequential_blocks: false
 disable_toolchain_version_check: false
-node_request_delay: ~
+client_request_delay: ~
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
@@ -23,6 +23,9 @@ OPTIONS:
         --block-page-size <BLOCK_PAGE_SIZE>
             Amount of blocks to return in a request to a Fuel node. [default: 20]
 
+        --client-request-delay <CLIENT_REQUEST_DELAY>
+            Make the service wait for the given duration between block requests to a Fuel client.
+
     -c, --config <FILE>
             Indexer service config file.
 
@@ -76,10 +79,6 @@ OPTIONS:
 
         --metrics
             Use Prometheus metrics reporting.
-
-        --node-request-delay <NODE_REQUEST_DELAY>
-            If present, the Fuel indexer service will wait for this particular duration between
-            requests to a Fuel node
 
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
@@ -77,6 +77,10 @@ OPTIONS:
         --metrics
             Use Prometheus metrics reporting.
 
+        --node-request-delay <NODE_REQUEST_DELAY>
+            If present, the Fuel indexer service will wait for this particular duration between
+            requests to a Fuel node
+
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_start_help_output.snap
@@ -23,11 +23,11 @@ OPTIONS:
         --block-page-size <BLOCK_PAGE_SIZE>
             Amount of blocks to return in a request to a Fuel node. [default: 20]
 
-        --client-request-delay <CLIENT_REQUEST_DELAY>
-            Make the service wait for the given duration between block requests to a Fuel client.
-
     -c, --config <FILE>
             Indexer service config file.
+
+        --client-request-delay <CLIENT_REQUEST_DELAY>
+            Make the service wait for the given duration between block requests to a Fuel client.
 
         --database <DATABASE>
             Database type. [default: postgres] [possible values: postgres]

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
@@ -23,6 +23,9 @@ OPTIONS:
         --block-page-size <BLOCK_PAGE_SIZE>
             Amount of blocks to return in a request to a Fuel node. [default: 20]
 
+        --client-request-delay <CLIENT_REQUEST_DELAY>
+            Make the service wait for the given duration between block requests to a Fuel client.
+
     -c, --config <FILE>
             Indexer service config file.
 
@@ -76,10 +79,6 @@ OPTIONS:
 
         --metrics
             Use Prometheus metrics reporting.
-
-        --node-request-delay <NODE_REQUEST_DELAY>
-            If present, the Fuel indexer service will wait for this particular duration between
-            requests to a Fuel node
 
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
@@ -77,6 +77,10 @@ OPTIONS:
         --metrics
             Use Prometheus metrics reporting.
 
+        --node-request-delay <NODE_REQUEST_DELAY>
+            If present, the Fuel indexer service will wait for this particular duration between
+            requests to a Fuel node
+
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__fuel_indexer_run_help_output.snap
@@ -23,11 +23,11 @@ OPTIONS:
         --block-page-size <BLOCK_PAGE_SIZE>
             Amount of blocks to return in a request to a Fuel node. [default: 20]
 
-        --client-request-delay <CLIENT_REQUEST_DELAY>
-            Make the service wait for the given duration between block requests to a Fuel client.
-
     -c, --config <FILE>
             Indexer service config file.
+
+        --client-request-delay <CLIENT_REQUEST_DELAY>
+            Make the service wait for the given duration between block requests to a Fuel client.
 
         --database <DATABASE>
             Database type. [default: postgres] [possible values: postgres]

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__forc_index_start_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__forc_index_start_help_output.snap
@@ -70,6 +70,10 @@ OPTIONS:
         --metrics
             Use Prometheus metrics reporting.
 
+        --node-request-delay <NODE_REQUEST_DELAY>
+            If present, the Fuel indexer service will wait for this particular duration between
+            requests to a Fuel node
+
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__forc_index_start_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__forc_index_start_help_output.snap
@@ -20,6 +20,9 @@ OPTIONS:
         --block-page-size <BLOCK_PAGE_SIZE>
             Amount of blocks to return in a request to a Fuel node. [default: 20]
 
+        --client-request-delay <CLIENT_REQUEST_DELAY>
+            Make the service wait for the given duration between block requests to a Fuel client.
+
     -c, --config <FILE>
             Indexer service config file.
 
@@ -69,10 +72,6 @@ OPTIONS:
 
         --metrics
             Use Prometheus metrics reporting.
-
-        --node-request-delay <NODE_REQUEST_DELAY>
-            If present, the Fuel indexer service will wait for this particular duration between
-            requests to a Fuel node
 
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__fuel_indexer_run_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__fuel_indexer_run_help_output.snap
@@ -70,6 +70,10 @@ OPTIONS:
         --metrics
             Use Prometheus metrics reporting.
 
+        --node-request-delay <NODE_REQUEST_DELAY>
+            If present, the Fuel indexer service will wait for this particular duration between
+            requests to a Fuel node
+
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.
 

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__fuel_indexer_run_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__snapshots__fuel_indexer_run_help_output.snap
@@ -20,6 +20,9 @@ OPTIONS:
         --block-page-size <BLOCK_PAGE_SIZE>
             Amount of blocks to return in a request to a Fuel node. [default: 20]
 
+        --client-request-delay <CLIENT_REQUEST_DELAY>
+            Make the service wait for the given duration between block requests to a Fuel client.
+
     -c, --config <FILE>
             Indexer service config file.
 
@@ -69,10 +72,6 @@ OPTIONS:
 
         --metrics
             Use Prometheus metrics reporting.
-
-        --node-request-delay <NODE_REQUEST_DELAY>
-            If present, the Fuel indexer service will wait for this particular duration between
-            requests to a Fuel node
 
         --postgres-database <POSTGRES_DATABASE>
             Postgres database.

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -115,7 +115,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
     }
 
     let allow_non_sequential_blocks = config.allow_non_sequential_blocks;
-    let node_request_delay = config.node_request_delay;
+    let client_request_delay = config.client_request_delay;
 
     let task = async move {
         let mut conn = pool
@@ -303,9 +303,8 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
             // Since we had successful call, we reset the retry count.
             consecutive_retries = 0;
 
-            if let Some(delay) = node_request_delay {
+            if let Some(delay) = client_request_delay {
                 sleep(Duration::from_secs(delay)).await;
-                continue;
             }
         }
     };

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -115,6 +115,7 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
     }
 
     let allow_non_sequential_blocks = config.allow_non_sequential_blocks;
+    let node_request_delay = config.node_request_delay;
 
     let task = async move {
         let mut conn = pool
@@ -301,6 +302,11 @@ pub fn run_executor<T: 'static + Executor + Send + Sync>(
 
             // Since we had successful call, we reset the retry count.
             consecutive_retries = 0;
+
+            if let Some(delay) = node_request_delay {
+                sleep(Duration::from_secs(delay)).await;
+                continue;
+            }
         }
     };
 

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -44,6 +44,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         block_page_size,
         allow_non_sequential_blocks,
         disable_toolchain_version_check,
+        node_request_delay,
     } = command;
 
     let mut cmd = Command::new("fuel-indexer");
@@ -114,6 +115,10 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
             ("--jwt-secret", jwt_secret),
             ("--jwt-issuer", jwt_issuer),
             ("--jwt-expiry", jwt_expiry.map(|x| x.to_string())),
+            (
+                "--node-request-delay",
+                node_request_delay.map(|x| x.to_string()),
+            ),
         ];
         for (opt, value) in options.iter() {
             if let Some(value) = value {

--- a/plugins/forc-index/src/ops/forc_index_start.rs
+++ b/plugins/forc-index/src/ops/forc_index_start.rs
@@ -44,7 +44,7 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
         block_page_size,
         allow_non_sequential_blocks,
         disable_toolchain_version_check,
-        node_request_delay,
+        client_request_delay,
     } = command;
 
     let mut cmd = Command::new("fuel-indexer");
@@ -116,8 +116,8 @@ pub async fn init(command: StartCommand) -> anyhow::Result<()> {
             ("--jwt-issuer", jwt_issuer),
             ("--jwt-expiry", jwt_expiry.map(|x| x.to_string())),
             (
-                "--node-request-delay",
-                node_request_delay.map(|x| x.to_string()),
+                "--client-request-delay",
+                client_request_delay.map(|x| x.to_string()),
             ),
         ];
         for (opt, value) in options.iter() {


### PR DESCRIPTION
### Description

Adds a configuration flag to delay requests to a Fuel node. This is useful if a Fuel node makes use of rate limiting.

### Testing steps

Run any of the examples with the `--verbose` flag and an arbitrary value for the `--node-request-delay`. You should see that the service waits for the desired amount of time before processing and committing another group of blocks to the database.
