### PR TITLE
add a test for find after save

### DIFF
--- a/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
+++ b/packages/fuel-indexer-tests/indexers/fuel-indexer-test/src/lib.rs
@@ -670,7 +670,7 @@ mod fuel_indexer_test {
             assert_eq!(fs[3].string_value, "find2");
 
             // Test searching for multiple entities, with limit
-            let fs: Vec<FindEntity> = FindEntity::find_many(
+            let mut fs: Vec<FindEntity> = FindEntity::find_many(
                 FindEntity::string_value()
                     .gt("f".to_string())
                     .order_by(FindEntity::value().desc())
@@ -680,6 +680,18 @@ mod fuel_indexer_test {
             assert_eq!(fs.len(), 2);
             assert_eq!(fs[0].string_value, "find5");
             assert_eq!(fs[1].string_value, "find4");
+
+            // Test find after save
+            fs[0].string_value = "findX".to_string();
+            fs[0].save();
+
+            let fe: FindEntity = FindEntity::find(
+                FindEntity::value()
+                    .eq(fs[0].value)
+                    .order_by(FindEntity::value().desc())
+            ).unwrap();
+
+            assert_eq!(&fe.string_value, "findX");
 
             // Test delete()
             let count: usize = FindEntity::delete_many(


### PR DESCRIPTION
### Description

Work in progress PR to deal with #1518 issue.

An example indexer to see the problem in isolation.

```graphql
type Block @entity {
    id: ID!
    height: U64!
    hash: Bytes32! @unique
    memo: String!
}
```

```rust
extern crate alloc;
use fuel_indexer_utils::prelude::*;

#[indexer(manifest = "find_after_save.manifest.yaml")]
pub mod find_after_save_index_mod {

    fn find_after_save_handler(block_data: BlockData) {
        if block_data.header.height == 1 {
            info!("Processing Block#{}. (>'.')>", block_data.header.height);

            let mut block = Block::new(
                block_data.header.height.into(),
                block_data.id,
                "one".to_string(),
            );
            block.save();
            info!("Saved: {block:#?}");

            let b = Block::find(Block::height().eq(block.height)).unwrap();
            info!("Found: {b:#?}");

            block.memo = "two".to_string();
            block.save();

            let b = Block::find(Block::height().eq(block.height)).unwrap();
            info!("Found (expecting modified): {b:#?}");

            assert_eq!(&b.memo, "two");
        }
    }
}
```

### Testing steps

Please provide the _exact_ testing steps for the reviewer(s) if this PR requires testing.

### Changelog

Please add neat Changelog info here, according to our [Contributor's Guide](./CONTRIBUTING.md).
