### PR TITLE
fix: add instantiating indexer status, and display error if instantiation fails

### DIFF
--- a/packages/fuel-indexer-database/database-types/src/lib.rs
+++ b/packages/fuel-indexer-database/database-types/src/lib.rs
@@ -569,6 +569,8 @@ impl RegisteredIndexer {
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, EnumString, strum::Display,
 )]
 pub enum IndexerStatusKind {
+    #[strum(serialize = "instantiating")]
+    Instantiating,
     #[strum(serialize = "starting")]
     Starting,
     #[strum(serialize = "running")]
@@ -590,6 +592,13 @@ pub struct IndexerStatus {
 }
 
 impl IndexerStatus {
+    pub fn instantiating() -> Self {
+        IndexerStatus {
+            status_kind: IndexerStatusKind::Instantiating,
+            status_message: "".to_string(),
+        }
+    }
+
     pub fn starting() -> Self {
         IndexerStatus {
             status_kind: IndexerStatusKind::Starting,

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -763,12 +763,35 @@ impl WasmIndexExecutor {
     ) -> IndexerResult<Self> {
         let uid = manifest.uid();
 
-        match WasmIndexExecutor::new(config, manifest, wasm_bytes, pool, schema_version)
-            .await
+        let mut conn = pool.acquire().await?;
+        queries::set_indexer_status(
+            &mut conn,
+            manifest.namespace(),
+            manifest.identifier(),
+            IndexerStatus::instantiating(),
+        )
+        .await?;
+
+        match WasmIndexExecutor::new(
+            config,
+            manifest,
+            wasm_bytes,
+            pool.clone(),
+            schema_version,
+        )
+        .await
         {
             Ok(executor) => Ok(executor),
             Err(e) => {
                 error!("Could not instantiate WasmIndexExecutor({uid}): {e:?}.");
+                let mut conn = pool.acquire().await?;
+                queries::set_indexer_status(
+                    &mut conn,
+                    manifest.namespace(),
+                    manifest.identifier(),
+                    IndexerStatus::error(format!("{e}")),
+                )
+                .await?;
                 Err(IndexerError::WasmExecutionInstantiationError)
             }
         }


### PR DESCRIPTION
### Description

On `develop`, when indexer instantiation fails, `forc index status` will display the last status from the database. This may be `running`, `Indexed 12345 blocks`.

This PR adds `IndexerStatusKind::Instantiating` to avoid this situation.

In addition, if the indexer instantiation fails, the status is set to `error` and a proper message is displayed:

```
Indexers:

─ fuellabs
   ├─ explorer
   |  • id: 1
   |  • created at: 2023-11-08 11:54:53.323558 UTC (6h 45m ago)
   |  • status: error
   |  • status message:
   |      Error instantiating wasm interpreter: Link(
   |          Import(
   |              "env",
   |              "ff_single_select",
   |              UnknownImport(
   |                  Function(
   |                      FunctionType {
   |                          params: [
   |                              I64,
   |                              I32,
   |                              I32,
   |                          ],
   |                          results: [
   |                              I32,
   |                          ],
   |                      },
   |                  ),
   |              ),
   |          ),
   |      )
```

### Testing steps

1. Check out `maciej/1437-entity-find` and start the indexer:
```
cargo run --bin fuel-indexer -- run --run-migrations --fuel-node-host beta-4.fuel.network --fuel-node-port 80 --replace-indexer --manifest examples/fuel-explorer/fuel-explorer/fuel_explorer.manifest.yaml
```
2. Check out `develop`, and restart the indexer without `--manifest` to keep the incompatible indexer in the database.
3. Run `forc index status` to see the incorrect status.
4. Check out `maciej/add-more-indexer-statuses`, and restart the indexer (again, without `--manifest`).
5. Run `forc index status` to see the correct status and error.