### PR TITLE
chore: don't override the manifest file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -656,7 +656,7 @@ dependencies = [
  "futures-lite 2.1.0",
  "parking",
  "polling 3.3.1",
- "rustix 0.38.26",
+ "rustix 0.38.28",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -727,7 +727,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1028,7 +1028,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1434,7 +1434,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1992,7 +1992,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2103,7 +2103,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2136,7 +2136,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2477,7 +2477,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2490,7 +2490,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2511,7 +2511,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2635,7 +2635,7 @@ checksum = "dd65f1b59dd22d680c7a626cc4a000c1e03d241c51c3e034d2bc9f1e90734f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2905,7 +2905,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.39",
+ "syn 2.0.40",
  "thiserror",
 ]
 
@@ -3462,7 +3462,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -3485,7 +3485,7 @@ dependencies = [
  "quote",
  "serde_json",
  "sha2 0.10.8",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -3851,7 +3851,7 @@ dependencies = [
  "quote",
  "regex",
  "serde_json",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -3867,7 +3867,7 @@ dependencies = [
  "quote",
  "regex",
  "serde_json",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -3883,7 +3883,7 @@ dependencies = [
  "quote",
  "regex",
  "serde_json",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -3928,7 +3928,7 @@ dependencies = [
  "rand",
  "regex",
  "serde_json",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -3942,7 +3942,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rand",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -4093,7 +4093,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -4491,9 +4491,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -4590,7 +4590,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.9",
+ "rustls 0.21.10",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -4824,7 +4824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.26",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -4857,9 +4857,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
@@ -4963,9 +4963,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
@@ -5350,9 +5350,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -5395,7 +5395,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5406,9 +5406,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.6+3.1.4"
+version = "300.2.0+3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+checksum = "b1ebed1d188c4cd64c2bcd73d6c1fe1092f3d98c111831923cc1b706c3859fca"
 dependencies = [
  "cc",
 ]
@@ -5664,7 +5664,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5769,7 +5769,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5880,7 +5880,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.26",
+ "rustix 0.38.28",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -5941,7 +5941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -6071,7 +6071,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -6341,7 +6341,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.9",
+ "rustls 0.21.10",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6512,9 +6512,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -6550,9 +6550,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.7",
@@ -6611,9 +6611,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "salsa20"
@@ -6824,7 +6824,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7526,9 +7526,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7603,7 +7603,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall 0.4.1",
- "rustix 0.38.26",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -7639,7 +7639,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7728,9 +7728,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7763,7 +7763,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7814,7 +7814,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.9",
+ "rustls 0.21.10",
  "tokio",
 ]
 
@@ -7997,7 +7997,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -8099,9 +8099,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
@@ -8372,7 +8372,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
  "wasm-bindgen-shared",
 ]
 
@@ -8406,7 +8406,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8674,7 +8674,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.26",
+ "rustix 0.38.28",
 ]
 
 [[package]]
@@ -8970,9 +8970,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.25"
+version = "0.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
+checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
 dependencies = [
  "memchr",
 ]
@@ -9025,11 +9025,13 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+checksum = "d367426ae76bdfce3d8eaea6e94422afd6def7d46f9c89e2980309115b3c2c41"
 dependencies = [
  "libc",
+ "linux-raw-sys 0.4.12",
+ "rustix 0.38.28",
 ]
 
 [[package]]
@@ -9061,22 +9063,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.29"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
+checksum = "306dca4455518f1f31635ec308b6b3e4eb1b11758cefafc782827d0aa7acb5c7"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.29"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
+checksum = "be912bf68235a88fbefd1b73415cb218405958d1655b2ece9035a19920bdf6ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -9096,7 +9098,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]

--- a/packages/fuel-indexer-lib/src/manifest.rs
+++ b/packages/fuel-indexer-lib/src/manifest.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
-    io::{Read, Write},
+    io::Read,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -145,18 +145,6 @@ impl Manifest {
                 Ok(bytes)
             }
         }
-    }
-
-    /// Write this manifest to a given path.
-    pub fn write(&self, path: &PathBuf) -> ManifestResult<()> {
-        let mut file = File::create(path).map_err(|err| {
-            ManifestError::FileError(path.to_str().unwrap_or_default().to_string(), err)
-        })?;
-        let content: Vec<u8> = Self::into(self.clone());
-        file.write_all(&content).map_err(|err| {
-            ManifestError::FileError(path.to_str().unwrap_or_default().to_string(), err)
-        })?;
-        Ok(())
     }
 
     /// Set the start block for this indexer.

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_build_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_build_help_output.snap
@@ -8,9 +8,29 @@ USAGE:
     forc-index build [OPTIONS]
 
 OPTIONS:
-    -d, --debug                  Build artifacts with the debug profile.
-    -h, --help                   Print help information
-        --locked                 Ensure that the Cargo.lock file is up-to-date.
-    -m, --manifest <MANIFEST>    Manifest file name of indexer being built.
-    -p, --path <PATH>            Path to the indexer project.
-    -v, --verbose                Enable verbose output.
+    -d, --debug
+            Build artifacts with the debug profile.
+
+    -h, --help
+            Print help information
+
+        --locked
+            Ensure that the Cargo.lock file is up-to-date.
+
+    -m, --manifest <MANIFEST>
+            Manifest file name of indexer being built.
+
+        --override-end-block <OVERRIDE_END_BLOCK>
+            Override the end blockt.
+
+        --override-identifier <OVERRIDE_IDENTIFIER>
+            Override the identifier.
+
+        --override-start-block <OVERRIDE_START_BLOCK>
+            Override the start block.
+
+    -p, --path <PATH>
+            Path to the indexer project.
+
+    -v, --verbose
+            Enable verbose output.

--- a/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_deploy_help_output.snap
+++ b/packages/fuel-indexer-tests/tests/snapshots/integration_tests__commands__forc_index_deploy_help_output.snap
@@ -8,15 +8,44 @@ USAGE:
     forc-index deploy [OPTIONS]
 
 OPTIONS:
-        --auth <AUTH>            Authentication header value.
-    -d, --debug                  Build optimized artifacts with the debug profile.
-    -h, --help                   Print help information
-        --locked                 Ensure that the Cargo.lock file is up-to-date.
-    -m, --manifest <MANIFEST>    Path to the manifest of indexer project being deployed.
-    -p, --path <PATH>            Path to the indexer project.
-        --remove-data            Remove all indexed data when replacing an existing indexer.
-        --replace-indexer        If an indexer with the same UID exists, remove it.
-        --skip-build             Do not build before deploying.
-        --url <URL>              URL at which to deploy indexer assets. [default:
-                                 http://127.0.0.1:29987]
-    -v, --verbose                Enable verbose logging.
+        --auth <AUTH>
+            Authentication header value.
+
+    -d, --debug
+            Build optimized artifacts with the debug profile.
+
+    -h, --help
+            Print help information
+
+        --locked
+            Ensure that the Cargo.lock file is up-to-date.
+
+    -m, --manifest <MANIFEST>
+            Path to the manifest of indexer project being deployed.
+
+        --override-end-block <OVERRIDE_END_BLOCK>
+            Override the end blockt.
+
+        --override-identifier <OVERRIDE_IDENTIFIER>
+            Override the identifier.
+
+        --override-start-block <OVERRIDE_START_BLOCK>
+            Override the start block.
+
+    -p, --path <PATH>
+            Path to the indexer project.
+
+        --remove-data
+            Remove all indexed data when replacing an existing indexer.
+
+        --replace-indexer
+            If an indexer with the same UID exists, remove it.
+
+        --skip-build
+            Do not build before deploying.
+
+        --url <URL>
+            URL at which to deploy indexer assets. [default: http://127.0.0.1:29987]
+
+    -v, --verbose
+            Enable verbose logging.

--- a/plugins/forc-index/src/commands/build.rs
+++ b/plugins/forc-index/src/commands/build.rs
@@ -25,6 +25,18 @@ pub struct Command {
     /// Enable verbose output.
     #[clap(short, long, help = "Enable verbose output.")]
     pub verbose: bool,
+
+    /// Override the start block
+    #[clap(long, help = "Override the start block.")]
+    pub override_start_block: Option<u32>,
+
+    /// Override the end block
+    #[clap(long, help = "Override the end blockt.")]
+    pub override_end_block: Option<u32>,
+
+    /// Override the identifier
+    #[clap(long, help = "Override the identifier.")]
+    pub override_identifier: Option<String>,
 }
 
 pub fn exec(command: Command) -> Result<()> {

--- a/plugins/forc-index/src/commands/deploy.rs
+++ b/plugins/forc-index/src/commands/deploy.rs
@@ -56,6 +56,18 @@ pub struct Command {
         help = "Remove all indexed data when replacing an existing indexer."
     )]
     pub remove_data: bool,
+
+    /// Override the start block
+    #[clap(long, help = "Override the start block.")]
+    pub override_start_block: Option<u32>,
+
+    /// Override the end block
+    #[clap(long, help = "Override the end blockt.")]
+    pub override_end_block: Option<u32>,
+
+    /// Override the identifier
+    #[clap(long, help = "Override the identifier.")]
+    pub override_identifier: Option<String>,
 }
 
 pub async fn exec(command: Command) -> Result<()> {

--- a/plugins/forc-index/src/ops/forc_index_build.rs
+++ b/plugins/forc-index/src/ops/forc_index_build.rs
@@ -1,8 +1,5 @@
 use crate::{cli::BuildCommand, defaults, utils::project_dir_info};
-use fuel_indexer_lib::{
-    manifest::{Manifest, Module},
-    utils::Config,
-};
+use fuel_indexer_lib::{manifest::Manifest, utils::Config};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::HashSet;
 use std::{
@@ -182,7 +179,7 @@ pub fn init(command: BuildCommand) -> anyhow::Result<()> {
     let abs_artifact_path = target_dir
         .join(defaults::WASM_TARGET)
         .join(profile)
-        .join(&binary);
+        .join(binary);
 
     let abs_wasm = abs_artifact_path.as_path().display().to_string();
 

--- a/plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -29,6 +29,9 @@ pub async fn init(command: DeployCommand) -> anyhow::Result<()> {
         replace_indexer,
         remove_data,
         skip_build,
+        override_start_block,
+        override_end_block,
+        override_identifier,
     } = command;
 
     if !skip_build {
@@ -38,6 +41,9 @@ pub async fn init(command: DeployCommand) -> anyhow::Result<()> {
             debug,
             verbose,
             locked,
+            override_start_block,
+            override_end_block,
+            override_identifier,
         })?;
     }
 


### PR DESCRIPTION
### Description

Closes #1350.

Instead of overriding the Manifest file, this PR adds `--override-{start-block, end-block, identifier}` CLI options to `forc-index {build, deploy}`, which allows us to achieve what we need for the QA script without touching the manifest file.

It also looks like `forc index build` unnecessarily writes the `module` path to the `manifest`:

```
    let relative_wasm = rel_artifact_path.as_path().display().to_string();

    manifest.set_module(Module::Wasm(relative_wasm));
```

I think `forc-index` shouldn't modify the user's source files.

### Testing steps

CI tests should pass.

### Changelog

* Remove the `write` method from the `Manifest`
* `forc-index build` no longer overwrites the manifest file.
* Add CLI flags to change the start and end blocks and the identifier of the indexer being deployed.
* Change the QA script to use the new CLI flags instead of overwriting the manifest file. 
