### PR TITLE
chore: upgrade Fuel dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   REGISTRY: ghcr.io
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
   SQLX_OFFLINE: true
-  RUSTC_VERSION: 1.73.0
+  RUSTC_VERSION: 1.75.0
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   IS_MASTER: ${{ github.head_ref == 'master' || github.ref_name == 'master' }}
   IS_DEVELOP: ${{ github.head_ref == 'develop' || github.ref_name == 'develop' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
  "fuel-tx 0.43.1",
- "fuels",
+ "fuels 0.55.0",
  "hex",
  "humantime",
  "hyper-rustls 0.23.2",
@@ -2806,18 +2806,18 @@ dependencies = [
  "clap 4.4.11",
  "derive_more",
  "enum-iterator 1.4.1",
- "fuel-core-chain-config",
+ "fuel-core-chain-config 0.21.0",
  "fuel-core-consensus-module",
  "fuel-core-database",
  "fuel-core-executor",
  "fuel-core-importer",
- "fuel-core-metrics",
- "fuel-core-poa",
+ "fuel-core-metrics 0.21.0",
+ "fuel-core-poa 0.21.0",
  "fuel-core-producer",
- "fuel-core-services",
- "fuel-core-storage",
+ "fuel-core-services 0.21.0",
+ "fuel-core-storage 0.21.0",
  "fuel-core-txpool",
- "fuel-core-types",
+ "fuel-core-types 0.21.0",
  "futures",
  "hex",
  "hyper",
@@ -2848,13 +2848,31 @@ checksum = "84319b8e7a3b422b0f38c6ad4abd29f48b923797b7555c3bb53151322779f9bf"
 dependencies = [
  "anyhow",
  "bech32",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-storage 0.21.0",
+ "fuel-core-types 0.21.0",
  "hex",
  "itertools 0.10.5",
  "postcard",
  "serde",
  "serde_json",
+ "serde_with 1.14.0",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-chain-config"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f2b1fe72649f4eca267dc49f9ef1edfdc4b8f0d6325a8b1ebeb6641b11e1c3"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "fuel-core-storage 0.22.0",
+ "fuel-core-types 0.22.0",
+ "hex",
+ "itertools 0.10.5",
+ "postcard",
+ "serde",
  "serde_with 1.14.0",
  "tracing",
 ]
@@ -2869,7 +2887,31 @@ dependencies = [
  "cynic",
  "derive_more",
  "eventsource-client",
- "fuel-core-types",
+ "fuel-core-types 0.21.0",
+ "futures",
+ "hex",
+ "hyper-rustls 0.24.2",
+ "itertools 0.10.5",
+ "reqwest",
+ "schemafy_lib",
+ "serde",
+ "serde_json",
+ "tai64",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-client"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609b815dd45f01a012fa237d9ea946dcc67d6858d141bf64cbeb9fb0a80a6474"
+dependencies = [
+ "anyhow",
+ "cynic",
+ "derive_more",
+ "eventsource-client",
+ "fuel-core-types 0.22.0",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -2890,9 +2932,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50fd6d90df194b5970bf16681bfad9f917ff3f837e00c6538a8b95d2e0a6fdf9"
 dependencies = [
  "anyhow",
- "fuel-core-chain-config",
- "fuel-core-poa",
- "fuel-core-types",
+ "fuel-core-chain-config 0.21.0",
+ "fuel-core-poa 0.21.0",
+ "fuel-core-types 0.21.0",
  "tokio",
 ]
 
@@ -2904,8 +2946,8 @@ checksum = "fb7b7cd46a2de1df8c71b4541bf19e09870965cb6ac72ee564170f9bcc8df909"
 dependencies = [
  "anyhow",
  "derive_more",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-storage 0.21.0",
+ "fuel-core-types 0.21.0",
 ]
 
 [[package]]
@@ -2915,9 +2957,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a5ed529258ded68048806b150e190ab03dc399bdd5547096525c3419cca188"
 dependencies = [
  "anyhow",
- "fuel-core-chain-config",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-chain-config 0.21.0",
+ "fuel-core-storage 0.21.0",
+ "fuel-core-types 0.21.0",
 ]
 
 [[package]]
@@ -2928,9 +2970,9 @@ checksum = "acd700b679be3cda7561f46778aa136ba4af1048570e116d8eb1d3e0f0a316a9"
 dependencies = [
  "anyhow",
  "derive_more",
- "fuel-core-metrics",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-metrics 0.21.0",
+ "fuel-core-storage 0.21.0",
+ "fuel-core-types 0.21.0",
  "tokio",
  "tracing",
 ]
@@ -2951,6 +2993,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuel-core-metrics"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d853a839036a1906e8082192268034ace79e5d04dbd935abeaee745c5f5a39"
+dependencies = [
+ "axum 0.5.17",
+ "once_cell",
+ "pin-project-lite",
+ "prometheus-client 0.18.1",
+ "prometheus-client 0.20.0",
+ "regex",
+ "tracing",
+]
+
+[[package]]
 name = "fuel-core-poa"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,10 +3015,27 @@ checksum = "93ef8dd121e59450d695435af4dea14d60acb41195cdd2dc64d3980aef42fbd9"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-chain-config",
- "fuel-core-services",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-chain-config 0.21.0",
+ "fuel-core-services 0.21.0",
+ "fuel-core-storage 0.21.0",
+ "fuel-core-types 0.21.0",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-poa"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c94a4807d14918f6f2f30c29fd4cfed0c7b7565c01d51c05cffff2881b468f3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fuel-core-chain-config 0.22.0",
+ "fuel-core-services 0.22.0",
+ "fuel-core-storage 0.22.0",
+ "fuel-core-types 0.22.0",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2976,8 +3050,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "derive_more",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-storage 0.21.0",
+ "fuel-core-types 0.21.0",
  "tokio",
  "tokio-rayon",
  "tracing",
@@ -2991,7 +3065,22 @@ checksum = "f2a3a0ed906c332d13802209ab5839d81e464abd14307b75f58550cf0de30430"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-metrics",
+ "fuel-core-metrics 0.21.0",
+ "futures",
+ "parking_lot 0.12.1",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-services"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d8ed6f17fc5e42094412ea2af7a9e6a2ec5cd6fe56548ef0e0730938b55c26"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fuel-core-metrics 0.22.0",
  "futures",
  "parking_lot 0.12.1",
  "tokio",
@@ -3006,8 +3095,21 @@ checksum = "33b84df7585c184d79c342833321db43c610d38bccf913acdf526e64fd292ab2"
 dependencies = [
  "anyhow",
  "derive_more",
- "fuel-core-types",
+ "fuel-core-types 0.21.0",
  "fuel-vm 0.43.1",
+]
+
+[[package]]
+name = "fuel-core-storage"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8188ae0d5af2925ca05608b60f69cdc89f9e33b6500f776e7e1ecd2c44d32447"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "fuel-core-types 0.22.0",
+ "fuel-vm 0.43.1",
+ "primitive-types",
 ]
 
 [[package]]
@@ -3018,11 +3120,11 @@ checksum = "943dec1ff13cd4fcd3c0f9ae826be09de1520bab5565916ec91cb31429c59f9a"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-chain-config",
- "fuel-core-metrics",
- "fuel-core-services",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-chain-config 0.21.0",
+ "fuel-core-metrics 0.21.0",
+ "fuel-core-services 0.21.0",
+ "fuel-core-storage 0.21.0",
+ "fuel-core-types 0.21.0",
  "futures",
  "parking_lot 0.12.1",
  "tokio",
@@ -3038,6 +3140,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91b55088841f6211b3ba452687c301fee4b9d1cf52dc6fc47f940a6681336cff"
 dependencies = [
  "anyhow",
+ "derive_more",
+ "fuel-vm 0.43.1",
+ "secrecy",
+ "serde",
+ "tai64",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "fuel-core-types"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd06358708d4c61ef53ad73c26ae55a0ed59ba9096c56b64a1eb56af748e9f0"
+dependencies = [
+ "anyhow",
+ "bs58",
  "derive_more",
  "fuel-vm 0.43.1",
  "secrecy",
@@ -3184,7 +3303,7 @@ dependencies = [
  "cynic",
  "forc-postgres",
  "fuel-core",
- "fuel-core-client",
+ "fuel-core-client 0.21.0",
  "fuel-crypto 0.43.1",
  "fuel-indexer-api-server",
  "fuel-indexer-database",
@@ -3248,7 +3367,7 @@ dependencies = [
  "clap 3.2.25",
  "criterion",
  "duct",
- "fuel-core-client",
+ "fuel-core-client 0.21.0",
  "fuel-indexer",
  "fuel-indexer-database",
  "fuel-indexer-graphql",
@@ -3354,8 +3473,8 @@ dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-schema",
  "fuel-indexer-types",
- "fuels",
- "fuels-code-gen 0.53.0",
+ "fuels 0.55.0",
+ "fuels-code-gen 0.55.0",
  "lazy_static",
  "proc-macro-error",
  "proc-macro2",
@@ -3429,7 +3548,7 @@ name = "fuel-indexer-test"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels",
+ "fuels 0.55.0",
  "getrandom",
  "serde",
 ]
@@ -3458,7 +3577,7 @@ dependencies = [
  "fuel-indexer-utils",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels",
+ "fuels 0.53.0",
  "fuels-macros 0.46.0",
  "futures",
  "hex",
@@ -3493,7 +3612,7 @@ dependencies = [
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels",
+ "fuels 0.55.0",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -3544,7 +3663,7 @@ dependencies = [
  "clap 3.2.25",
  "fuel-indexer-tests",
  "fuel-types 0.43.1",
- "fuels",
+ "fuels 0.55.0",
  "tokio",
 ]
 
@@ -3685,7 +3804,7 @@ name = "fuel_explorer"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels",
+ "fuels 0.55.0",
  "serde",
 ]
 
@@ -3696,13 +3815,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ad2e6a398d3ea13edd540c29d9e6452bc3e690ab763f5373ba960f17cdae4d"
 dependencies = [
  "fuel-core",
- "fuel-core-client",
+ "fuel-core-client 0.21.0",
  "fuel-tx 0.43.1",
- "fuels-accounts",
- "fuels-core",
+ "fuels-accounts 0.53.0",
+ "fuels-core 0.53.0",
  "fuels-macros 0.53.0",
- "fuels-programs",
- "fuels-test-helpers",
+ "fuels-programs 0.53.0",
+ "fuels-test-helpers 0.53.0",
+]
+
+[[package]]
+name = "fuels"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0761be35fa13d61c0220aa4535d3cc990542032abfc006bef709121a402637"
+dependencies = [
+ "fuel-core-client 0.22.0",
+ "fuel-crypto 0.43.1",
+ "fuel-tx 0.43.1",
+ "fuels-accounts 0.55.0",
+ "fuels-core 0.55.0",
+ "fuels-macros 0.55.0",
+ "fuels-programs 0.55.0",
+ "fuels-test-helpers 0.55.0",
 ]
 
 [[package]]
@@ -3715,12 +3850,37 @@ dependencies = [
  "chrono",
  "elliptic-curve",
  "eth-keystore",
- "fuel-core-client",
+ "fuel-core-client 0.21.0",
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
  "fuel-vm 0.43.1",
- "fuels-core",
+ "fuels-core 0.53.0",
+ "hex",
+ "rand",
+ "semver",
+ "tai64",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "fuels-accounts"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ddc69fefff879a914aa06b2d7e5396a596399e6db4383015a3d222699f4b31"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "elliptic-curve",
+ "eth-keystore",
+ "fuel-core-client 0.22.0",
+ "fuel-crypto 0.43.1",
+ "fuel-tx 0.43.1",
+ "fuel-types 0.43.1",
+ "fuels-core 0.55.0",
  "hex",
  "rand",
  "semver",
@@ -3764,6 +3924,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuels-code-gen"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19daefd4e70d4b6998b6650dea23d982360650f8710e5c7bc6e8a5b91228814d"
+dependencies = [
+ "Inflector",
+ "fuel-abi-types 0.3.0",
+ "itertools 0.12.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_json",
+ "syn 2.0.40",
+]
+
+[[package]]
 name = "fuels-core"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3774,8 +3950,8 @@ dependencies = [
  "chrono",
  "fuel-abi-types 0.3.0",
  "fuel-asm 0.43.1",
- "fuel-core-chain-config",
- "fuel-core-client",
+ "fuel-core-chain-config 0.21.0",
+ "fuel-core-client 0.21.0",
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
@@ -3789,6 +3965,33 @@ dependencies = [
  "thiserror",
  "uint",
  "zeroize",
+]
+
+[[package]]
+name = "fuels-core"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0389e16906fbb1119006e5c09ce789aeb6d0d8e344372c077ac8484bab8a12b9"
+dependencies = [
+ "async-trait",
+ "bech32",
+ "chrono",
+ "fuel-abi-types 0.3.0",
+ "fuel-asm 0.43.1",
+ "fuel-core-chain-config 0.22.0",
+ "fuel-core-client 0.22.0",
+ "fuel-crypto 0.43.1",
+ "fuel-tx 0.43.1",
+ "fuel-types 0.43.1",
+ "fuel-vm 0.43.1",
+ "fuels-macros 0.55.0",
+ "hex",
+ "itertools 0.12.0",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "uint",
 ]
 
 [[package]]
@@ -3824,6 +4027,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuels-macros"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce17afcb07246c221da0d5a55d4ffc748d4b49a0fd7058a90b1ad1c6f0023a7"
+dependencies = [
+ "fuels-code-gen 0.55.0",
+ "itertools 0.12.0",
+ "proc-macro2",
+ "quote",
+ "rand",
+ "syn 2.0.40",
+]
+
+[[package]]
 name = "fuels-programs"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,8 +4052,28 @@ dependencies = [
  "fuel-asm 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels-accounts",
- "fuels-core",
+ "fuels-accounts 0.53.0",
+ "fuels-core 0.53.0",
+ "itertools 0.12.0",
+ "rand",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "fuels-programs"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7898f4e9f3b438de60b55644806bf2718e1c09e0605180c19fb44a8ca0a1165"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "fuel-abi-types 0.3.0",
+ "fuel-asm 0.43.1",
+ "fuel-tx 0.43.1",
+ "fuel-types 0.43.1",
+ "fuels-accounts 0.55.0",
+ "fuels-core 0.55.0",
  "itertools 0.12.0",
  "rand",
  "serde_json",
@@ -3850,14 +4087,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5742db9887960bbd58bf0b7cb3b0adaa5e29ce4bd667d1063bbe12491c52852"
 dependencies = [
  "fuel-core",
- "fuel-core-chain-config",
- "fuel-core-client",
- "fuel-core-poa",
- "fuel-core-services",
+ "fuel-core-chain-config 0.21.0",
+ "fuel-core-client 0.21.0",
+ "fuel-core-poa 0.21.0",
+ "fuel-core-services 0.21.0",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels-accounts",
- "fuels-core",
+ "fuels-accounts 0.53.0",
+ "fuels-core 0.53.0",
+ "futures",
+ "hex",
+ "portpicker",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_with 3.4.0",
+ "tempfile",
+ "tokio",
+ "which",
+]
+
+[[package]]
+name = "fuels-test-helpers"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7620c418f9501713c2cd976f216b9d46ff847a4d681af56e36af17ad26dac14e"
+dependencies = [
+ "fuel-core-chain-config 0.22.0",
+ "fuel-core-client 0.22.0",
+ "fuel-core-poa 0.22.0",
+ "fuel-core-services 0.22.0",
+ "fuel-crypto 0.43.1",
+ "fuel-tx 0.43.1",
+ "fuel-types 0.43.1",
+ "fuels-accounts 0.55.0",
+ "fuels-core 0.55.0",
  "futures",
  "hex",
  "portpicker",
@@ -4100,7 +4364,7 @@ dependencies = [
  "fuel-indexer-tests",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels",
+ "fuels 0.55.0",
  "rand",
  "thiserror",
  "tokio",
@@ -4120,7 +4384,7 @@ name = "greetings_indexer"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels",
+ "fuels 0.55.0",
  "serde",
 ]
 
@@ -4282,7 +4546,7 @@ name = "hello_world"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels",
+ "fuels 0.55.0",
  "serde",
 ]
 
@@ -6873,7 +7137,7 @@ version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
  "fuel-tx 0.43.1",
- "fuels",
+ "fuels 0.55.0",
  "serde",
  "sha2 0.10.8",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ dependencies = [
  "fuel-indexer-database-types",
  "fuel-indexer-lib",
  "fuel-tx 0.43.1",
- "fuels 0.55.0",
+ "fuels",
  "hex",
  "humantime",
  "hyper-rustls 0.23.2",
@@ -2795,9 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c545fd12c8b5bbc495fd37a4fdf2548450b07b3fb26ac8ea20a10436c311e1d0"
+checksum = "b784b66a9dc46393d69967727895db787974a4d6349cc139c940125ede40c681"
 dependencies = [
  "anyhow",
  "async-graphql 4.0.16",
@@ -2806,25 +2806,23 @@ dependencies = [
  "clap 4.4.11",
  "derive_more",
  "enum-iterator 1.4.1",
- "fuel-core-chain-config 0.21.0",
+ "fuel-core-chain-config",
  "fuel-core-consensus-module",
  "fuel-core-database",
  "fuel-core-executor",
  "fuel-core-importer",
- "fuel-core-metrics 0.21.0",
- "fuel-core-poa 0.21.0",
+ "fuel-core-metrics",
+ "fuel-core-poa",
  "fuel-core-producer",
- "fuel-core-services 0.21.0",
- "fuel-core-storage 0.21.0",
+ "fuel-core-services",
+ "fuel-core-storage",
  "fuel-core-txpool",
- "fuel-core-types 0.21.0",
+ "fuel-core-types",
  "futures",
  "hex",
  "hyper",
  "itertools 0.10.5",
- "parking_lot 0.12.1",
  "postcard",
- "primitive-types",
  "rand",
  "rocksdb",
  "serde",
@@ -2842,62 +2840,20 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84319b8e7a3b422b0f38c6ad4abd29f48b923797b7555c3bb53151322779f9bf"
-dependencies = [
- "anyhow",
- "bech32",
- "fuel-core-storage 0.21.0",
- "fuel-core-types 0.21.0",
- "hex",
- "itertools 0.10.5",
- "postcard",
- "serde",
- "serde_json",
- "serde_with 1.14.0",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-chain-config"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f2b1fe72649f4eca267dc49f9ef1edfdc4b8f0d6325a8b1ebeb6641b11e1c3"
 dependencies = [
  "anyhow",
  "bech32",
- "fuel-core-storage 0.22.0",
- "fuel-core-types 0.22.0",
+ "fuel-core-storage",
+ "fuel-core-types",
  "hex",
  "itertools 0.10.5",
  "postcard",
  "serde",
- "serde_with 1.14.0",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-client"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3555027c1362e8ff1b03783399b0baa62911ffcf4254c533f3f32c98982562"
-dependencies = [
- "anyhow",
- "cynic",
- "derive_more",
- "eventsource-client",
- "fuel-core-types 0.21.0",
- "futures",
- "hex",
- "hyper-rustls 0.24.2",
- "itertools 0.10.5",
- "reqwest",
- "schemafy_lib",
- "serde",
  "serde_json",
- "tai64",
- "thiserror",
+ "serde_with 1.14.0",
  "tracing",
 ]
 
@@ -2911,7 +2867,7 @@ dependencies = [
  "cynic",
  "derive_more",
  "eventsource-client",
- "fuel-core-types 0.22.0",
+ "fuel-core-types",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -2927,68 +2883,56 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd6d90df194b5970bf16681bfad9f917ff3f837e00c6538a8b95d2e0a6fdf9"
+checksum = "0b22705ff15266cd0206aea5e59e881be3606bc221ec29b938a2e630c72420b8"
 dependencies = [
  "anyhow",
- "fuel-core-chain-config 0.21.0",
- "fuel-core-poa 0.21.0",
- "fuel-core-types 0.21.0",
+ "fuel-core-chain-config",
+ "fuel-core-poa",
+ "fuel-core-types",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7b7cd46a2de1df8c71b4541bf19e09870965cb6ac72ee564170f9bcc8df909"
+checksum = "11202dd7027502e663178663ab0a995d2ea93a0d543775d63730f8daa2cd490c"
 dependencies = [
  "anyhow",
  "derive_more",
- "fuel-core-storage 0.21.0",
- "fuel-core-types 0.21.0",
+ "fuel-core-storage",
+ "fuel-core-types",
 ]
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a5ed529258ded68048806b150e190ab03dc399bdd5547096525c3419cca188"
+checksum = "2d1cbcc8e330681305d603c22f736df3fe403bfedf5c122066fb853638286a9c"
 dependencies = [
  "anyhow",
- "fuel-core-chain-config 0.21.0",
- "fuel-core-storage 0.21.0",
- "fuel-core-types 0.21.0",
-]
-
-[[package]]
-name = "fuel-core-importer"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd700b679be3cda7561f46778aa136ba4af1048570e116d8eb1d3e0f0a316a9"
-dependencies = [
- "anyhow",
- "derive_more",
- "fuel-core-metrics 0.21.0",
- "fuel-core-storage 0.21.0",
- "fuel-core-types 0.21.0",
- "tokio",
+ "fuel-core-chain-config",
+ "fuel-core-storage",
+ "fuel-core-types",
+ "hex",
+ "parking_lot 0.12.1",
  "tracing",
 ]
 
 [[package]]
-name = "fuel-core-metrics"
-version = "0.21.0"
+name = "fuel-core-importer"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f87fec36f415dd9cdc2f723f018c30985bbeeadbc7e066e27fc79f3a3e2e6f3"
+checksum = "db12defb4ed0d3aff3d39138925a0d8467f857254cba5d5e9de9bc273ade25d0"
 dependencies = [
- "axum 0.5.17",
- "once_cell",
- "pin-project-lite",
- "prometheus-client 0.18.1",
- "prometheus-client 0.20.0",
- "regex",
+ "anyhow",
+ "derive_more",
+ "fuel-core-metrics",
+ "fuel-core-storage",
+ "fuel-core-types",
+ "tokio",
  "tracing",
 ]
 
@@ -3009,33 +2953,16 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ef8dd121e59450d695435af4dea14d60acb41195cdd2dc64d3980aef42fbd9"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-chain-config 0.21.0",
- "fuel-core-services 0.21.0",
- "fuel-core-storage 0.21.0",
- "fuel-core-types 0.21.0",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-poa"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c94a4807d14918f6f2f30c29fd4cfed0c7b7565c01d51c05cffff2881b468f3"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-chain-config 0.22.0",
- "fuel-core-services 0.22.0",
- "fuel-core-storage 0.22.0",
- "fuel-core-types 0.22.0",
+ "fuel-core-chain-config",
+ "fuel-core-services",
+ "fuel-core-storage",
+ "fuel-core-types",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3043,32 +2970,17 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85951fa8159a4698a6d523fc44fd3659b9db63800fcfd9619f4283a568296ce"
+checksum = "21bbc29241e839c711ee2fcb9729978c1717f02e02459c00216a63e15384b275"
 dependencies = [
  "anyhow",
  "async-trait",
  "derive_more",
- "fuel-core-storage 0.21.0",
- "fuel-core-types 0.21.0",
+ "fuel-core-storage",
+ "fuel-core-types",
  "tokio",
  "tokio-rayon",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-services"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a3a0ed906c332d13802209ab5839d81e464abd14307b75f58550cf0de30430"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-metrics 0.21.0",
- "futures",
- "parking_lot 0.12.1",
- "tokio",
  "tracing",
 ]
 
@@ -3080,23 +2992,11 @@ checksum = "c0d8ed6f17fc5e42094412ea2af7a9e6a2ec5cd6fe56548ef0e0730938b55c26"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-metrics 0.22.0",
+ "fuel-core-metrics",
  "futures",
  "parking_lot 0.12.1",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "fuel-core-storage"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b84df7585c184d79c342833321db43c610d38bccf913acdf526e64fd292ab2"
-dependencies = [
- "anyhow",
- "derive_more",
- "fuel-core-types 0.21.0",
- "fuel-vm 0.43.1",
 ]
 
 [[package]]
@@ -3107,46 +3007,30 @@ checksum = "8188ae0d5af2925ca05608b60f69cdc89f9e33b6500f776e7e1ecd2c44d32447"
 dependencies = [
  "anyhow",
  "derive_more",
- "fuel-core-types 0.22.0",
+ "fuel-core-types",
  "fuel-vm 0.43.1",
  "primitive-types",
 ]
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943dec1ff13cd4fcd3c0f9ae826be09de1520bab5565916ec91cb31429c59f9a"
+checksum = "ef6228d74e0a2efeda97a7f5f3c31052c3b0e961ca92c6754cbb19c864813f3d"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-chain-config 0.21.0",
- "fuel-core-metrics 0.21.0",
- "fuel-core-services 0.21.0",
- "fuel-core-storage 0.21.0",
- "fuel-core-types 0.21.0",
+ "fuel-core-chain-config",
+ "fuel-core-metrics",
+ "fuel-core-services",
+ "fuel-core-storage",
+ "fuel-core-types",
  "futures",
  "parking_lot 0.12.1",
  "tokio",
  "tokio-rayon",
  "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "fuel-core-types"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b55088841f6211b3ba452687c301fee4b9d1cf52dc6fc47f940a6681336cff"
-dependencies = [
- "anyhow",
- "derive_more",
- "fuel-vm 0.43.1",
- "secrecy",
- "serde",
- "tai64",
- "thiserror",
- "zeroize",
 ]
 
 [[package]]
@@ -3303,7 +3187,7 @@ dependencies = [
  "cynic",
  "forc-postgres",
  "fuel-core",
- "fuel-core-client 0.21.0",
+ "fuel-core-client",
  "fuel-crypto 0.43.1",
  "fuel-indexer-api-server",
  "fuel-indexer-database",
@@ -3367,7 +3251,7 @@ dependencies = [
  "clap 3.2.25",
  "criterion",
  "duct",
- "fuel-core-client 0.21.0",
+ "fuel-core-client",
  "fuel-indexer",
  "fuel-indexer-database",
  "fuel-indexer-graphql",
@@ -3473,7 +3357,7 @@ dependencies = [
  "fuel-indexer-lib",
  "fuel-indexer-schema",
  "fuel-indexer-types",
- "fuels 0.55.0",
+ "fuels",
  "fuels-code-gen 0.55.0",
  "lazy_static",
  "proc-macro-error",
@@ -3548,7 +3432,7 @@ name = "fuel-indexer-test"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels 0.55.0",
+ "fuels",
  "getrandom",
  "serde",
 ]
@@ -3577,7 +3461,7 @@ dependencies = [
  "fuel-indexer-utils",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels 0.53.0",
+ "fuels",
  "fuels-macros 0.46.0",
  "futures",
  "hex",
@@ -3612,7 +3496,7 @@ dependencies = [
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels 0.55.0",
+ "fuels",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -3663,7 +3547,7 @@ dependencies = [
  "clap 3.2.25",
  "fuel-indexer-tests",
  "fuel-types 0.43.1",
- "fuels 0.55.0",
+ "fuels",
  "tokio",
 ]
 
@@ -3804,24 +3688,8 @@ name = "fuel_explorer"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels 0.55.0",
+ "fuels",
  "serde",
-]
-
-[[package]]
-name = "fuels"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ad2e6a398d3ea13edd540c29d9e6452bc3e690ab763f5373ba960f17cdae4d"
-dependencies = [
- "fuel-core",
- "fuel-core-client 0.21.0",
- "fuel-tx 0.43.1",
- "fuels-accounts 0.53.0",
- "fuels-core 0.53.0",
- "fuels-macros 0.53.0",
- "fuels-programs 0.53.0",
- "fuels-test-helpers 0.53.0",
 ]
 
 [[package]]
@@ -3830,40 +3698,15 @@ version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0761be35fa13d61c0220aa4535d3cc990542032abfc006bef709121a402637"
 dependencies = [
- "fuel-core-client 0.22.0",
+ "fuel-core",
+ "fuel-core-client",
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
- "fuels-accounts 0.55.0",
- "fuels-core 0.55.0",
+ "fuels-accounts",
+ "fuels-core",
  "fuels-macros 0.55.0",
- "fuels-programs 0.55.0",
- "fuels-test-helpers 0.55.0",
-]
-
-[[package]]
-name = "fuels-accounts"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f6435a6631577fa20aedbd88c4e59d9f1541a6bbb3a7b63715e40c15790f0"
-dependencies = [
- "async-trait",
- "chrono",
- "elliptic-curve",
- "eth-keystore",
- "fuel-core-client 0.21.0",
- "fuel-crypto 0.43.1",
- "fuel-tx 0.43.1",
- "fuel-types 0.43.1",
- "fuel-vm 0.43.1",
- "fuels-core 0.53.0",
- "hex",
- "rand",
- "semver",
- "tai64",
- "thiserror",
- "tokio",
- "tracing",
- "zeroize",
+ "fuels-programs",
+ "fuels-test-helpers",
 ]
 
 [[package]]
@@ -3876,11 +3719,11 @@ dependencies = [
  "chrono",
  "elliptic-curve",
  "eth-keystore",
- "fuel-core-client 0.22.0",
+ "fuel-core-client",
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels-core 0.55.0",
+ "fuels-core",
  "hex",
  "rand",
  "semver",
@@ -3909,22 +3752,6 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a76d2517cebc47be8723312e80634b6389e0c5db34663bd1360afee504f0cfb"
-dependencies = [
- "Inflector",
- "fuel-abi-types 0.3.0",
- "itertools 0.12.0",
- "proc-macro2",
- "quote",
- "regex",
- "serde_json",
- "syn 2.0.40",
-]
-
-[[package]]
-name = "fuels-code-gen"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19daefd4e70d4b6998b6650dea23d982360650f8710e5c7bc6e8a5b91228814d"
@@ -3941,34 +3768,6 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a98b3217932b1f8f639fd4c1268923f0862166fecf7a897c3c2bd5bae8706d"
-dependencies = [
- "async-trait",
- "bech32",
- "chrono",
- "fuel-abi-types 0.3.0",
- "fuel-asm 0.43.1",
- "fuel-core-chain-config 0.21.0",
- "fuel-core-client 0.21.0",
- "fuel-crypto 0.43.1",
- "fuel-tx 0.43.1",
- "fuel-types 0.43.1",
- "fuel-vm 0.43.1",
- "fuels-macros 0.53.0",
- "hex",
- "itertools 0.12.0",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "thiserror",
- "uint",
- "zeroize",
-]
-
-[[package]]
-name = "fuels-core"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0389e16906fbb1119006e5c09ce789aeb6d0d8e344372c077ac8484bab8a12b9"
@@ -3978,8 +3777,8 @@ dependencies = [
  "chrono",
  "fuel-abi-types 0.3.0",
  "fuel-asm 0.43.1",
- "fuel-core-chain-config 0.22.0",
- "fuel-core-client 0.22.0",
+ "fuel-core-chain-config",
+ "fuel-core-client",
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
@@ -4014,20 +3813,6 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cb90a892ac4b1acfd6f383a7505ce5f33764495adcf9c34371bbcabf9a4042"
-dependencies = [
- "fuels-code-gen 0.53.0",
- "itertools 0.12.0",
- "proc-macro2",
- "quote",
- "rand",
- "syn 2.0.40",
-]
-
-[[package]]
-name = "fuels-macros"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce17afcb07246c221da0d5a55d4ffc748d4b49a0fd7058a90b1ad1c6f0023a7"
@@ -4042,26 +3827,6 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9fd3a7722685ba45a6794374f44530732f4f2f43f507eb1ec6fd0656abacf8"
-dependencies = [
- "async-trait",
- "bytes",
- "fuel-abi-types 0.3.0",
- "fuel-asm 0.43.1",
- "fuel-tx 0.43.1",
- "fuel-types 0.43.1",
- "fuels-accounts 0.53.0",
- "fuels-core 0.53.0",
- "itertools 0.12.0",
- "rand",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "fuels-programs"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7898f4e9f3b438de60b55644806bf2718e1c09e0605180c19fb44a8ca0a1165"
@@ -4072,8 +3837,8 @@ dependencies = [
  "fuel-asm 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels-accounts 0.55.0",
- "fuels-core 0.55.0",
+ "fuels-accounts",
+ "fuels-core",
  "itertools 0.12.0",
  "rand",
  "serde_json",
@@ -4082,46 +3847,20 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5742db9887960bbd58bf0b7cb3b0adaa5e29ce4bd667d1063bbe12491c52852"
-dependencies = [
- "fuel-core",
- "fuel-core-chain-config 0.21.0",
- "fuel-core-client 0.21.0",
- "fuel-core-poa 0.21.0",
- "fuel-core-services 0.21.0",
- "fuel-tx 0.43.1",
- "fuel-types 0.43.1",
- "fuels-accounts 0.53.0",
- "fuels-core 0.53.0",
- "futures",
- "hex",
- "portpicker",
- "rand",
- "serde",
- "serde_json",
- "serde_with 3.4.0",
- "tempfile",
- "tokio",
- "which",
-]
-
-[[package]]
-name = "fuels-test-helpers"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7620c418f9501713c2cd976f216b9d46ff847a4d681af56e36af17ad26dac14e"
 dependencies = [
- "fuel-core-chain-config 0.22.0",
- "fuel-core-client 0.22.0",
- "fuel-core-poa 0.22.0",
- "fuel-core-services 0.22.0",
+ "fuel-core",
+ "fuel-core-chain-config",
+ "fuel-core-client",
+ "fuel-core-poa",
+ "fuel-core-services",
  "fuel-crypto 0.43.1",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels-accounts 0.55.0",
- "fuels-core 0.55.0",
+ "fuels-accounts",
+ "fuels-core",
  "futures",
  "hex",
  "portpicker",
@@ -4364,7 +4103,7 @@ dependencies = [
  "fuel-indexer-tests",
  "fuel-tx 0.43.1",
  "fuel-types 0.43.1",
- "fuels 0.55.0",
+ "fuels",
  "rand",
  "thiserror",
  "tokio",
@@ -4384,7 +4123,7 @@ name = "greetings_indexer"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels 0.55.0",
+ "fuels",
  "serde",
 ]
 
@@ -4546,7 +4285,7 @@ name = "hello_world"
 version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
- "fuels 0.55.0",
+ "fuels",
  "serde",
 ]
 
@@ -7137,7 +6876,7 @@ version = "0.0.0"
 dependencies = [
  "fuel-indexer-utils",
  "fuel-tx 0.43.1",
- "fuels 0.55.0",
+ "fuels",
  "serde",
  "sha2 0.10.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-indexer"
-rust-version = "1.73.0"
+rust-version = "1.75.0"
 version = "0.24.3"
 
 [workspace.dependencies]
@@ -88,8 +88,8 @@ fuel-crypto = { version = "0.43", default-features = false }
 fuel-tx = { version = "0.43", default-features = false }
 fuel-types = { version = "0.43", default-features = false, features = ["serde"] }
 fuel-vm = { version = "0.43", default-features = false }
-fuels = { version = "0.53", default-features = false }
-fuels-code-gen = { version = "0.53", default-features = false }
+fuels = { version = "0.55", default-features = false }
+fuels-code-gen = { version = "0.55", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 thiserror = "1.0"

--- a/ci/Dockerfile.fuel-node
+++ b/ci/Dockerfile.fuel-node
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.73.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.75.0 AS chef
 
 WORKDIR /build/
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
-FROM --platform=$BUILDPLATFORM rust:1.73.0 AS chef
+FROM --platform=$BUILDPLATFORM rust:1.75.0 AS chef
 
 ARG TARGETPLATFORM
 RUN cargo install cargo-chef

--- a/examples/fuel-explorer/fuel-explorer/Cargo.toml
+++ b/examples/fuel-explorer/fuel-explorer/Cargo.toml
@@ -3,7 +3,7 @@ name = "fuel_explorer"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.73.0"
+rust-version = "1.75.0"
 
 [lib]
 crate-type = ['cdylib']

--- a/examples/greetings/greetings-data/Cargo.toml
+++ b/examples/greetings/greetings-data/Cargo.toml
@@ -10,7 +10,7 @@ fuel-indexer-lib = { workspace = true }
 fuel-indexer-tests = { version = "0.0.0", path = "./../../../packages/fuel-indexer-tests" }
 fuel-tx = { workspace = true }
 fuel-types = { workspace = true }
-fuels = { version = "0.53" }
+fuels = { version = "0.55" }
 rand = "0.8"
 thiserror = { workspace = true }
 tokio = { features = ["macros", "rt-multi-thread"], workspace = true }

--- a/examples/greetings/greetings-indexer/Cargo.toml
+++ b/examples/greetings/greetings-indexer/Cargo.toml
@@ -3,7 +3,7 @@ name = "greetings_indexer"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.72.1"
+rust-version = "1.75.0"
 
 [lib]
 crate-type = ['cdylib']

--- a/examples/hello-world/hello-world/Cargo.toml
+++ b/examples/hello-world/hello-world/Cargo.toml
@@ -3,7 +3,7 @@ name = "hello_world"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.73.0"
+rust-version = "1.75.0"
 
 [lib]
 crate-type = ['cdylib']

--- a/packages/fuel-indexer-benchmarks/Cargo.toml
+++ b/packages/fuel-indexer-benchmarks/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { workspace = true }
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 duct = "0.13"
-fuel-core-client = "0.21"
+fuel-core-client = "0.22"
 fuel-indexer = { workspace = true }
 fuel-indexer-database = { workspace = true }
 fuel-indexer-graphql = { workspace = true }

--- a/packages/fuel-indexer-schema/src/lib.rs
+++ b/packages/fuel-indexer-schema/src/lib.rs
@@ -258,21 +258,13 @@ mod tests {
             )
             .unwrap(),
         ));
-        let addr =
-            FtColumn::Address(Some(Address::try_from([0x12; 32]).expect("Bad bytes")));
-        let asset_id =
-            FtColumn::AssetId(Some(AssetId::try_from([0xA5; 32]).expect("Bad bytes")));
-        let bytes4 =
-            FtColumn::Bytes4(Some(Bytes4::try_from([0xF0; 4]).expect("Bad bytes")));
-        let bytes8 =
-            FtColumn::Bytes8(Some(Bytes8::try_from([0x9D; 8]).expect("Bad bytes")));
-        let bytes32 =
-            FtColumn::Bytes32(Some(Bytes32::try_from([0xEE; 32]).expect("Bad bytes")));
-        let bytes64 =
-            FtColumn::Bytes64(Some(Bytes64::try_from([0x12; 64]).expect("Bad bytes")));
-        let contractid = FtColumn::ContractId(Some(
-            ContractId::try_from([0x78; 32]).expect("Bad bytes"),
-        ));
+        let addr = FtColumn::Address(Some(Address::from([0x12; 32])));
+        let asset_id = FtColumn::AssetId(Some(AssetId::from([0xA5; 32])));
+        let bytes4 = FtColumn::Bytes4(Some(Bytes4::from([0xF0; 4])));
+        let bytes8 = FtColumn::Bytes8(Some(Bytes8::from([0x9D; 8])));
+        let bytes32 = FtColumn::Bytes32(Some(Bytes32::from([0xEE; 32])));
+        let bytes64 = FtColumn::Bytes64(Some(Bytes64::from([0x12; 64])));
+        let contractid = FtColumn::ContractId(Some(ContractId::from([0x78; 32])));
         let array = FtColumn::Array(Some(vec![FtColumn::I32(Some(1))]));
         let bytes = FtColumn::Bytes(Some(Bytes::from(vec![0u8, 1, 2, 3, 4, 5])));
         let identity = FtColumn::Identity(Some(Identity::Address([0x12; 32].into())));

--- a/packages/fuel-indexer-tests/Cargo.toml
+++ b/packages/fuel-indexer-tests/Cargo.toml
@@ -41,7 +41,7 @@ fuel-indexer-types = { workspace = true }
 fuel-indexer-utils = { workspace = true }
 fuel-tx = { workspace = true }
 fuel-types = { workspace = true }
-fuels = { features = ["fuel-core-lib", "std"], version = "0.53" }
+fuels = { features = ["fuel-core-lib", "std"], version = "0.55" }
 fuels-macros = { version = "0.46", default-features = false }
 futures = "0.3"
 hex = "0.4"

--- a/packages/fuel-indexer-types/src/fuel.rs
+++ b/packages/fuel-indexer-types/src/fuel.rs
@@ -381,66 +381,39 @@ impl From<ClientOutput> for Output {
                 amount,
                 asset_id,
             } => Output::CoinOutput(CoinOutput {
-                to: Address::from(
-                    <[u8; 32]>::try_from(to).expect("Could not convert 'to' to bytes"),
-                ),
+                to: Address::from(<[u8; 32]>::from(to)),
                 amount,
-                asset_id: AssetId::from(
-                    <[u8; 32]>::try_from(asset_id)
-                        .expect("Could not convert asset ID to bytes"),
-                ),
+                asset_id: AssetId::from(<[u8; 32]>::from(asset_id)),
             }),
             ClientOutput::Contract(contract) => Output::ContractOutput(ContractOutput {
                 input_index: contract.input_index.into(),
-                balance_root: Bytes32::from(
-                    <[u8; 32]>::try_from(contract.balance_root)
-                        .expect("Could not convert balance root to bytes"),
-                ),
-                state_root: Bytes32::from(
-                    <[u8; 32]>::try_from(contract.state_root)
-                        .expect("Could not convert state root to bytes"),
-                ),
+                balance_root: Bytes32::from(<[u8; 32]>::from(contract.balance_root)),
+                state_root: Bytes32::from(<[u8; 32]>::from(contract.state_root)),
             }),
             ClientOutput::Change {
                 to,
                 amount,
                 asset_id,
             } => Output::ChangeOutput(ChangeOutput {
-                to: Address::from(
-                    <[u8; 32]>::try_from(to).expect("Could not convert 'to' to bytes"),
-                ),
+                to: Address::from(<[u8; 32]>::from(to)),
                 amount,
-                asset_id: AssetId::from(
-                    <[u8; 32]>::try_from(asset_id)
-                        .expect("Could not convert asset ID to bytes"),
-                ),
+                asset_id: AssetId::from(<[u8; 32]>::from(asset_id)),
             }),
             ClientOutput::Variable {
                 to,
                 amount,
                 asset_id,
             } => Output::VariableOutput(VariableOutput {
-                to: Address::from(
-                    <[u8; 32]>::try_from(to).expect("Could not convert 'to' to bytes"),
-                ),
+                to: Address::from(<[u8; 32]>::from(to)),
                 amount,
-                asset_id: AssetId::from(
-                    <[u8; 32]>::try_from(asset_id)
-                        .expect("Could not convert asset ID to bytes"),
-                ),
+                asset_id: AssetId::from(<[u8; 32]>::from(asset_id)),
             }),
             ClientOutput::ContractCreated {
                 contract_id,
                 state_root,
             } => Output::ContractCreated(ContractCreated {
-                contract_id: ContractId::from(
-                    <[u8; 32]>::try_from(contract_id)
-                        .expect("Could not convert contract ID to bytes"),
-                ),
-                state_root: Bytes32::from(
-                    <[u8; 32]>::try_from(state_root)
-                        .expect("Could not convert state root to bytes"),
-                ),
+                contract_id: ContractId::from(<[u8; 32]>::from(contract_id)),
+                state_root: Bytes32::from(<[u8; 32]>::from(state_root)),
             }),
         }
     }

--- a/packages/fuel-indexer/Cargo.toml
+++ b/packages/fuel-indexer/Cargo.toml
@@ -21,8 +21,8 @@ bincode = { workspace = true }
 clap = { features = ["cargo", "derive", "env"], workspace = true }
 cynic = "2.2"
 forc-postgres = { workspace = true }
-fuel-core = { version = "0.21", optional = true }
-fuel-core-client = "0.21"
+fuel-core = { version = "0.22", optional = true }
+fuel-core-client = "0.22"
 fuel-crypto = { workspace = true }
 fuel-indexer-api-server = { workspace = true, optional = true }
 fuel-indexer-database = { workspace = true }
@@ -46,7 +46,7 @@ version = "0.10.52"
 features = ["vendored"]
 
 [dev-dependencies]
-fuel-core-client = { version = "0.21", features = ["test-helpers"] }
+fuel-core-client = { version = "0.22", features = ["test-helpers"] }
 
 [features]
 default = ["api-server", "metrics"]

--- a/packages/fuel-indexer/src/executor.rs
+++ b/packages/fuel-indexer/src/executor.rs
@@ -406,6 +406,7 @@ pub async fn retrieve_blocks_from_node(
                     block_id,
                     time,
                     program_state,
+                    ..
                 } => {
                     let program_state = program_state.map(|p| match p {
                         ClientProgramState::Return(w) => ProgramState {
@@ -437,6 +438,7 @@ pub async fn retrieve_blocks_from_node(
                     time,
                     reason,
                     program_state,
+                    ..
                 } => {
                     let program_state = program_state.map(|p| match p {
                         ClientProgramState::Return(w) => ProgramState {

--- a/plugins/forc-index/src/defaults.rs
+++ b/plugins/forc-index/src/defaults.rs
@@ -22,14 +22,14 @@ name = "{indexer_name}"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.73.0"
+rust-version = "1.75.0"
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
 fuel-indexer-utils = {{ version = "0.24" }}
-fuels = {{ version = "0.53", default-features = false }}
+fuels = {{ version = "0.55", default-features = false }}
 getrandom = {{ version = "0.2", features = ["js"] }}
 serde = {{ version = "1.0", default-features = false, features = ["derive"] }}
 "#


### PR DESCRIPTION
This PR ensures that the "final" release of this implementation of the indexer project uses the latest available versions of Fuel dependencies.

## Changelog
- Update fuels-rs to v0.55
- Update fuel-core and fuel-core-client to v0.22
- Update default manifest to use fuels v0.55
- Use infallible conversions where appropriate