### PR TITLE
fix: include `std` feature on `strum` dependency

### DIFF
--- a/packages/fuel-indexer-api-server/Cargo.toml
+++ b/packages/fuel-indexer-api-server/Cargo.toml
@@ -36,7 +36,7 @@ serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 sqlparser = { version = "0.35" }
 sqlx = { version = "0.6", features = ["postgres", "runtime-tokio-rustls", "bigdecimal"] }
-strum = { version = "0.24", default-features = false, features = ["derive"] }
+strum = { version = "0.24", default-features = false, features = ["derive", "std"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4", features = ["limit", "buffer"] }


### PR DESCRIPTION
### Description

Includes `std` feature for `strum` in `fuel-indexer-api-server`.

### Testing steps

For some odd reason, I was unable to build the `fuel-indexer` package due to the following error:
```
error[E0599]: the method `as_dyn_error` exists for reference `&ParseError`, but its trait bounds were not satisfied
   --> packages/fuel-indexer-api-server/src/api.rs:105:18
    |
105 |     ParseError(#[from] strum::ParseError),
    |                  ^^^^ method cannot be called on `&ParseError` due to unsatisfied trait bounds
    |
```

Try to build on develop, and then try to build on this branch; you should see that it works in the latter.
