### PR TITLE
enhancement: add Entity::delete_many

### DIFF
--- a/packages/fuel-indexer-api-server/src/ffi.rs
+++ b/packages/fuel-indexer-api-server/src/ffi.rs
@@ -23,6 +23,10 @@ pub fn check_wasm_toolchain_version(data: Vec<u8>) -> anyhow::Result<String> {
         Function::new_typed(&mut store, |_: i64, _: i32, _: i32| 0i32),
     );
     exports.insert(
+        "ff_delete_many".to_string(),
+        Function::new_typed(&mut store, |_: i64, _: i32, _: i32| 0i64),
+    );
+    exports.insert(
         "ff_early_exit".to_string(),
         Function::new_typed(&mut store, |_: i32| {}),
     );

--- a/packages/fuel-indexer-plugin/src/wasm.rs
+++ b/packages/fuel-indexer-plugin/src/wasm.rs
@@ -57,6 +57,14 @@ impl Logger {
     }
 }
 
+/// Trait for a type entity which supports the `delete()` operation.
+pub trait EntityDelete<'a>: Sized + PartialEq + Eq + std::fmt::Debug {
+    /// Deletes the entity with the corresponding `ID` from the database.
+    /// Returns `true` when the value has been deleted, and `false` if it has
+    /// not.
+    fn delete(&self) -> bool;
+}
+
 /// Trait for a type entity.
 ///
 /// Any entity type that will be processed through a WASM indexer is required to implement this trait.

--- a/packages/fuel-indexer-plugin/src/wasm.rs
+++ b/packages/fuel-indexer-plugin/src/wasm.rs
@@ -25,7 +25,7 @@ pub use crate::find::{Field, Filter, ManyFilter, OptionField, SingleFilter};
 extern "C" {
     fn ff_get_object(type_id: i64, ptr: *const u8, len: *mut u8) -> *mut u8;
     fn ff_find_many(type_id: i64, ptr: *const u8, len: *mut u8) -> *mut u8;
-    fn ff_delete(type_id: i64, ptr: *const u8, len: *mut u8) -> u64;
+    fn ff_delete_many(type_id: i64, ptr: *const u8, len: *mut u8) -> u64;
     fn ff_log_data(ptr: *const u8, len: u32, log_level: u32);
     fn ff_put_object(type_id: i64, ptr: *const u8, len: u32);
     fn ff_put_many_to_many_record(ptr: *const u8, len: u32);
@@ -163,14 +163,14 @@ pub trait Entity<'a>: Sized + PartialEq + Eq + std::fmt::Debug {
     }
 
     /// Delete the entities that satisfy the given constraints.
-    fn delete(filter: impl Into<ManyFilter<Self>>) -> usize {
+    fn delete_many(filter: impl Into<ManyFilter<Self>>) -> usize {
         let filter: ManyFilter<Self> = filter.into();
         let buff =
             bincode::serialize(&filter.to_string()).expect("Failed to serialize query");
         let mut bufflen = (buff.len() as u32).to_le_bytes();
 
         let count =
-            unsafe { ff_delete(Self::TYPE_ID, buff.as_ptr(), bufflen.as_mut_ptr()) };
+            unsafe { ff_delete_many(Self::TYPE_ID, buff.as_ptr(), bufflen.as_mut_ptr()) };
 
         count as usize
     }

--- a/packages/fuel-indexer-plugin/src/wasm.rs
+++ b/packages/fuel-indexer-plugin/src/wasm.rs
@@ -25,6 +25,7 @@ pub use crate::find::{Field, Filter, ManyFilter, OptionField, SingleFilter};
 extern "C" {
     fn ff_get_object(type_id: i64, ptr: *const u8, len: *mut u8) -> *mut u8;
     fn ff_find_many(type_id: i64, ptr: *const u8, len: *mut u8) -> *mut u8;
+    fn ff_delete(type_id: i64, ptr: *const u8, len: *mut u8) -> u64;
     fn ff_log_data(ptr: *const u8, len: u32, log_level: u32);
     fn ff_put_object(type_id: i64, ptr: *const u8, len: u32);
     fn ff_put_many_to_many_record(ptr: *const u8, len: u32);
@@ -159,6 +160,19 @@ pub trait Entity<'a>: Sized + PartialEq + Eq + std::fmt::Debug {
                 vec![]
             }
         }
+    }
+
+    /// Delete the entities that satisfy the given constraints.
+    fn delete(filter: impl Into<ManyFilter<Self>>) -> usize {
+        let filter: ManyFilter<Self> = filter.into();
+        let buff =
+            bincode::serialize(&filter.to_string()).expect("Failed to serialize query");
+        let mut bufflen = (buff.len() as u32).to_le_bytes();
+
+        let count =
+            unsafe { ff_delete(Self::TYPE_ID, buff.as_ptr(), bufflen.as_mut_ptr()) };
+
+        count as usize
     }
 
     /// Saves a record.

--- a/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
@@ -682,13 +682,15 @@ mod fuel_indexer_test {
             assert_eq!(fs[1].string_value, "find4");
 
             // Test delete()
-            let count: usize =
-                FindEntity::delete_many(FindEntity::string_value().eq("find3".to_string()));
+            let count: usize = FindEntity::delete_many(
+                FindEntity::string_value().eq("find3".to_string()),
+            );
             assert_eq!(count, 1);
 
             // "find3" has already been deleted
-            let count: usize =
-                FindEntity::delete_many(FindEntity::string_value().eq("find3".to_string()));
+            let count: usize = FindEntity::delete_many(
+                FindEntity::string_value().eq("find3".to_string()),
+            );
             assert_eq!(count, 0);
 
             // Test searching for multiple entities, with limit

--- a/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
@@ -680,6 +680,44 @@ mod fuel_indexer_test {
             assert_eq!(fs.len(), 2);
             assert_eq!(fs[0].string_value, "find5");
             assert_eq!(fs[1].string_value, "find4");
+
+            // Test delete()
+            let count: usize =
+                FindEntity::delete(FindEntity::string_value().eq("find3".to_string()));
+            assert_eq!(count, 1);
+
+            // "find3" has already been deleted
+            let count: usize =
+                FindEntity::delete(FindEntity::string_value().eq("find3".to_string()));
+            assert_eq!(count, 0);
+
+            // Test searching for multiple entities, with limit
+            let fs: Vec<FindEntity> = FindEntity::find_many(
+                FindEntity::string_value()
+                    .gt("f".to_string())
+                    .order_by(FindEntity::value()),
+            );
+            // There were four, but one has been deleted.
+            assert_eq!(fs.len(), 3);
+
+            // Next, delete "find2" and "find4"
+            let count: usize = FindEntity::delete(
+                FindEntity::string_value()
+                    .gt("f".to_string())
+                    .and(FindEntity::string_value().lt("find5".to_string())),
+            );
+            assert_eq!(count, 2);
+
+            // Test searching for multiple entities, with limit
+            let fs: Vec<FindEntity> = FindEntity::find_many(
+                FindEntity::string_value()
+                    .gt("f".to_string())
+                    .order_by(FindEntity::value()),
+            );
+
+            // Now there is only one left
+            assert_eq!(fs.len(), 1);
+            assert_eq!(fs[0].string_value, "find5");
         } else if block_data.height == 6 {
             // There is no such block. The lookup will fail.
             IndexMetadataEntity::find(IndexMetadataEntity::block_height().eq(777))

--- a/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
@@ -683,12 +683,12 @@ mod fuel_indexer_test {
 
             // Test delete()
             let count: usize =
-                FindEntity::delete(FindEntity::string_value().eq("find3".to_string()));
+                FindEntity::delete_many(FindEntity::string_value().eq("find3".to_string()));
             assert_eq!(count, 1);
 
             // "find3" has already been deleted
             let count: usize =
-                FindEntity::delete(FindEntity::string_value().eq("find3".to_string()));
+                FindEntity::delete_many(FindEntity::string_value().eq("find3".to_string()));
             assert_eq!(count, 0);
 
             // Test searching for multiple entities, with limit
@@ -701,7 +701,7 @@ mod fuel_indexer_test {
             assert_eq!(fs.len(), 3);
 
             // Next, delete "find2" and "find4"
-            let count: usize = FindEntity::delete(
+            let count: usize = FindEntity::delete_many(
                 FindEntity::string_value()
                     .gt("f".to_string())
                     .and(FindEntity::string_value().lt("find5".to_string())),

--- a/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
@@ -699,7 +699,7 @@ mod fuel_indexer_test {
                     .gt("f".to_string())
                     .order_by(FindEntity::value()),
             );
-            // There were four, but one has been deleted.
+            // There were four, but one has been deleted
             assert_eq!(fs.len(), 3);
 
             // Next, delete "find2" and "find4"
@@ -720,6 +720,19 @@ mod fuel_indexer_test {
             // Now there is only one left
             assert_eq!(fs.len(), 1);
             assert_eq!(fs[0].string_value, "find5");
+
+            // Directly delete the last value
+            let deleted = fs[0].delete();
+            assert!(deleted);
+
+            let fs: Vec<FindEntity> = FindEntity::find_many(
+                FindEntity::string_value()
+                    .gt("f".to_string())
+                    .order_by(FindEntity::value()),
+            );
+
+            // Nothing left.
+            assert_eq!(fs.len(), 0);
         } else if block_data.height == 6 {
             // There is no such block. The lookup will fail.
             IndexMetadataEntity::find(IndexMetadataEntity::block_height().eq(777))

--- a/packages/fuel-indexer-tests/tests/indexing.rs
+++ b/packages/fuel-indexer-tests/tests/indexing.rs
@@ -721,7 +721,7 @@ async fn test_no_missing_blocks() {
 }
 
 #[actix_web::test]
-async fn test_find() {
+async fn test_find_and_delete() {
     let IndexingTestComponents {
         ref node, ref db, ..
     } = setup_indexing_test_components(None).await;

--- a/packages/fuel-indexer/src/database.rs
+++ b/packages/fuel-indexer/src/database.rs
@@ -242,6 +242,31 @@ Do your WASM modules need to be rebuilt?
         }
     }
 
+    /// Delete multiple objects from the database that satisfy the given constraints.
+    pub async fn delete(
+        &mut self,
+        type_id: i64,
+        constraints: String,
+    ) -> IndexerResult<usize> {
+        let table = &self
+            .tables
+            .get(&type_id)
+            .ok_or(IndexerDatabaseError::TableMappingDoesNotExist(type_id))?;
+
+        let query = format!("DELETE from {table} WHERE {constraints}");
+
+        info!("QUERY: {query}");
+
+        let conn = self
+            .stashed
+            .as_mut()
+            .ok_or(IndexerError::NoTransactionError("find_many".to_string()))?;
+
+        let count = queries::execute_query(conn, query).await?;
+
+        Ok(count)
+    }
+
     /// Load the schema for this indexer from the database, and build a mapping of `TypeId`s to tables.
     pub async fn load_schema(&mut self, version: String) -> IndexerResult<()> {
         self.version = version;

--- a/packages/fuel-indexer/src/database.rs
+++ b/packages/fuel-indexer/src/database.rs
@@ -243,7 +243,7 @@ Do your WASM modules need to be rebuilt?
     }
 
     /// Delete multiple objects from the database that satisfy the given constraints.
-    pub async fn delete(
+    pub async fn delete_many(
         &mut self,
         type_id: i64,
         constraints: String,

--- a/packages/fuel-indexer/src/ffi.rs
+++ b/packages/fuel-indexer/src/ffi.rs
@@ -475,7 +475,7 @@ pub fn get_exports(store: &mut Store, env: &wasmer::FunctionEnv<IndexEnv>) -> Ex
 
     let f_get_obj = Function::new_typed_with_env(store, env, get_object);
     let f_find_many = Function::new_typed_with_env(store, env, find_many);
-    let f_delete = Function::new_typed_with_env(store, env, delete_many);
+    let f_delete_many = Function::new_typed_with_env(store, env, delete_many);
     let f_put_obj = Function::new_typed_with_env(store, env, put_object);
     let f_log_data = Function::new_typed_with_env(store, env, log_data);
     let f_put_many_to_many_record =
@@ -485,7 +485,7 @@ pub fn get_exports(store: &mut Store, env: &wasmer::FunctionEnv<IndexEnv>) -> Ex
     exports.insert("ff_early_exit".to_string(), f_early_exit);
     exports.insert("ff_get_object".to_string(), f_get_obj);
     exports.insert("ff_find_many".to_string(), f_find_many);
-    exports.insert("ff_delete".to_string(), f_delete);
+    exports.insert("ff_delete_many".to_string(), f_delete_many);
     exports.insert("ff_put_object".to_string(), f_put_obj);
     exports.insert(
         "ff_put_many_to_many_record".to_string(),

--- a/packages/fuel-indexer/src/ffi.rs
+++ b/packages/fuel-indexer/src/ffi.rs
@@ -284,7 +284,7 @@ fn find_many(
 }
 
 /// Delete multiple objects from the database that satisfy the given constraints.
-fn delete(
+fn delete_many(
     mut env: FunctionEnvMut<IndexEnv>,
     type_id: i64,
     ptr: u32,
@@ -316,7 +316,14 @@ fn delete(
 
     let rt = tokio::runtime::Handle::current();
     let count = rt
-        .block_on(async { idx_env.db.lock().await.delete(type_id, constraints).await })
+        .block_on(async {
+            idx_env
+                .db
+                .lock()
+                .await
+                .delete_many(type_id, constraints)
+                .await
+        })
         .unwrap();
 
     Ok(count as u64)
@@ -468,7 +475,7 @@ pub fn get_exports(store: &mut Store, env: &wasmer::FunctionEnv<IndexEnv>) -> Ex
 
     let f_get_obj = Function::new_typed_with_env(store, env, get_object);
     let f_find_many = Function::new_typed_with_env(store, env, find_many);
-    let f_delete = Function::new_typed_with_env(store, env, delete);
+    let f_delete = Function::new_typed_with_env(store, env, delete_many);
     let f_put_obj = Function::new_typed_with_env(store, env, put_object);
     let f_log_data = Function::new_typed_with_env(store, env, log_data);
     let f_put_many_to_many_record =


### PR DESCRIPTION
### Description

Closes #1511.

This PR adds `Entity::delete_many(filter)`, which removes all entities of type `T` matching the given filter, and a new trait `EntityDelete` which provides a `t.delete()` method on a single non-virtual entity type.

Some types are not stored in tables and hence do not have the `delete()` method:
```
examples/fuel-explorer/fuel-explorer/schema/fuel_explorer.schema.graphql
103:type Witness @entity(virtual: true) {
107:type InstructionResult @entity(virtual: true) {
112:type ProgramState @entity(virtual: true) {
117:type DryRun @entity(virtual: true) {
224:type CallReceipt @entity(virtual: true) {
241:type ReturnDataReceipt @entity(virtual: true) {
254:type PanicReceipt @entity(virtual: true) {
264:type RevertReceipt @entity(virtual: true) {
274:type LogReceipt @entity(virtual: true) {
287:type LogDataReceipt @entity(virtual: true) {
302:type ReturnReceipt @entity(virtual: true) {
312:type TransferReceipt @entity(virtual: true) {
326:type TransferOutReceipt @entity(virtual: true) {
340:type ScriptResultReceipt @entity(virtual: true) {
347:type MessageOutReceipt @entity(virtual: true) {
361:type MintReceipt @entity(virtual: true) {
370:type BurnReceipt @entity(virtual: true) {
```

`t.delete()` translates to:

```
DELETE FROM entity_table WHERE id = 'some_id'
```

### Testing steps

CI tests should pass. This PR includes new tests for `delete_many()`

### Changelog

* Add `Entity::delete_many()` which deletes all entities matching the given filter from the database.
* Add `t.delete()`, which deletes a single entity from the database.
* Add add tests for `Entity::delete_many()` and `t.delete()`.