### PR TITLE
bugfix: fix bytes encoding in entity::find

### DIFF
--- a/packages/fuel-indexer-plugin/src/find.rs
+++ b/packages/fuel-indexer-plugin/src/find.rs
@@ -441,8 +441,14 @@ mod tests {
         let addr: Filter<MyStruct> = my_address_field().eq(Address::zeroed());
         assert_eq!(&addr.to_string(), "my_address_field = '0000000000000000000000000000000000000000000000000000000000000000'");
 
-        let addr: Filter<MyStruct> = my_bytes8_field().eq(Bytes8::zeroed());
-        assert_eq!(&addr.to_string(), "my_bytes8_field = '0000000000000000'");
+        let addr: Filter<MyStruct> = my_address_field().eq(Address::from([238; 32]));
+        assert_eq!(&addr.to_string(), "my_address_field = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'");
+
+        let bytes: Filter<MyStruct> = my_bytes8_field().eq(Bytes8::zeroed());
+        assert_eq!(&bytes.to_string(), "my_bytes8_field = '0000000000000000'");
+
+        let bytes: Filter<MyStruct> = my_bytes8_field().eq(Bytes8::from([1, 2, 3, 4, 5, 6, 7, 15]));
+        assert_eq!(&bytes.to_string(), "my_bytes8_field = '010203040506070f'");
 
         let word: Filter<MyStruct> = my_blockheight_field().eq(BlockHeight::new(123));
         assert_eq!(&word.to_string(), "my_blockheight_field = 123");

--- a/packages/fuel-indexer-plugin/src/find.rs
+++ b/packages/fuel-indexer-plugin/src/find.rs
@@ -224,11 +224,7 @@ macro_rules! impl_bytes_to_sql_value {
     ($T:ident) => {
         impl ToSQLValue for fuel_indexer_types::scalar::$T {
             fn to_sql_value(self) -> sql::Value {
-                unsafe {
-                    sql::Value::SingleQuotedByteStringLiteral(
-                        std::str::from_utf8_unchecked(self.as_ref()).to_string(),
-                    )
-                }
+                sql::Value::SingleQuotedString(hex::encode(self))
             }
         }
     };

--- a/packages/fuel-indexer-plugin/src/find.rs
+++ b/packages/fuel-indexer-plugin/src/find.rs
@@ -447,7 +447,8 @@ mod tests {
         let bytes: Filter<MyStruct> = my_bytes8_field().eq(Bytes8::zeroed());
         assert_eq!(&bytes.to_string(), "my_bytes8_field = '0000000000000000'");
 
-        let bytes: Filter<MyStruct> = my_bytes8_field().eq(Bytes8::from([1, 2, 3, 4, 5, 6, 7, 15]));
+        let bytes: Filter<MyStruct> =
+            my_bytes8_field().eq(Bytes8::from([1, 2, 3, 4, 5, 6, 7, 15]));
         assert_eq!(&bytes.to_string(), "my_bytes8_field = '010203040506070f'");
 
         let word: Filter<MyStruct> = my_blockheight_field().eq(BlockHeight::new(123));


### PR DESCRIPTION
### Description

Fixes #1480.

The issue was an incorrect conversion of (various) `bytes` scalars to `sqlparser::Value` as `SingleQuotedByteStringLiteral`.

All `bytes` scalars are stored as lower-hex encoded strings. Thus, changing the conversion to `sql::Value::SingleQuotedString(hex::encode(self))` fixes the issue.

### Testing steps

The same testing steps as outlined in #1480.

This PR also adds a couple of test cases.

### Changelog

* Fix `ToSQLValue` encoding of bytes `[u8]` scalar types
