### PR TITLE
docs: fix forc index import

### DIFF
--- a/docs/src/forc-index/index.md
+++ b/docs/src/forc-index/index.md
@@ -3,5 +3,5 @@
 `forc index` is the recommended method for end users to interact with the Fuel indexer. After you have installed `fuelup`, you can run the `forc index help` command in your terminal to view the available commands.
 
 ```text,ignore
-{{#include ./../../README.md 59:84}}
+{{#include ./../../README.md:60:83}}
 ```


### PR DESCRIPTION
### Description

Fixes an issue importing forc index commands to the forc index page. You can see the live issue here: https://fuellabs.github.io/fuel-indexer/master/forc-index/index.html

### Testing steps

Run the mdbook locally.

### Changelog

fix code import in docs
