### PR TITLE
chore: add executor metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,7 @@ dependencies = [
  "fuel-indexer-api-server",
  "fuel-indexer-database",
  "fuel-indexer-lib",
+ "fuel-indexer-metrics",
  "fuel-indexer-schema",
  "fuel-indexer-types",
  "fuel-tx 0.35.3",

--- a/packages/fuel-indexer-metrics/src/lib.rs
+++ b/packages/fuel-indexer-metrics/src/lib.rs
@@ -26,6 +26,14 @@ pub fn encode_metrics_response() -> impl IntoResponse {
         return error_body();
     }
 
+    if encode(&mut encoded, &METRICS.exec.handler.registry).is_err() {
+        return error_body();
+    }
+
+    if encode(&mut encoded, &METRICS.exec.web.registry).is_err() {
+        return error_body();
+    }
+
     Response::builder()
         .status(StatusCode::OK)
         .body(Body::from(encoded))

--- a/packages/fuel-indexer-tests/tests/web_server.rs
+++ b/packages/fuel-indexer-tests/tests/web_server.rs
@@ -23,7 +23,7 @@ const SIGNATURE: &str = "cb19384361af5dd7fec2a0052ca49d289f997238ea90590baf47f16
 const NONCE: &str = "ea35be0c98764e7ca06d02067982e3b4";
 
 #[tokio::test]
-async fn test_metrics_endpoint_returns_proper_count_of_metrics_postgres() {
+async fn test_metrics_endpoint_returns_proper_count_of_metrics() {
     let WebTestComponents { server, client, .. } = setup_web_test_components(None).await;
 
     let _ = client

--- a/packages/fuel-indexer/Cargo.toml
+++ b/packages/fuel-indexer/Cargo.toml
@@ -26,8 +26,8 @@ fuel-core-client = "0.20"
 fuel-crypto = { version = "=0.35.3" }
 fuel-indexer-api-server = { workspace = true, optional = true }
 fuel-indexer-database = { workspace = true }
-fuel-indexer-metrics = { workspace = true, optional = true }
 fuel-indexer-lib = { workspace = true }
+fuel-indexer-metrics = { workspace = true, optional = true }
 fuel-indexer-schema = { workspace = true, features = ["db-models"] }
 fuel-indexer-types = { workspace = true }
 fuel-tx = { workspace = true }

--- a/packages/fuel-indexer/Cargo.toml
+++ b/packages/fuel-indexer/Cargo.toml
@@ -26,6 +26,7 @@ fuel-core-client = "0.20"
 fuel-crypto = { version = "=0.35.3" }
 fuel-indexer-api-server = { workspace = true, optional = true }
 fuel-indexer-database = { workspace = true }
+fuel-indexer-metrics = { workspace = true, optional = true }
 fuel-indexer-lib = { workspace = true }
 fuel-indexer-schema = { workspace = true, features = ["db-models"] }
 fuel-indexer-types = { workspace = true }
@@ -48,6 +49,7 @@ features = ["vendored"]
 fuel-core-client = { version = "0.20", features = ["test-helpers"] }
 
 [features]
-default = ["api-server"]
+default = ["api-server", "metrics"]
 fuel-core-lib = ["fuel-core"]
 api-server = ["fuel-indexer-api-server"]
+metrics = ["fuel-indexer-metrics"]


### PR DESCRIPTION
Thanks for opening a PR with the Fuel Indexer project. Please review the **Checklist** below and ensure you've completed all of the necessary steps to make this PR review as painless as possible.


### Checklist
- [ ] Ensure your top-level commit message is in line with our [contributor guidelines](./CONTRIBUTING.md).
- [ ] Please add proper labels.
- [ ] If there is an issue associated with this PR, please link the issue (right-hand sidebar)
- [ ] If there is not an issue associated with this PR, add this PR to the "Fuel Indexer" project (right-hand sidebar)
- [ ] Please allow Codeowners at least 24 hours to do a first-pass review.
- [ ] Please add thoroughly detailed testing steps below.
- [ ] Please keep your Changelog message short and sweet.

### Description

- PR adds a few metrics to the executor.
- Might have to add more later, but want to see how these do for now 

### Testing steps

- [ ] Start the service on beta-4 `cargo run --bin fuel-indexer -- run --run-migrations --fuel-node-host beta-4.fuel.network --fuel-node-port 80`
- [ ] Deploy the hello-world indexer `forc index deploy --path examples/hello-world/hello-world`
- [ ] View the new metrics `curl http://localhost:29987/api/metrics`
- [ ] Should see the new metrics

```
# EOF
# HELP executor_handler_operation_duration .
# TYPE executor_handler_operation_duration histogram
executor_handler_operation_duration_sum{path="fuellabs.hello_world"} 1071.0
executor_handler_operation_duration_count{path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="0.0",path="fuellabs.hello_world"} 0
executor_handler_operation_duration_bucket{le="10.0",path="fuellabs.hello_world"} 0
executor_handler_operation_duration_bucket{le="100.0",path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="1000.0",path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="10000.0",path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="50000.0",path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="100000.0",path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="500000.0",path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="1000000.0",path="fuellabs.hello_world"} 35
executor_handler_operation_duration_bucket{le="+Inf",path="fuellabs.hello_world"} 35
# EOF
# HELP executor_web_request_duration .
# TYPE executor_web_request_duration histogram
executor_web_request_duration_sum{path="fuellabs.hello_world"} 3164.0
executor_web_request_duration_count{path="fuellabs.hello_world"} 35
executor_web_request_duration_bucket{le="0.0",path="fuellabs.hello_world"} 0
executor_web_request_duration_bucket{le="10.0",path="fuellabs.hello_world"} 0
executor_web_request_duration_bucket{le="100.0",path="fuellabs.hello_world"} 28
executor_web_request_duration_bucket{le="1000.0",path="fuellabs.hello_world"} 35
executor_web_request_duration_bucket{le="10000.0",path="fuellabs.hello_world"} 35
executor_web_request_duration_bucket{le="50000.0",path="fuellabs.hello_world"} 35
executor_web_request_duration_bucket{le="100000.0",path="fuellabs.hello_world"} 35
executor_web_request_duration_bucket{le="500000.0",path="fuellabs.hello_world"} 35
executor_web_request_duration_bucket{le="1000000.0",path="fuellabs.hello_world"} 35
executor_web_request_duration_bucket{le="+Inf",path="fuellabs.hello_world"} 35
# EOF
```

### Changelog

- chore: add executor metrics
